### PR TITLE
ci: debounce auto-rebase by 30 minutes

### DIFF
--- a/.github/workflows/auto-rebase-prs.yaml
+++ b/.github/workflows/auto-rebase-prs.yaml
@@ -25,32 +25,53 @@ permissions:
     contents: write
     pull-requests: write
 
-concurrency:
-    # Debounce window: pair with the `Debounce dev-push storms` sleep below.
-    # `cancel-in-progress: true` means a new push to dev kills the still-sleeping
-    # run and the fresh push starts its own 30-minute timer. End state: one
-    # rebase pass per quiet 30-minute window, regardless of how many merges
-    # land in that window. Manual `workflow_dispatch` runs share the same group
-    # but skip the sleep step, so a maintainer who needs an urgent rebase isn't
-    # blocked by the debounce.
-    group: auto-rebase-prs
-    cancel-in-progress: true
+# Two jobs by design:
+#
+# 1. `debounce` — sleeps for 30 minutes on push events. Has
+#    `cancel-in-progress: true` so a fresh push during the sleep
+#    kills the still-sleeping run and the new push starts its own
+#    timer. Workflow-dispatch runs skip the sleep entirely.
+# 2. `rebase` — depends on `debounce` and runs `peter-evans/rebase`.
+#    Has `cancel-in-progress: false` so once it starts force-pushing
+#    PR heads, it can't be interrupted mid-flight by a subsequent
+#    push. The downside is a small window (the rebase duration)
+#    where an additional push has to queue rather than supersede —
+#    but interrupting force-pushes mid-rebase leaves PRs in an
+#    inconsistent half-rebased state, which is worse.
+#
+# End state: one rebase pass per quiet 30-min window, no half-done
+# rebases.
 
 jobs:
-    rebase:
+    debounce:
         runs-on: ubuntu-latest
+        # The debounce job alone is cancellable — a new push restarts
+        # its 30-minute timer, dropping the prior queued run.
+        concurrency:
+            group: auto-rebase-prs-debounce
+            cancel-in-progress: true
         steps:
             - name: Debounce dev-push storms
-              # Only debounce when fired by a push to dev. Manual dispatches run
-              # immediately. If another push lands during this sleep, the
-              # concurrency policy above cancels this run before it does any
-              # work, and the new push gets its own debounce. Coalesces a
-              # burst of PR merges into a single rebase pass per PR, keeping
-              # the PR-build CI load proportional to landings/half-hour rather
-              # than landings × open-PR-count.
+              # Only debounce when fired by a push to dev. Manual dispatches
+              # run immediately (the next job has no dependency wait when
+              # this step is skipped). Coalesces a burst of PR merges into
+              # a single rebase pass, keeping PR-build CI load proportional
+              # to landings/half-hour rather than landings × open-PR-count.
               if: github.event_name == 'push'
               run: sleep 1800
 
+    rebase:
+        runs-on: ubuntu-latest
+        needs: debounce
+        # The rebase job is NOT cancellable — once peter-evans/rebase
+        # starts force-pushing PR heads, interrupting it mid-flight could
+        # leave some PRs rebased and others not, or interrupt a push
+        # mid-operation. A subsequent dev push queues behind this run
+        # instead.
+        concurrency:
+            group: auto-rebase-prs-rebase
+            cancel-in-progress: false
+        steps:
             - name: Checkout
               uses: actions/checkout@v6
               with:

--- a/.github/workflows/auto-rebase-prs.yaml
+++ b/.github/workflows/auto-rebase-prs.yaml
@@ -26,15 +26,31 @@ permissions:
     pull-requests: write
 
 concurrency:
-    # Serialize so two back-to-back pushes to dev don't race and produce
-    # interleaved force-pushes on the same PR.
+    # Debounce window: pair with the `Debounce dev-push storms` sleep below.
+    # `cancel-in-progress: true` means a new push to dev kills the still-sleeping
+    # run and the fresh push starts its own 30-minute timer. End state: one
+    # rebase pass per quiet 30-minute window, regardless of how many merges
+    # land in that window. Manual `workflow_dispatch` runs share the same group
+    # but skip the sleep step, so a maintainer who needs an urgent rebase isn't
+    # blocked by the debounce.
     group: auto-rebase-prs
-    cancel-in-progress: false
+    cancel-in-progress: true
 
 jobs:
     rebase:
         runs-on: ubuntu-latest
         steps:
+            - name: Debounce dev-push storms
+              # Only debounce when fired by a push to dev. Manual dispatches run
+              # immediately. If another push lands during this sleep, the
+              # concurrency policy above cancels this run before it does any
+              # work, and the new push gets its own debounce. Coalesces a
+              # burst of PR merges into a single rebase pass per PR, keeping
+              # the PR-build CI load proportional to landings/half-hour rather
+              # than landings × open-PR-count.
+              if: github.event_name == 'push'
+              run: sleep 1800
+
             - name: Checkout
               uses: actions/checkout@v6
               with:


### PR DESCRIPTION
## Summary

- Add a 30-minute debounce to `auto-rebase-prs.yaml` so a burst of PR merges into `dev` coalesces into a single rebase pass instead of firing one rebase per merge.
- Flip the concurrency policy from `cancel-in-progress: false` (queue) to `cancel-in-progress: true` (replace), so a new push during the sleep window kills the still-sleeping run and the fresh push gets its own timer.
- Gate the sleep on `github.event_name == 'push'` so `workflow_dispatch` runs (urgent manual rebase) skip the wait entirely.

## Why

Currently every push to `dev` triggers an immediate rebase across all open PRs. Each rebased head fires that PR's build pipeline. With 5 open PRs and 3 merges in a few minutes, that's 15 PR-build firings — the per-PR `cancel-in-progress` on `pr-checks.yaml` cancels back-to-back builds on the *same* PR head but can't help across PRs. CI ends up doing a lot of work that the next merge invalidates a minute later.

The 30-minute debounce makes CI load proportional to landings-per-half-hour rather than landings × open-PR-count.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Single merge, then quiet | rebase fires immediately | rebase fires after 30 min |
| 3 merges in 10 min | 3 rebase passes × N PRs each | 1 rebase pass × N PRs (after the last merge + 30 min) |
| `workflow_dispatch` (manual urgent) | immediate | immediate (sleep skipped) |
| Push lands during prior sleep | second run queued behind first | first run cancelled; second run starts its own 30-min timer |

## Test plan

- [ ] Merge a small PR into `dev`. Confirm the `Auto-rebase open PRs` workflow run enters the `Debounce dev-push storms` step and sits in `sleep 1800` for the configured 30 min before proceeding to checkout.
- [ ] During that sleep, push a noop commit to `dev`. Confirm the first run reports cancelled and a second run starts with a fresh debounce.
- [ ] Trigger the workflow via `gh workflow run "Auto-rebase open PRs" --ref dev` and confirm the debounce step is skipped (manual dispatch).
- [ ] After the debounce completes, confirm the rebase action still runs against all open non-draft PRs targeting `dev` (same coverage as today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)