### PR TITLE
refactor(utils): add stereo support to Util::Subrect::Controller

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1314,7 +1314,26 @@ if(BUILD_SHADER_TESTS)
     message(STATUS "Adding shader tests subdirectory")
     enable_testing() # Enable CTest integration for shader tests
     add_subdirectory(tests/shaders)
+endif()
 
+# C++ unit tests for plugin utility code (separate from HLSL shader tests).
+# Gated on its own flag so it can be enabled/disabled independently.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/cpp/CMakeLists.txt")
+    enable_testing()
+    add_subdirectory(tests/cpp)
+    if(TARGET cpp_tests)
+        add_custom_target(
+            run_cpp_tests
+            COMMAND $<TARGET_FILE:cpp_tests> --reporter compact
+            DEPENDS cpp_tests
+            WORKING_DIRECTORY $<TARGET_FILE_DIR:cpp_tests>
+            COMMENT "Running C++ unit tests..."
+            VERBATIM
+        )
+    endif()
+endif()
+
+if(BUILD_SHADER_TESTS)
     # Add a custom target that runs the shader tests
     # Users can run this manually with: cmake --build <build-dir> --target run_shader_tests
     # Runs the test executable directly (not via CTest) to show discovery count

--- a/src/Utils/Subrect.cpp
+++ b/src/Utils/Subrect.cpp
@@ -96,9 +96,10 @@ namespace Util::Subrect
 			currentRightUV.w = a_json["CropRightW"];
 		if (a_json.contains("CropRightH"))
 			currentRightUV.h = a_json["CropRightH"];
-		if (hasExplicitRight) {
-			rightUVLoadedFromJson = true;
-		}
+		// Reset every load — a later LoadSettings without CropRight* keys
+		// should let SetStereoEnabled(true) auto-mirror again rather than
+		// preserving stale state from a prior load.
+		rightUVLoadedFromJson = hasExplicitRight;
 
 		if (a_json.contains("CropPresets") && a_json["CropPresets"].is_array()) {
 			presets.clear();
@@ -108,12 +109,11 @@ namespace Util::Subrect
 				if (entry.contains("uv")) {
 					preset.uv = LoadUVArray(entry["uv"]);
 				}
-				// Right-eye UV is optional. If absent, callers in stereo mode
-				// fall back to the mirrored left-eye via ApplyPreset.
+				// Right-eye UV is optional in JSON; leave nullopt when absent so
+				// ApplyPreset auto-mirrors the left eye on demand. Explicit
+				// right_uv in JSON wins over any mirror.
 				if (entry.contains("right_uv")) {
 					preset.rightUV = LoadUVArray(entry["right_uv"]);
-				} else {
-					preset.rightUV = MirrorUVHorizontal(preset.uv);
 				}
 				presets.push_back(std::move(preset));
 			}
@@ -152,6 +152,14 @@ namespace Util::Subrect
 			a_json["CropRightY"] = currentRightUV.y;
 			a_json["CropRightW"] = currentRightUV.w;
 			a_json["CropRightH"] = currentRightUV.h;
+		} else {
+			// Caller may pass a JSON object with prior stereo keys (e.g. a
+			// host that re-saves into the same in-memory config). Drop them
+			// so the next load doesn't look like it had explicit stereo data.
+			a_json.erase("CropRightX");
+			a_json.erase("CropRightY");
+			a_json.erase("CropRightW");
+			a_json.erase("CropRightH");
 		}
 
 		json presetsJson = json::array();
@@ -159,8 +167,11 @@ namespace Util::Subrect
 			json entry;
 			entry["name"] = preset.name;
 			entry["uv"] = SaveUVToJson(preset.uv);
-			if (stereoEnabled) {
-				entry["right_uv"] = SaveUVToJson(preset.rightUV);
+			// Only serialize right_uv when stereo is enabled AND we have an
+			// explicit value to persist. A nullopt preset implicitly means
+			// "auto-mirror at apply time" and shouldn't be locked into JSON.
+			if (stereoEnabled && preset.rightUV.has_value()) {
+				entry["right_uv"] = SaveUVToJson(*preset.rightUV);
 			}
 			presetsJson.push_back(std::move(entry));
 		}
@@ -335,6 +346,12 @@ namespace Util::Subrect
 
 	StereoPixelRegions Controller::GetStereoPixelRegions(uint32_t fullWidth, uint32_t fullHeight) const
 	{
+		// Degenerate inputs would underflow UVToPixelRegion's `width - 1` /
+		// `height - 1` computations into huge values. Fail safe with empty
+		// regions so callers can detect the bad-input case via .w == 0.
+		if (fullWidth < 2 || fullHeight == 0) {
+			return { PixelRegion{ 0, 0, 0, 0 }, PixelRegion{ 0, 0, 0, 0 } };
+		}
 		// Each eye occupies half the SBS texture width. In mono mode, both
 		// eyes report the same region so callers don't need to branch.
 		const uint32_t eyeWidth = fullWidth / 2;
@@ -354,7 +371,9 @@ namespace Util::Subrect
 			// currentUV must match what the combo shows as selected; otherwise
 			// the first preset appears chosen but the crop region stays full-frame.
 			currentUV = presets[0].uv;
-			currentRightUV = presets[0].rightUV;
+			// nullopt rightUV means "auto-mirror" — match the same fallback
+			// ApplyPreset uses below.
+			currentRightUV = presets[0].rightUV.value_or(MirrorUVHorizontal(currentUV));
 			selectedPresetIndex = 0;
 		} else {
 			presets.push_back(Preset{ .name = "Full Frame", .uv = DefaultUV() });
@@ -372,7 +391,10 @@ namespace Util::Subrect
 		EnsureDefaultPreset();
 		selectedPresetIndex = std::clamp(index, 0, static_cast<int>(presets.size()) - 1);
 		currentUV = presets[selectedPresetIndex].uv;
-		currentRightUV = presets[selectedPresetIndex].rightUV;
+		// Nullopt right-UV → mirror left around x=0.5. This is the safe default
+		// for presets created without a stereo-specific intent (e.g. via
+		// SeedDefaultPresets with only .name + .uv specified).
+		currentRightUV = presets[selectedPresetIndex].rightUV.value_or(MirrorUVHorizontal(currentUV));
 		ClampCurrentUV();
 	}
 

--- a/src/Utils/Subrect.cpp
+++ b/src/Utils/Subrect.cpp
@@ -211,7 +211,11 @@ namespace Util::Subrect
 		if (ImGui::Button("Save Preset")) {
 			std::string presetName = newPresetName;
 			if (!presetName.empty()) {
-				presets.push_back(Preset{ .name = presetName, .uv = currentUV });
+				// Preserve the right-eye UV when stereo is on; otherwise rightUV
+				// is unused and value-init is fine. Without this, saving a
+				// preset in stereo mode loses the right-eye crop on re-apply
+				// (CodeRabbit Major @ scs#2356).
+				presets.push_back(Preset{ .name = presetName, .uv = currentUV, .rightUV = currentRightUV });
 				selectedPresetIndex = static_cast<int>(presets.size()) - 1;
 				newPresetName[0] = '\0';
 			}

--- a/src/Utils/Subrect.cpp
+++ b/src/Utils/Subrect.cpp
@@ -85,9 +85,14 @@ namespace Util::Subrect
 		const bool hasExplicitLeft =
 			a_json.contains("CropX") || a_json.contains("CropY") ||
 			a_json.contains("CropW") || a_json.contains("CropH");
+		// Require the full quartet before declaring the right-eye UV explicit.
+		// A partial config (e.g. only CropRightW present) would otherwise reuse
+		// stale values for the missing components and silently suppress the
+		// left→right auto-mirror fallback. With AND semantics, partial keys
+		// behave as "not explicit" and the mirror still runs.
 		const bool hasExplicitRight =
-			a_json.contains("CropRightX") || a_json.contains("CropRightY") ||
-			a_json.contains("CropRightW") || a_json.contains("CropRightH");
+			a_json.contains("CropRightX") && a_json.contains("CropRightY") &&
+			a_json.contains("CropRightW") && a_json.contains("CropRightH");
 		if (a_json.contains("CropRightX"))
 			currentRightUV.x = a_json["CropRightX"];
 		if (a_json.contains("CropRightY"))
@@ -111,8 +116,15 @@ namespace Util::Subrect
 				}
 				// Right-eye UV is optional in JSON; leave nullopt when absent so
 				// ApplyPreset auto-mirrors the left eye on demand. Explicit
-				// right_uv in JSON wins over any mirror.
-				if (entry.contains("right_uv")) {
+				// right_uv in JSON wins over any mirror — but only when it
+				// looks structurally valid. LoadUVArray falls back to a
+				// full-frame UV on malformed input, so without this guard a
+				// bad `right_uv` payload would suppress auto-mirroring AND
+				// land the right eye as full-frame, which is the worst of
+				// both worlds.
+				if (entry.contains("right_uv") &&
+					entry["right_uv"].is_array() &&
+					entry["right_uv"].size() == 4) {
 					preset.rightUV = LoadUVArray(entry["right_uv"]);
 				}
 				presets.push_back(std::move(preset));
@@ -229,11 +241,18 @@ namespace Util::Subrect
 		if (ImGui::Button("Save Preset")) {
 			std::string presetName = newPresetName;
 			if (!presetName.empty()) {
-				// Preserve the right-eye UV when stereo is on; otherwise rightUV
-				// is unused and value-init is fine. Without this, saving a
-				// preset in stereo mode loses the right-eye crop on re-apply
-				// (CodeRabbit Major @ scs#2356).
-				presets.push_back(Preset{ .name = presetName, .uv = currentUV, .rightUV = currentRightUV });
+				// Preserve the right-eye UV only when stereo is on. In mono
+				// mode currentRightUV is not tracked against currentUV, so
+				// snapshotting it would falsely mark the preset as having an
+				// explicit right eye and disable the auto-mirror fallback
+				// once stereo is later enabled. Leave rightUV as nullopt in
+				// mono — ApplyPreset will mirror left at apply time.
+				// (CodeRabbit Major @ scs#2356 for the stereo-side fix.)
+				Preset newPreset{ .name = presetName, .uv = currentUV };
+				if (stereoEnabled) {
+					newPreset.rightUV = currentRightUV;
+				}
+				presets.push_back(std::move(newPreset));
 				selectedPresetIndex = static_cast<int>(presets.size()) - 1;
 				newPresetName[0] = '\0';
 			}

--- a/src/Utils/Subrect.cpp
+++ b/src/Utils/Subrect.cpp
@@ -1,6 +1,8 @@
 #include "Utils/Subrect.h"
 
 #include <algorithm>
+#include <cmath>
+#include <d3d11.h>
 #include <imgui.h>
 
 namespace
@@ -39,6 +41,16 @@ namespace
 		return ClampUV(uv);
 	}
 
+	Util::Subrect::UVRegion MirrorUVHorizontal(const Util::Subrect::UVRegion& uv)
+	{
+		// HMD nose-side overlap: left-eye nose-side region is on the right
+		// half of the eye texture; mirror around x=0.5 maps it to the
+		// right-eye's left half.
+		Util::Subrect::UVRegion mirrored = uv;
+		mirrored.x = 1.0f - uv.x - uv.w;
+		return ClampUV(mirrored);
+	}
+
 	json SaveUVToJson(const Util::Subrect::UVRegion& uv)
 	{
 		return { uv.x, uv.y, uv.w, uv.h };
@@ -70,6 +82,21 @@ namespace Util::Subrect
 		if (a_json.contains("CropH"))
 			currentUV.h = a_json["CropH"];
 
+		const bool hasExplicitLeft =
+			a_json.contains("CropX") || a_json.contains("CropY") ||
+			a_json.contains("CropW") || a_json.contains("CropH");
+		const bool hasExplicitRight =
+			a_json.contains("CropRightX") || a_json.contains("CropRightY") ||
+			a_json.contains("CropRightW") || a_json.contains("CropRightH");
+		if (a_json.contains("CropRightX"))
+			currentRightUV.x = a_json["CropRightX"];
+		if (a_json.contains("CropRightY"))
+			currentRightUV.y = a_json["CropRightY"];
+		if (a_json.contains("CropRightW"))
+			currentRightUV.w = a_json["CropRightW"];
+		if (a_json.contains("CropRightH"))
+			currentRightUV.h = a_json["CropRightH"];
+
 		if (a_json.contains("CropPresets") && a_json["CropPresets"].is_array()) {
 			presets.clear();
 			for (auto& entry : a_json["CropPresets"]) {
@@ -78,12 +105,27 @@ namespace Util::Subrect
 				if (entry.contains("uv")) {
 					preset.uv = LoadUVArray(entry["uv"]);
 				}
+				// Right-eye UV is optional. If absent, callers in stereo mode
+				// fall back to the mirrored left-eye via ApplyPreset.
+				if (entry.contains("right_uv")) {
+					preset.rightUV = LoadUVArray(entry["right_uv"]);
+				} else {
+					preset.rightUV = MirrorUVHorizontal(preset.uv);
+				}
 				presets.push_back(std::move(preset));
 			}
 		}
 
 		EnsureDefaultPreset();
 		ClampCurrentUV();
+
+		// Legacy upgrade: if the JSON has the mono crop keys but no right-eye
+		// keys, mirror left → right so existing user settings transition
+		// cleanly. If neither side is present, leave currentRightUV alone so
+		// EnsureDefaultPreset's seeded right-eye value survives.
+		if (stereoEnabled && hasExplicitLeft && !hasExplicitRight) {
+			SyncRightUV();
+		}
 
 		if (a_json.contains("SelectedPresetIndex")) {
 			selectedPresetIndex = a_json["SelectedPresetIndex"];
@@ -102,11 +144,21 @@ namespace Util::Subrect
 		a_json["CropW"] = currentUV.w;
 		a_json["CropH"] = currentUV.h;
 
+		if (stereoEnabled) {
+			a_json["CropRightX"] = currentRightUV.x;
+			a_json["CropRightY"] = currentRightUV.y;
+			a_json["CropRightW"] = currentRightUV.w;
+			a_json["CropRightH"] = currentRightUV.h;
+		}
+
 		json presetsJson = json::array();
 		for (const auto& preset : presets) {
 			json entry;
 			entry["name"] = preset.name;
 			entry["uv"] = SaveUVToJson(preset.uv);
+			if (stereoEnabled) {
+				entry["right_uv"] = SaveUVToJson(preset.rightUV);
+			}
 			presetsJson.push_back(std::move(entry));
 		}
 		a_json["CropPresets"] = presetsJson;
@@ -116,6 +168,17 @@ namespace Util::Subrect
 	void Controller::SeedDefaultPresets(std::vector<Preset> defaults)
 	{
 		seededDefaults = std::move(defaults);
+	}
+
+	void Controller::SetStereoEnabled(bool enabled)
+	{
+		if (stereoEnabled == enabled) {
+			return;
+		}
+		stereoEnabled = enabled;
+		if (stereoEnabled) {
+			SyncRightUV();
+		}
 	}
 
 	void Controller::DrawEditor(ID3D11ShaderResourceView* previewSrv, ID3D11Texture2D* previewTexture, float uvVisibleWidth, float uvStartX, ImDrawCallback imageRenderCallback)
@@ -177,6 +240,9 @@ namespace Util::Subrect
 		if (changed) {
 			selectedPresetIndex = -1;
 			ClampCurrentUV();
+			if (stereoEnabled) {
+				SyncRightUV();
+			}
 		}
 
 		ImGui::Spacing();
@@ -235,6 +301,9 @@ namespace Util::Subrect
 			currentUV.w = maxX - minX;
 			currentUV.h = maxY - minY;
 			ClampCurrentUV();
+			if (stereoEnabled) {
+				SyncRightUV();
+			}
 
 			if (!ImGui::IsMouseDown(ImGuiMouseButton_Left)) {
 				isDraggingCrop = false;
@@ -253,6 +322,17 @@ namespace Util::Subrect
 		return UVToPixelRegion(currentUV, width, height);
 	}
 
+	StereoPixelRegions Controller::GetStereoPixelRegions(uint32_t fullWidth, uint32_t fullHeight) const
+	{
+		// Each eye occupies half the SBS texture width. In mono mode, both
+		// eyes report the same region so callers don't need to branch.
+		const uint32_t eyeWidth = fullWidth / 2;
+		StereoPixelRegions regions;
+		regions.leftEye = UVToPixelRegion(currentUV, eyeWidth, fullHeight);
+		regions.rightEye = UVToPixelRegion(stereoEnabled ? currentRightUV : currentUV, eyeWidth, fullHeight);
+		return regions;
+	}
+
 	void Controller::EnsureDefaultPreset()
 	{
 		if (!presets.empty()) {
@@ -263,6 +343,7 @@ namespace Util::Subrect
 			// currentUV must match what the combo shows as selected; otherwise
 			// the first preset appears chosen but the crop region stays full-frame.
 			currentUV = presets[0].uv;
+			currentRightUV = presets[0].rightUV;
 			selectedPresetIndex = 0;
 		} else {
 			presets.push_back(Preset{ .name = "Full Frame", .uv = DefaultUV() });
@@ -272,6 +353,7 @@ namespace Util::Subrect
 	void Controller::ClampCurrentUV()
 	{
 		currentUV = ClampUV(currentUV);
+		currentRightUV = ClampUV(currentRightUV);
 	}
 
 	void Controller::ApplyPreset(int index)
@@ -279,6 +361,12 @@ namespace Util::Subrect
 		EnsureDefaultPreset();
 		selectedPresetIndex = std::clamp(index, 0, static_cast<int>(presets.size()) - 1);
 		currentUV = presets[selectedPresetIndex].uv;
+		currentRightUV = presets[selectedPresetIndex].rightUV;
 		ClampCurrentUV();
+	}
+
+	void Controller::SyncRightUV()
+	{
+		currentRightUV = MirrorUVHorizontal(currentUV);
 	}
 }  // namespace Util::Subrect

--- a/src/Utils/Subrect.cpp
+++ b/src/Utils/Subrect.cpp
@@ -96,6 +96,9 @@ namespace Util::Subrect
 			currentRightUV.w = a_json["CropRightW"];
 		if (a_json.contains("CropRightH"))
 			currentRightUV.h = a_json["CropRightH"];
+		if (hasExplicitRight) {
+			rightUVLoadedFromJson = true;
+		}
 
 		if (a_json.contains("CropPresets") && a_json["CropPresets"].is_array()) {
 			presets.clear();
@@ -176,7 +179,11 @@ namespace Util::Subrect
 			return;
 		}
 		stereoEnabled = enabled;
-		if (stereoEnabled) {
+		// Only auto-mirror left→right when the right-eye UV hasn't been
+		// explicitly loaded from JSON. Otherwise a caller that does
+		// `LoadSettings` (stereo off) then `SetStereoEnabled(true)` would
+		// silently overwrite a deliberate persisted right-eye crop.
+		if (stereoEnabled && !rightUVLoadedFromJson) {
 			SyncRightUV();
 		}
 	}

--- a/src/Utils/Subrect.h
+++ b/src/Utils/Subrect.h
@@ -1,7 +1,20 @@
 #pragma once
 
+#include <cstdint>
 #include <imgui.h>
+#include <nlohmann/json.hpp>
+#include <string>
 #include <vector>
+
+// Forward-declared so the header doesn't drag in <d3d11.h>. The plugin's PCH
+// brings the real types into scope at definition sites.
+struct ID3D11ShaderResourceView;
+struct ID3D11Texture2D;
+
+// Mirrors the global `using json = nlohmann::json;` from the plugin PCH so
+// the header builds standalone (e.g. in unit-test targets that don't
+// precompile PCH). Identical aliases in the same scope are well-defined.
+using json = nlohmann::json;
 
 namespace Util::Subrect
 {
@@ -21,15 +34,27 @@ namespace Util::Subrect
 		uint32_t h = 1;
 	};
 
+	struct StereoPixelRegions
+	{
+		PixelRegion leftEye;
+		PixelRegion rightEye;
+	};
+
 	struct Preset
 	{
 		std::string name;
-		UVRegion uv;
+		UVRegion uv;         // Left-eye UV when stereo is enabled; sole UV otherwise.
+		UVRegion rightUV{};  // Only consulted when the host enables stereo.
 	};
 
 	// "User picks a sub-rectangle of an image" controller. Crop UV is in [0,1]
 	// of the source the caller passes to GetPixelRegion(). Hosts that want
 	// preset-based eye selection seed Left/Right/Full Frame via SeedDefaultPresets.
+	//
+	// Stereo: hosts that consume a side-by-side stereo texture call
+	// SetStereoEnabled(true) to track a separate right-eye UV. Right-eye UV
+	// auto-mirrors left around x=0.5 unless explicitly edited; this matches
+	// HMD nose-side overlap symmetry.
 	class Controller
 	{
 	public:
@@ -39,6 +64,12 @@ namespace Util::Subrect
 		// Replaces the built-in "Full Frame" placeholder used when JSON has no
 		// CropPresets entry yet. Empty-case only - user edits/deletions persist.
 		void SeedDefaultPresets(std::vector<Preset> defaults);
+
+		// Toggles right-eye UV tracking. Off by default (mono).
+		// When enabled, edits to the primary UV auto-mirror to the right-eye
+		// UV (around x=0.5), and SaveSettings emits the extra right-eye keys.
+		void SetStereoEnabled(bool enabled);
+		bool IsStereoEnabled() const { return stereoEnabled; }
 
 		// uvStartX/uvVisibleWidth window the preview onto a sub-region of the
 		// texture; crop UV stays in [0,1] of that window. imageRenderCallback,
@@ -52,7 +83,12 @@ namespace Util::Subrect
 		// Resolves the crop UV against an arbitrary pixel size.
 		PixelRegion GetPixelRegion(uint32_t width, uint32_t height) const;
 
+		// In stereo mode, resolves both eyes' UVs against an SBS texture by
+		// dividing width by 2. In mono mode, both eyes resolve from currentUV.
+		StereoPixelRegions GetStereoPixelRegions(uint32_t fullWidth, uint32_t fullHeight) const;
+
 		const UVRegion& GetUV() const { return currentUV; }
+		const UVRegion& GetRightEyeUV() const { return stereoEnabled ? currentRightUV : currentUV; }
 
 	private:
 		std::vector<Preset> presets;
@@ -61,6 +97,8 @@ namespace Util::Subrect
 		char newPresetName[64] = "";
 
 		UVRegion currentUV{};
+		UVRegion currentRightUV{};
+		bool stereoEnabled = false;
 
 		bool isDraggingCrop = false;
 		float dragStartUV[2] = { 0.0f, 0.0f };
@@ -68,5 +106,6 @@ namespace Util::Subrect
 		void EnsureDefaultPreset();
 		void ClampCurrentUV();
 		void ApplyPreset(int index);
+		void SyncRightUV();
 	};
 }  // namespace Util::Subrect

--- a/src/Utils/Subrect.h
+++ b/src/Utils/Subrect.h
@@ -85,6 +85,11 @@ namespace Util::Subrect
 
 		// In stereo mode, resolves both eyes' UVs against an SBS texture by
 		// dividing width by 2. In mono mode, both eyes resolve from currentUV.
+		//
+		// Coordinate space: both leftEye.x and rightEye.x are in PER-EYE
+		// space (i.e. x in [0, fullWidth/2)) — the right eye is NOT
+		// pre-offset by eyeWidth. Callers that draw into the full SBS
+		// texture must add `fullWidth / 2` to rightEye.x themselves.
 		StereoPixelRegions GetStereoPixelRegions(uint32_t fullWidth, uint32_t fullHeight) const;
 
 		const UVRegion& GetUV() const { return currentUV; }
@@ -99,6 +104,11 @@ namespace Util::Subrect
 		UVRegion currentUV{};
 		UVRegion currentRightUV{};
 		bool stereoEnabled = false;
+		// True once LoadSettings sees an explicit CropRight* key. Suppresses
+		// the auto-mirror in SetStereoEnabled(true) so a deliberate JSON
+		// right-eye crop survives a mono→stereo transition that happens
+		// after the load.
+		bool rightUVLoadedFromJson = false;
 
 		bool isDraggingCrop = false;
 		float dragStartUV[2] = { 0.0f, 0.0f };

--- a/src/Utils/Subrect.h
+++ b/src/Utils/Subrect.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <imgui.h>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -43,8 +44,14 @@ namespace Util::Subrect
 	struct Preset
 	{
 		std::string name;
-		UVRegion uv;         // Left-eye UV when stereo is enabled; sole UV otherwise.
-		UVRegion rightUV{};  // Only consulted when the host enables stereo.
+		UVRegion uv;  // Left-eye UV when stereo is enabled; sole UV otherwise.
+		// Right-eye UV. `std::nullopt` means "no explicit right eye — auto-mirror
+		// left around x=0.5 when stereo is enabled". A default-constructed
+		// `UVRegion{}` (full frame) would otherwise be ambiguous: it could mean
+		// "the user wants full frame" or "the caller didn't supply one", and
+		// the silent-full-frame case bites SeedDefaultPresets callers that only
+		// fill `.name` and `.uv`.
+		std::optional<UVRegion> rightUV{};
 	};
 
 	// "User picks a sub-rectangle of an image" controller. Crop UV is in [0,1]

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -1,0 +1,79 @@
+# C++ unit tests for plugin utility code.
+#
+# Catch2-based. Disjoint from tests/shaders (which tests HLSL via
+# ShaderTestFramework). Add test sources here for any plugin code that
+# doesn't require a live DirectX device or ImGui context.
+
+cmake_minimum_required(VERSION 4.2)
+
+option(BUILD_CPP_TESTS "Build C++ unit tests for plugin utilities" ON)
+
+if(NOT BUILD_CPP_TESTS)
+    message(STATUS "C++ unit tests disabled")
+    return()
+endif()
+
+message(STATUS "Configuring C++ unit tests...")
+
+include(FetchContent)
+
+# Reused by tests/shaders if that target is also enabled. FetchContent dedupes
+# by name, so the same Catch2 source tree serves both.
+FetchContent_Declare(
+    catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.11.0
+)
+FetchContent_MakeAvailable(Catch2)
+
+# MSVC 14.50+ (VS 2026) ICE workaround copied from tests/shaders.
+if(MSVC AND MSVC_VERSION GREATER_EQUAL 1950)
+    if(TARGET Catch2)
+        target_compile_options(Catch2 PRIVATE /Od)
+    endif()
+endif()
+
+find_package(nlohmann_json CONFIG REQUIRED)
+find_package(imgui CONFIG REQUIRED)
+
+add_executable(cpp_tests
+    test_main.cpp
+    test_subrect.cpp
+    # Compile the unit-under-test directly into the test binary so we don't
+    # depend on the plugin DLL build (which pulls in FFX/Streamline/etc.).
+    "${CMAKE_SOURCE_DIR}/src/Utils/Subrect.cpp"
+)
+
+set_property(TARGET cpp_tests PROPERTY CXX_STANDARD 23)
+set_property(TARGET cpp_tests PROPERTY CXX_STANDARD_REQUIRED ON)
+
+target_include_directories(cpp_tests PRIVATE
+    "${CMAKE_SOURCE_DIR}/src"
+)
+
+target_link_libraries(cpp_tests PRIVATE
+    Catch2::Catch2
+    nlohmann_json::nlohmann_json
+    imgui::imgui
+)
+
+# windows.h (pulled in via d3d11.h) defines min/max macros that break the
+# std::min<T>/std::max<T> calls in Subrect.cpp. The plugin's PCH suppresses
+# this implicitly; the test target needs it explicitly.
+target_compile_definitions(cpp_tests PRIVATE
+    NOMINMAX
+    WIN32_LEAN_AND_MEAN
+)
+
+enable_testing()
+add_test(
+    NAME CppUtilTests
+    COMMAND cpp_tests --reporter compact
+    WORKING_DIRECTORY $<TARGET_FILE_DIR:cpp_tests>
+)
+set_tests_properties(CppUtilTests PROPERTIES
+    TIMEOUT 60
+    LABELS "Cpp;UnitTests"
+)
+
+message(STATUS "C++ unit tests configured successfully")

--- a/tests/cpp/test_main.cpp
+++ b/tests/cpp/test_main.cpp
@@ -1,0 +1,9 @@
+// Explicit main() for C++ unit tests.
+// Catch2WithMain has linker issues with CMake 4.0 (see tests/shaders/minimal_test.cpp);
+// we provide our own session entry point.
+#include <catch2/catch_session.hpp>
+
+int main(int argc, char* argv[])
+{
+	return Catch::Session().run(argc, argv);
+}

--- a/tests/cpp/test_subrect.cpp
+++ b/tests/cpp/test_subrect.cpp
@@ -364,3 +364,43 @@ TEST_CASE("Seeded preset without explicit rightUV auto-mirrors in stereo", "[sub
 	// Mirror of {0, 0, 0.5, 1.0} around x=0.5 is {0.5, 0, 0.5, 1.0}.
 	REQUIRE(UVApprox(c.GetRightEyeUV(), { 0.5f, 0.0f, 0.5f, 1.0f }));
 }
+
+TEST_CASE("Partial CropRight* keys still allow auto-mirror", "[subrect][stereo][regression]")
+{
+	// Only one of the four right-eye keys was provided. The old OR semantics
+	// would mark this as "explicit right eye" and suppress the mirror on
+	// SetStereoEnabled(true), leaving currentRightUV with mixed stale + loaded
+	// components. The fixed AND semantics treat partial as not-explicit so
+	// the mirror still runs.
+	Controller c;
+	json partial = {
+		{ "CropX", 0.20f }, { "CropY", 0.00f }, { "CropW", 0.60f }, { "CropH", 1.00f },
+		{ "CropRightW", 0.50f }  // a single right-eye key — incomplete quartet
+	};
+	c.LoadSettings(partial);
+	c.SetStereoEnabled(true);
+	// Mirror of {0.20, 0, 0.60, 1.0} is {0.20, 0, 0.60, 1.0} — confirms the
+	// mirror ran rather than landing the half-loaded right UV.
+	REQUIRE(UVApprox(c.GetRightEyeUV(), { 0.20f, 0.0f, 0.60f, 1.0f }));
+}
+
+TEST_CASE("Malformed preset right_uv falls back to auto-mirror", "[subrect][stereo][regression]")
+{
+	// LoadUVArray returns a default full-frame UV on malformed input. Without
+	// shape validation, a bad `right_uv` payload would land the right eye as
+	// full-frame AND suppress the auto-mirror — the worst of both worlds.
+	// With validation, malformed input is ignored and the mirror takes over.
+	Controller c;
+	c.SetStereoEnabled(true);
+	json bad = {
+		{ "CropPresets", json::array({ json{
+							 { "name", "Bad" },
+							 { "uv", { 0.10f, 0.0f, 0.40f, 1.0f } },
+							 { "right_uv", "not an array" }  // malformed
+						 } }) },
+		{ "SelectedPresetIndex", 0 }
+	};
+	c.LoadSettings(bad);
+	// Auto-mirror of {0.10, 0, 0.40, 1.0} = {0.50, 0, 0.40, 1.0}, NOT {0,0,1,1}.
+	REQUIRE(UVApprox(c.GetRightEyeUV(), { 0.50f, 0.0f, 0.40f, 1.0f }));
+}

--- a/tests/cpp/test_subrect.cpp
+++ b/tests/cpp/test_subrect.cpp
@@ -197,25 +197,55 @@ TEST_CASE("GetStereoPixelRegions in mono mode returns identical eyes", "[subrect
 	REQUIRE(regions.leftEye.w == regions.rightEye.w);
 }
 
-TEST_CASE("Stereo preset save captures right-eye UV", "[subrect][stereo][regression]")
+TEST_CASE("Stereo SaveSettings emits right_uv for every preset", "[subrect][stereo][regression]")
 {
 	// Regression for CodeRabbit Major @ scs#2356: the Save Preset button used
 	// to drop currentRightUV, so re-applying a saved preset would zero out the
-	// right eye. We can't drive the ImGui button from a test, but we can
-	// verify the same Preset construction Save Preset uses round-trips both
-	// eyes through SaveSettings/LoadSettings.
+	// right eye. We can't drive the ImGui Save Preset button from a test, but
+	// we can stage the same end state (a Controller with stereo enabled and an
+	// in-memory preset whose rightUV differs from a mirror of left) and verify
+	// it round-trips both eyes through SaveSettings → LoadSettings.
 	Controller src;
 	src.SetStereoEnabled(true);
-	src.LoadSettings(json::object());
 
-	// Simulate what the Save Preset button now does: pushes a Preset built
-	// from BOTH currentUV and currentRightUV (not just .uv).
+	// Stage a preset with an explicit asymmetric right_uv that doesn't equal
+	// MirrorUVHorizontal(uv) — otherwise we couldn't distinguish "right_uv was
+	// preserved" from "default fallback mirrored it back".
+	const UVRegion leftUV{ 0.10f, 0.0f, 0.40f, 1.0f };
+	const UVRegion rightUV{ 0.55f, 0.0f, 0.35f, 1.0f };
+	json staged = {
+		{ "CropX", leftUV.x },
+		{ "CropY", leftUV.y },
+		{ "CropW", leftUV.w },
+		{ "CropH", leftUV.h },
+		{ "CropRightX", rightUV.x },
+		{ "CropRightY", rightUV.y },
+		{ "CropRightW", rightUV.w },
+		{ "CropRightH", rightUV.h },
+		{ "CropPresets", json::array({ json{
+			{ "name", "Asymmetric" },
+			{ "uv", json::array({ leftUV.x, leftUV.y, leftUV.w, leftUV.h }) },
+			{ "right_uv", json::array({ rightUV.x, rightUV.y, rightUV.w, rightUV.h }) } }) }
+		},
+		{ "SelectedPresetIndex", 0 }
+	};
+	src.LoadSettings(staged);
+
 	json saved;
 	src.SaveSettings(saved);
 	REQUIRE(saved["CropPresets"].is_array());
+	REQUIRE_FALSE(saved["CropPresets"].empty());
 	for (const auto& entry : saved["CropPresets"]) {
 		REQUIRE(entry.contains("right_uv"));
 	}
+
+	// Round-trip into a fresh controller and confirm the asymmetric right UV
+	// survived. Before the fix the saved preset's right_uv would be missing
+	// and LoadSettings would mirror left → right, equalizing the eyes.
+	Controller dst;
+	dst.SetStereoEnabled(true);
+	dst.LoadSettings(saved);
+	REQUIRE(UVApprox(dst.GetRightEyeUV(), rightUV));
 }
 
 TEST_CASE("MirrorUVHorizontal symmetry via SetStereoEnabled", "[subrect][stereo][math]")
@@ -235,4 +265,27 @@ TEST_CASE("MirrorUVHorizontal symmetry via SetStereoEnabled", "[subrect][stereo]
 	c.SetStereoEnabled(true);
 	// x = 1 - 0.4 - 0.6 = 0.0
 	REQUIRE(UVApprox(c.GetRightEyeUV(), { 0.0f, 0.0f, 0.6f, 1.0f }));
+}
+
+TEST_CASE("SetStereoEnabled preserves explicit right UV loaded earlier", "[subrect][stereo][regression]")
+{
+	// Regression for the call-order trap: LoadSettings (mono) → SetStereoEnabled(true)
+	// must NOT overwrite an explicit CropRight* value with the mirror of the left eye.
+	Controller c;
+	const UVRegion explicitRight{ 0.62f, 0.10f, 0.30f, 0.80f };
+	json in = {
+		{ "CropX", 0.10f },
+		{ "CropY", 0.00f },
+		{ "CropW", 0.40f },
+		{ "CropH", 1.00f },
+		{ "CropRightX", explicitRight.x },
+		{ "CropRightY", explicitRight.y },
+		{ "CropRightW", explicitRight.w },
+		{ "CropRightH", explicitRight.h },
+	};
+	c.LoadSettings(in);
+	REQUIRE_FALSE(c.IsStereoEnabled());
+
+	c.SetStereoEnabled(true);
+	REQUIRE(UVApprox(c.GetRightEyeUV(), explicitRight));
 }

--- a/tests/cpp/test_subrect.cpp
+++ b/tests/cpp/test_subrect.cpp
@@ -1,0 +1,217 @@
+// Unit tests for Util::Subrect::Controller.
+//
+// Focus: API contract for the stereo extension (PR-1 of the DLSS-PR-PLAN decomposition).
+// Cannot exercise DrawEditor (needs an ImGui context); covers everything else:
+// JSON load/save round-trips, mirror math, preset apply, mono/stereo back-compat.
+
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+#include <imgui.h>  // ImDrawCallback declared in Subrect.h signature
+
+#include "Utils/Subrect.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+using Catch::Matchers::WithinAbs;
+using Util::Subrect::Controller;
+using Util::Subrect::Preset;
+using Util::Subrect::UVRegion;
+
+namespace
+{
+	bool UVApprox(const UVRegion& a, const UVRegion& b, float eps = 1e-5f)
+	{
+		return std::abs(a.x - b.x) < eps && std::abs(a.y - b.y) < eps &&
+		       std::abs(a.w - b.w) < eps && std::abs(a.h - b.h) < eps;
+	}
+}
+
+TEST_CASE("Controller defaults to mono mode", "[subrect]")
+{
+	Controller c;
+	REQUIRE_FALSE(c.IsStereoEnabled());
+	// Right-eye accessor folds onto primary UV in mono mode.
+	REQUIRE(UVApprox(c.GetUV(), c.GetRightEyeUV()));
+}
+
+TEST_CASE("SaveSettings in mono mode emits no right-eye keys", "[subrect][backcompat]")
+{
+	// Pre-stereo screenshot JSON shape must round-trip bit-identically: this is
+	// the core back-compat contract for the existing ScreenshotFeature consumer.
+	// EnsureDefaultPreset is lazy (only runs in LoadSettings/ApplyPreset/DrawEditor),
+	// so prime it with an empty load to realize the placeholder preset.
+	Controller c;
+	c.LoadSettings(json::object());
+	json out;
+	c.SaveSettings(out);
+
+	REQUIRE(out.contains("CropX"));
+	REQUIRE(out.contains("CropY"));
+	REQUIRE(out.contains("CropW"));
+	REQUIRE(out.contains("CropH"));
+	REQUIRE_FALSE(out.contains("CropRightX"));
+	REQUIRE_FALSE(out.contains("CropRightY"));
+	REQUIRE_FALSE(out.contains("CropRightW"));
+	REQUIRE_FALSE(out.contains("CropRightH"));
+
+	REQUIRE(out["CropPresets"].is_array());
+	REQUIRE(out["CropPresets"].size() >= 1);
+	for (const auto& entry : out["CropPresets"]) {
+		REQUIRE(entry.contains("uv"));
+		REQUIRE_FALSE(entry.contains("right_uv"));
+	}
+}
+
+TEST_CASE("LoadSettings reads legacy mono JSON unchanged", "[subrect][backcompat]")
+{
+	// Replicates the screenshot feature's existing on-disk schema.
+	json in = {
+		{ "CropX", 0.25f },
+		{ "CropY", 0.10f },
+		{ "CropW", 0.5f },
+		{ "CropH", 0.8f },
+		{ "CropPresets", json::array({
+							 {
+								 { "name", "Full Frame" },
+								 { "uv", { 0.0f, 0.0f, 1.0f, 1.0f } },
+							 },
+						 }) },
+		{ "SelectedPresetIndex", -1 },
+	};
+
+	Controller c;
+	c.LoadSettings(in);
+
+	REQUIRE(UVApprox(c.GetUV(), { 0.25f, 0.10f, 0.5f, 0.8f }));
+	REQUIRE_FALSE(c.IsStereoEnabled());
+}
+
+TEST_CASE("SetStereoEnabled toggles mirror sync", "[subrect][stereo]")
+{
+	// Stereo enable on a fresh controller mirrors the default UV (which is
+	// {0,0,1,1}); the mirror of a full-frame is still full-frame.
+	Controller c;
+	c.SetStereoEnabled(true);
+	REQUIRE(c.IsStereoEnabled());
+
+	// Re-enable is a no-op (no double-sync, no state corruption).
+	c.SetStereoEnabled(true);
+	REQUIRE(c.IsStereoEnabled());
+
+	c.SetStereoEnabled(false);
+	REQUIRE_FALSE(c.IsStereoEnabled());
+}
+
+TEST_CASE("Stereo save then load round-trips right-eye keys", "[subrect][stereo]")
+{
+	// Seed presets with explicit asymmetric right-eye to confirm the on-disk
+	// schema preserves it (rather than always mirroring on load).
+	Controller src;
+	src.SetStereoEnabled(true);
+	src.SeedDefaultPresets({
+		Preset{ .name = "Asym", .uv = { 0.1f, 0.0f, 0.5f, 1.0f }, .rightUV = { 0.3f, 0.0f, 0.4f, 0.9f } },
+	});
+	// Realize the seed and copy it into currentUV/currentRightUV.
+	src.LoadSettings(json::object());
+
+	json saved;
+	src.SaveSettings(saved);
+
+	REQUIRE(saved.contains("CropRightX"));
+	REQUIRE(saved["CropPresets"][0].contains("right_uv"));
+
+	Controller dst;
+	dst.SetStereoEnabled(true);
+	dst.LoadSettings(saved);
+
+	// After load, applying the asymmetric preset must restore both eyes
+	// exactly (not mirror-overwrite the right eye).
+	REQUIRE(UVApprox(dst.GetUV(), { 0.1f, 0.0f, 0.5f, 1.0f }));
+	REQUIRE(UVApprox(dst.GetRightEyeUV(), { 0.3f, 0.0f, 0.4f, 0.9f }));
+}
+
+TEST_CASE("Stereo load mirrors right-eye when JSON lacks CropRight keys", "[subrect][stereo][backcompat]")
+{
+	// A user upgrading from a mono build has CropX/Y/W/H but no CropRight*.
+	// In stereo mode, the controller mirrors the primary UV around x=0.5.
+	json legacy = {
+		{ "CropX", 0.2f },
+		{ "CropY", 0.0f },
+		{ "CropW", 0.5f },
+		{ "CropH", 1.0f },
+	};
+
+	Controller c;
+	c.SetStereoEnabled(true);
+	c.LoadSettings(legacy);
+
+	REQUIRE(UVApprox(c.GetUV(), { 0.2f, 0.0f, 0.5f, 1.0f }));
+	// Mirror: x = 1 - 0.2 - 0.5 = 0.3
+	REQUIRE(UVApprox(c.GetRightEyeUV(), { 0.3f, 0.0f, 0.5f, 1.0f }));
+}
+
+TEST_CASE("GetStereoPixelRegions splits SBS width per eye", "[subrect][stereo]")
+{
+	// Stereo regions resolve against half-width per eye (the texture is SBS).
+	// Caller passes the full stereo texture size; controller divides W by 2.
+	Controller c;
+	c.SetStereoEnabled(true);
+
+	// Make eyes asymmetric so we can tell them apart.
+	c.SeedDefaultPresets({
+		Preset{
+			.name = "Asym",
+			.uv = { 0.0f, 0.0f, 1.0f, 1.0f },       // full left eye
+			.rightUV = { 0.0f, 0.0f, 0.5f, 1.0f },  // left half of right eye
+		},
+	});
+	// Realize the seed so currentUV/currentRightUV pick up the preset values.
+	c.LoadSettings(json::object());
+
+	const auto regions = c.GetStereoPixelRegions(2000, 1000);
+	// Left eye spans the full 1000-wide left half.
+	REQUIRE(regions.leftEye.x == 0);
+	REQUIRE(regions.leftEye.w == 1000);
+	REQUIRE(regions.leftEye.h == 1000);
+	// Right eye spans only half the 1000-wide right half = 500 px.
+	REQUIRE(regions.rightEye.w == 500);
+}
+
+TEST_CASE("GetStereoPixelRegions in mono mode returns identical eyes", "[subrect][stereo]")
+{
+	// Mono callers can use the stereo accessor and both eyes will resolve from
+	// the primary UV — lets DLSS consumers stay agnostic of stereo state.
+	Controller c;
+	json in = {
+		{ "CropX", 0.0f },
+		{ "CropY", 0.0f },
+		{ "CropW", 1.0f },
+		{ "CropH", 1.0f },
+	};
+	c.LoadSettings(in);
+
+	const auto regions = c.GetStereoPixelRegions(2000, 1000);
+	REQUIRE(regions.leftEye.x == regions.rightEye.x);
+	REQUIRE(regions.leftEye.w == regions.rightEye.w);
+}
+
+TEST_CASE("MirrorUVHorizontal symmetry via SetStereoEnabled", "[subrect][stereo][math]")
+{
+	// {0.4, *, 0.6, *} mirrors to {0, *, 0.6, *} — the nose-side overlap case.
+	// Exercised through SetStereoEnabled since MirrorUVHorizontal is private.
+	Controller c;
+	json in = {
+		{ "CropX", 0.4f },
+		{ "CropY", 0.0f },
+		{ "CropW", 0.6f },
+		{ "CropH", 1.0f },
+	};
+	c.LoadSettings(in);
+	REQUIRE_FALSE(c.IsStereoEnabled());
+
+	c.SetStereoEnabled(true);
+	// x = 1 - 0.4 - 0.6 = 0.0
+	REQUIRE(UVApprox(c.GetRightEyeUV(), { 0.0f, 0.0f, 0.6f, 1.0f }));
+}

--- a/tests/cpp/test_subrect.cpp
+++ b/tests/cpp/test_subrect.cpp
@@ -197,6 +197,27 @@ TEST_CASE("GetStereoPixelRegions in mono mode returns identical eyes", "[subrect
 	REQUIRE(regions.leftEye.w == regions.rightEye.w);
 }
 
+TEST_CASE("Stereo preset save captures right-eye UV", "[subrect][stereo][regression]")
+{
+	// Regression for CodeRabbit Major @ scs#2356: the Save Preset button used
+	// to drop currentRightUV, so re-applying a saved preset would zero out the
+	// right eye. We can't drive the ImGui button from a test, but we can
+	// verify the same Preset construction Save Preset uses round-trips both
+	// eyes through SaveSettings/LoadSettings.
+	Controller src;
+	src.SetStereoEnabled(true);
+	src.LoadSettings(json::object());
+
+	// Simulate what the Save Preset button now does: pushes a Preset built
+	// from BOTH currentUV and currentRightUV (not just .uv).
+	json saved;
+	src.SaveSettings(saved);
+	REQUIRE(saved["CropPresets"].is_array());
+	for (const auto& entry : saved["CropPresets"]) {
+		REQUIRE(entry.contains("right_uv"));
+	}
+}
+
 TEST_CASE("MirrorUVHorizontal symmetry via SetStereoEnabled", "[subrect][stereo][math]")
 {
 	// {0.4, *, 0.6, *} mirrors to {0, *, 0.6, *} — the nose-side overlap case.

--- a/tests/cpp/test_subrect.cpp
+++ b/tests/cpp/test_subrect.cpp
@@ -12,11 +12,11 @@ using json = nlohmann::json;
 #include "Utils/Subrect.h"
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_floating_point.hpp>
 
-#include <cmath>  // std::abs
+#include <cmath>    // std::abs
+#include <utility>  // std::pair
+#include <vector>   // std::vector — degenerate-dimensions cases enumerate (w,h) pairs
 
-using Catch::Matchers::WithinAbs;
 using Util::Subrect::Controller;
 using Util::Subrect::Preset;
 using Util::Subrect::UVRegion;

--- a/tests/cpp/test_subrect.cpp
+++ b/tests/cpp/test_subrect.cpp
@@ -14,6 +14,8 @@ using json = nlohmann::json;
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include <cmath>  // std::abs
+
 using Catch::Matchers::WithinAbs;
 using Util::Subrect::Controller;
 using Util::Subrect::Preset;
@@ -111,7 +113,7 @@ TEST_CASE("Stereo save then load round-trips right-eye keys", "[subrect][stereo]
 	Controller src;
 	src.SetStereoEnabled(true);
 	src.SeedDefaultPresets({
-		Preset{ .name = "Asym", .uv = { 0.1f, 0.0f, 0.5f, 1.0f }, .rightUV = { 0.3f, 0.0f, 0.4f, 0.9f } },
+		Preset{ .name = "Asym", .uv = { 0.1f, 0.0f, 0.5f, 1.0f }, .rightUV = UVRegion{ 0.3f, 0.0f, 0.4f, 0.9f } },
 	});
 	// Realize the seed and copy it into currentUV/currentRightUV.
 	src.LoadSettings(json::object());
@@ -163,8 +165,8 @@ TEST_CASE("GetStereoPixelRegions splits SBS width per eye", "[subrect][stereo]")
 	c.SeedDefaultPresets({
 		Preset{
 			.name = "Asym",
-			.uv = { 0.0f, 0.0f, 1.0f, 1.0f },       // full left eye
-			.rightUV = { 0.0f, 0.0f, 0.5f, 1.0f },  // left half of right eye
+			.uv = { 0.0f, 0.0f, 1.0f, 1.0f },               // full left eye
+			.rightUV = UVRegion{ 0.0f, 0.0f, 0.5f, 1.0f },  // left half of right eye
 		},
 	});
 	// Realize the seed so currentUV/currentRightUV pick up the preset values.
@@ -288,4 +290,77 @@ TEST_CASE("SetStereoEnabled preserves explicit right UV loaded earlier", "[subre
 
 	c.SetStereoEnabled(true);
 	REQUIRE(UVApprox(c.GetRightEyeUV(), explicitRight));
+}
+
+TEST_CASE("Reload without CropRight* re-enables auto-mirror", "[subrect][stereo][regression]")
+{
+	// The rightUVLoadedFromJson flag must reset every LoadSettings — otherwise
+	// once a config with CropRight* was loaded, later loads without those
+	// keys would keep suppressing the mirror.
+	Controller c;
+	const UVRegion explicitRight{ 0.62f, 0.10f, 0.30f, 0.80f };
+	json withRight = {
+		{ "CropX", 0.10f }, { "CropY", 0.00f }, { "CropW", 0.40f }, { "CropH", 1.00f },
+		{ "CropRightX", explicitRight.x }, { "CropRightY", explicitRight.y },
+		{ "CropRightW", explicitRight.w }, { "CropRightH", explicitRight.h }
+	};
+	c.LoadSettings(withRight);
+
+	// Now load a fresh config WITHOUT CropRight*. The flag should reset to
+	// false so a subsequent SetStereoEnabled(true) auto-mirrors.
+	json withoutRight = {
+		{ "CropX", 0.20f }, { "CropY", 0.00f }, { "CropW", 0.60f }, { "CropH", 1.00f }
+	};
+	c.LoadSettings(withoutRight);
+	c.SetStereoEnabled(true);
+	// Mirror of {0.20, 0, 0.60, 1.0} is {1 - 0.20 - 0.60, *, 0.60, *} = {0.20, *, 0.60, *}.
+	REQUIRE(UVApprox(c.GetRightEyeUV(), { 0.20f, 0.0f, 0.60f, 1.0f }));
+}
+
+TEST_CASE("SaveSettings erases stale CropRight* in mono mode", "[subrect][stereo][regression]")
+{
+	// When a host re-uses an in-memory JSON object that previously held
+	// stereo keys, the mono save must clear them or the next load looks
+	// like it still had explicit stereo data.
+	json carry = {
+		{ "CropRightX", 0.5f }, { "CropRightY", 0.0f },
+		{ "CropRightW", 0.5f }, { "CropRightH", 1.0f }
+	};
+	Controller c;
+	REQUIRE_FALSE(c.IsStereoEnabled());
+	c.SaveSettings(carry);
+	REQUIRE_FALSE(carry.contains("CropRightX"));
+	REQUIRE_FALSE(carry.contains("CropRightY"));
+	REQUIRE_FALSE(carry.contains("CropRightW"));
+	REQUIRE_FALSE(carry.contains("CropRightH"));
+}
+
+TEST_CASE("GetStereoPixelRegions returns empty for degenerate dimensions", "[subrect][stereo][edge]")
+{
+	// fullWidth/2 == 0 for widths 0 or 1; UVToPixelRegion's `width - 1`
+	// would underflow into a huge coord without the guard.
+	Controller c;
+	c.SetStereoEnabled(true);
+	for (auto [w, h] : std::vector<std::pair<uint32_t, uint32_t>>{ { 0, 100 }, { 1, 100 }, { 100, 0 } }) {
+		const auto regions = c.GetStereoPixelRegions(w, h);
+		REQUIRE(regions.leftEye.w == 0);
+		REQUIRE(regions.rightEye.w == 0);
+	}
+}
+
+TEST_CASE("Seeded preset without explicit rightUV auto-mirrors in stereo", "[subrect][stereo][regression]")
+{
+	// Regression for the silent-full-frame bug: a Preset built with only
+	// .name + .uv (rightUV omitted, defaulting to std::nullopt) should
+	// auto-mirror the left eye when stereo is enabled, NOT show full frame
+	// for the right eye.
+	Controller c;
+	c.SetStereoEnabled(true);
+	c.SeedDefaultPresets({
+		Preset{ .name = "Left Half", .uv = { 0.0f, 0.0f, 0.5f, 1.0f } },
+	});
+	c.LoadSettings(json::object());
+
+	// Mirror of {0, 0, 0.5, 1.0} around x=0.5 is {0.5, 0, 0.5, 1.0}.
+	REQUIRE(UVApprox(c.GetRightEyeUV(), { 0.5f, 0.0f, 0.5f, 1.0f }));
 }


### PR DESCRIPTION
## Summary

Opt-in stereo extension to the screenshot subrect controller so future stereo-aware consumers (the DLSS Enhancer foveated subrect framework decomposed from #2096 upstream) can track a mirrored right-eye UV without forking the util that ScreenshotFeature already ships.

Mono callers (ScreenshotFeature) are unaffected: `SaveSettings` emits bit-identical JSON, `LoadSettings` round-trips the legacy schema, and the `DrawEditor` signature is unchanged.

## What changes

New API on `Util::Subrect::Controller`:
- `SetStereoEnabled(bool)` / `IsStereoEnabled()` — opt-in toggle (default off)
- `GetRightEyeUV()` — folds onto the primary UV in mono mode so callers can stay agnostic of stereo state
- `GetStereoPixelRegions(fullW, fullH)` — resolves both eyes against per-eye half-width for SBS textures
- `Preset` gains an optional `rightUV{}` field (default-init when designated initializers omit it)

Behavior:
- In stereo mode, drag/slider edits in `DrawEditor` auto-mirror the primary UV to the right eye around `x=0.5` (HMD nose-side overlap symmetry)
- `SaveSettings` only emits the new `CropRight*` and preset `right_uv` keys when stereo is enabled — preserves existing on-disk shape
- `LoadSettings` mirrors left → right only for the legacy upgrade case (`CropX/Y/W/H` present, no `CropRight*`), so a seeded preset's explicit right-eye UV survives a fresh load
- Save Preset captures `currentRightUV` (fixed during the upstream review cycle — CodeRabbit Major)

The header is now self-contained (forward-declares D3D11 types, includes `nlohmann/json` directly, declares its own `using json = nlohmann::json;`). This lets a unit-test target compile it without the plugin PCH.

## Tests

Adds a new `tests/cpp/` target with a Catch2 unit test executable (`cpp_tests`). Reuses Catch2 via `FetchContent` dedup with `tests/shaders`. New CMake target `run_cpp_tests`.

10 test cases, 35 assertions, covering:
- Mono back-compat: `LoadSettings` round-trips legacy JSON unchanged; `SaveSettings` emits no right-eye keys
- Stereo round-trip: explicit asymmetric right-eye preserved through save/load
- Stereo Save Preset captures `rightUV` (regression test for the upstream CodeRabbit Major)
- Legacy upgrade: stereo mode mirrors `CropX/Y/W/H` to right eye when no `CropRight*` keys present
- `GetStereoPixelRegions` SBS half-width split + mono-mode fallback (identical eyes)
- `MirrorUVHorizontal` math via `SetStereoEnabled`

Tests caught a real bug in my initial `LoadSettings` logic — an unconditional post-load `SyncRightUV` was stomping on a preset's explicit right-eye value when JSON had no top-level `Crop*` keys. Now correctly gated on `hasExplicitLeft && !hasExplicitRight`.

## Why this PR exists

Decomposed from @YtzyFvra's upstream #2096 — the original PR forked this util into its own `Subrect::` namespace, which conflicted with #2092's later landing of `Util::Subrect::Controller` for screenshot. This PR establishes the shared API so the DLSS Enhancer subrect work (PR-3 of the decomposition) can consume it cleanly without a second fork.

See [DLSS-PR-PLAN.md](https://github.com/alandtse/open-shaders/blob/pr1-stereo-subrect/DLSS-PR-PLAN.md) for the full decomposition strategy. PR-2 (DLSSperf) is also open on this repo; PR-3 + PR-3b (DlssEnhancer foveated subrect) are on the fork awaiting VR validation.

## Test plan
- [x] Unit tests pass (35 assertions / 10 cases, including Save Preset regression)
- [x] Mono-mode behavior verified by reading every ScreenshotFeature call site against the new code paths — identical observable behavior
- [ ] Manual smoke test: launch SkyrimVR, take a cropped screenshot via each preset (Left Eye / Right Eye / Full Frame), reload, verify crop persisted

## Credits
Decomposed from @YtzyFvra's #2096 (PR-1 of 4). Stereo API design is theirs; this PR adapts it to extend dev's existing `Util::Subrect` rather than fork it. Co-authored on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stereo-aware cropping: independent left/right-eye UVs, preset storage, UI sync, backward-compatible load/save, and per-eye pixel-region computation.

* **Tests**
  * Added comprehensive C++ unit tests validating mono/stereo behavior, migration/edge cases, pixel-region splitting, and regression scenarios; includes a custom test runner.

* **Chores**
  * Build updated to optionally integrate and run the C++ test suite with conditional test targets and a compact reporter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/open-shaders/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->