### PR TITLE
chore: test cpp-only PR check

### DIFF
--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -1,3 +1,4 @@
+// ci-test
 #include "Deferred.h"
 #include "Features/Upscaling.h"
 #include "FrameAnnotations.h"


### PR DESCRIPTION
Tests that pr-checks.yaml runs C++ build but skips shader validation when only C++ files change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal updates with no impact on user experience or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->