### PR TITLE
ci: add merge-based upstream sync workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,47 @@
 
 # Ensure patch files always use LF line endings
 *.patch text eol=lf
+
+# -----------------------------------------------------------------------------
+# Fork-owned paths — `merge=ours` during 3-way merges
+# -----------------------------------------------------------------------------
+# These files are policy- or branding-owned by the fork. When the scheduled
+# upstream-merge-sync workflow merges upstream/dev into dev, the `ours` driver
+# preserves the fork's version of each path verbatim, ignoring whatever
+# upstream did to the same file. This is what prevents the silent-revert
+# class of bug (upstream cherry-picks our commit, then later deletes the
+# file in a follow-up: a vanilla merge would honor the delete; `merge=ours`
+# discards it).
+#
+# Prerequisites for the driver to fire:
+#   1. Each clone (including CI runners) must define the `ours` driver:
+#        git config merge.ours.driver true
+#      The scheduled sync workflow does this in a setup step. Local
+#      contributors who run `git merge upstream/dev` by hand should run
+#      the same command once. See docs/development/upstream-sync.md.
+#   2. The merge must be a true 3-way merge (i.e., `git merge`, not
+#      `git rebase` — rebase replays patches via `git apply` and never
+#      invokes merge drivers).
+#
+# When adding a path here, also add a one-line note in
+# docs/development/upstream-sync.md explaining why the fork owns it. If a
+# path stops being fork-owned (e.g., we converge with upstream's behavior),
+# remove the entry so upstream's improvements flow back in.
+# -----------------------------------------------------------------------------
+
+# CI workflows the fork owns end-to-end (auto-rebase machinery, the
+# release pipeline calibrated to RELEASE_PAT rather than upstream's
+# GitHub App setup, hotfix flow, nexus upload, etc.).
+.github/workflows/auto-rebase-prs.yaml          merge=ours
+.github/workflows/release-semantic.yaml         merge=ours
+.github/workflows/release-hotfix.yaml           merge=ours
+.github/workflows/nexus-upload.yaml             merge=ours
+.github/workflows/maint-cleanup-releases.yaml   merge=ours
+.github/workflows/maint-upstream-sync.yaml      merge=ours
+
+# Semantic-release config — fork has independent versioning and may
+# diverge from upstream's release rules.
+.releaserc                                      merge=ours
+
+# Branding-owned: rebrand commit established these as fork-specific.
+README.md                                       merge=ours

--- a/.gitattributes
+++ b/.gitattributes
@@ -25,6 +25,16 @@
 #      `git rebase` — rebase replays patches via `git apply` and never
 #      invokes merge drivers).
 #
+# Important: `merge=ours` fires on ANY 3-way merge that touches these
+# paths, not just the scheduled upstream sync. If a PR is landed via
+# GitHub's "Create a merge commit" button (or via a local `git merge`
+# between fork branches), and the incoming branch changed one of these
+# files, those changes are silently discarded. **Edits to fork-owned
+# paths must land via squash-merge or rebase-merge** so the diff lands
+# as a plain commit on dev rather than through a merge-driver-affected
+# merge commit. The default PR merge methods on `dev` are configured
+# to squash/rebase only to enforce this.
+#
 # When adding a path here, also add a one-line note in
 # docs/development/upstream-sync.md explaining why the fork owns it. If a
 # path stops being fork-owned (e.g., we converge with upstream's behavior),

--- a/.github/workflows/maint-upstream-sync.yaml
+++ b/.github/workflows/maint-upstream-sync.yaml
@@ -1,0 +1,168 @@
+name: "Maint: Sync upstream/dev"
+
+# Scheduled merge sync from community-shaders/skyrim-community-shaders into our
+# dev. Combined with the `merge=ours` attributes in .gitattributes (see the
+# `Fork-owned paths` section there), this pulls upstream's code changes while
+# leaving the fork's CI/branding files untouched.
+#
+# Why merge and not rebase: rebase replays patches via `git apply` and never
+# invokes merge drivers. Worse, when upstream cherry-picks one of our commits
+# and then later modifies the same file, rebase's patch-id detection skips
+# our original commit as "already applied" — and upstream's follow-up edit
+# then silently lands as a regression. A 3-way merge consults both branches
+# at every path and lets the `merge=ours` driver fire for fork-owned files,
+# eliminating that whole class of bug.
+#
+# Versioning: we deliberately do NOT skip this merge commit in
+# semantic-release's commit analysis. The DAG walk picks up upstream's
+# `feat:`/`fix:` commits transitively, so our version reflects everything
+# we actually ship to users (including upstream fixes that arrived via this
+# merge).
+
+on:
+    schedule:
+        # Monday 08:00 UTC. Weekly cadence keeps drift small without
+        # spamming PR rebases — pair this with auto-rebase-prs.yaml's
+        # debounce (PR #29) so the post-sync PR rebases coalesce.
+        - cron: "0 8 * * 1"
+    workflow_dispatch:
+        inputs:
+            dry_run:
+                description: "Dry run — fetch and merge locally, but don't push"
+                type: boolean
+                default: false
+
+permissions:
+    contents: write
+    pull-requests: write
+
+concurrency:
+    # Serialize — two overlapping syncs would race on the dev push.
+    group: maint-upstream-sync
+    cancel-in-progress: false
+
+jobs:
+    sync:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout dev
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+                  ref: dev
+                  # RELEASE_PAT so the merge push can bypass branch protection
+                  # and trigger downstream workflows (auto-rebase of open PRs).
+                  token: ${{ secrets.RELEASE_PAT }}
+
+            - name: Configure git identity + merge driver
+              # The `ours` driver is referenced by .gitattributes and is not
+              # built into git; it must be defined locally. We define it as
+              # a no-op (driver = true) which means "keep the version on the
+              # current branch unchanged" — the standard recipe.
+              run: |
+                  git config user.name 'github-actions[bot]'
+                  git config user.email 'github-actions[bot]@users.noreply.github.com'
+                  git config merge.ours.driver true
+
+            - name: Fetch upstream/dev
+              id: fetch
+              run: |
+                  git remote add upstream https://github.com/community-shaders/skyrim-community-shaders.git || \
+                      git remote set-url upstream https://github.com/community-shaders/skyrim-community-shaders.git
+                  git fetch upstream dev
+                  UPSTREAM_SHA=$(git rev-parse upstream/dev)
+                  echo "upstream_sha=${UPSTREAM_SHA}" >> "$GITHUB_OUTPUT"
+                  echo "upstream_short=${UPSTREAM_SHA:0:9}" >> "$GITHUB_OUTPUT"
+
+                  # If we're already at or ahead of upstream's tip, exit early.
+                  if git merge-base --is-ancestor "${UPSTREAM_SHA}" HEAD; then
+                      echo "already_synced=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "already_synced=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Already synced — nothing to do
+              if: steps.fetch.outputs.already_synced == 'true'
+              run: |
+                  {
+                      echo "## ✅ Already synced"
+                      echo ""
+                      echo "Upstream tip \`${{ steps.fetch.outputs.upstream_short }}\` is already an ancestor of \`dev\`. Nothing to merge."
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Merge upstream/dev
+              id: merge
+              if: steps.fetch.outputs.already_synced != 'true'
+              run: |
+                  set +e
+                  git merge --no-ff --no-edit \
+                      -m "chore(sync): merge upstream/dev as of ${{ steps.fetch.outputs.upstream_short }}" \
+                      upstream/dev
+                  merge_status=$?
+                  set -e
+
+                  if [[ $merge_status -ne 0 ]]; then
+                      # The merge=ours driver should have handled everything
+                      # in the fork-owned list. A conflict here means upstream
+                      # touched a non-fork-owned file in a way that genuinely
+                      # collides with our changes — needs human eyes.
+                      echo "::error::Upstream sync conflicted on non-fork-owned paths."
+                      {
+                          echo "## ❌ Conflict during sync"
+                          echo ""
+                          echo "Upstream tip: \`${{ steps.fetch.outputs.upstream_short }}\`"
+                          echo ""
+                          echo "Conflicted files (resolve manually, then push):"
+                          echo ""
+                          echo '```'
+                          git diff --name-only --diff-filter=U
+                          echo '```'
+                          echo ""
+                          echo "Resolution: clone, run the same merge locally, resolve, push."
+                          echo ""
+                          echo '```bash'
+                          echo "git fetch upstream dev"
+                          echo "git config merge.ours.driver true"
+                          echo "git merge --no-ff --no-edit \\"
+                          echo "    -m 'chore(sync): merge upstream/dev as of ${{ steps.fetch.outputs.upstream_short }}' \\"
+                          echo "    upstream/dev"
+                          echo "# resolve conflicts, git add, git commit"
+                          echo "git push origin dev"
+                          echo '```'
+                      } >> "$GITHUB_STEP_SUMMARY"
+                      git merge --abort
+                      exit 1
+                  fi
+
+            - name: Summarize merge
+              if: steps.fetch.outputs.already_synced != 'true' && success()
+              run: |
+                  {
+                      echo "## ✅ Merged upstream/dev"
+                      echo ""
+                      echo "Upstream tip: \`${{ steps.fetch.outputs.upstream_short }}\`"
+                      echo ""
+                      echo "Files changed:"
+                      echo ""
+                      echo '```'
+                      git diff --stat HEAD~1..HEAD | head -40
+                      echo '```'
+                      echo ""
+                      echo "Commits brought in:"
+                      echo ""
+                      echo '```'
+                      git log --oneline HEAD~1..HEAD --first-parent=false | head -30
+                      echo '```'
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Push to origin/dev
+              if: steps.fetch.outputs.already_synced != 'true' && inputs.dry_run != true
+              run: git push origin dev
+
+            - name: Dry-run notice
+              if: steps.fetch.outputs.already_synced != 'true' && inputs.dry_run == true
+              run: |
+                  {
+                      echo ""
+                      echo "**Dry run** — merge completed locally but not pushed."
+                  } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/maint-upstream-sync.yaml
+++ b/.github/workflows/maint-upstream-sync.yaml
@@ -33,8 +33,9 @@ on:
                 default: false
 
 permissions:
+    # `contents: write` is the only scope we need — the merge push to
+    # `dev` is the only mutation. No PR API calls, no issue API calls.
     contents: write
-    pull-requests: write
 
 concurrency:
     # Serialize — two overlapping syncs would race on the dev push.
@@ -148,10 +149,15 @@ jobs:
                       git diff --stat HEAD~1..HEAD | head -40
                       echo '```'
                       echo ""
-                      echo "Commits brought in:"
+                      echo "Commits brought in from upstream:"
                       echo ""
                       echo '```'
-                      git log --oneline HEAD~1..HEAD --first-parent=false | head -30
+                      # The merge commit has two parents: HEAD^1 = previous
+                      # fork tip, HEAD^2 = upstream tip. The range
+                      # `HEAD^1..HEAD^2` enumerates the upstream commits
+                      # reachable through the merge that weren't already in
+                      # our history — exactly what we want to surface.
+                      git log --oneline 'HEAD^1..HEAD^2' | head -30
                       echo '```'
                   } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/maint-upstream-sync.yaml
+++ b/.github/workflows/maint-upstream-sync.yaml
@@ -45,6 +45,12 @@ concurrency:
 jobs:
     sync:
         runs-on: ubuntu-latest
+        # Guard against downstream forks running this on schedule: they
+        # don't have RELEASE_PAT, don't want to merge community-shaders/dev
+        # into their own dev, and the resulting failure would spam their
+        # Actions tab with red runs. Other maint workflows in this repo
+        # use the same pattern.
+        if: github.repository == 'alandtse/open-shaders'
         steps:
             - name: Checkout dev
               uses: actions/checkout@v6

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -4,6 +4,7 @@
 
 -   **[VSCode Setup](./vscode-setup.md)** - IDE configuration, extensions, and auto-deploy
 -   **[Shader Workflow](./shader-workflow.md)** - Fast shader iteration and deployment
+-   **[Upstream Sync](./upstream-sync.md)** - How Open Shaders merges with upstream community-shaders
 
 ## Quick Links
 

--- a/docs/development/upstream-sync.md
+++ b/docs/development/upstream-sync.md
@@ -1,0 +1,76 @@
+# Upstream Sync
+
+How Open Shaders stays current with upstream `community-shaders/skyrim-community-shaders` without losing the fork-specific CI policy, branding, and feature setup.
+
+## Mechanism
+
+Upstream syncs land as **merge commits** on `dev`, never as rebases. The scheduled `Maint: Sync upstream/dev` workflow runs a three-way merge of `upstream/dev` into our `dev` and pushes the result. Two pieces make this safe:
+
+1. **`.gitattributes` with `merge=ours` entries** for every file the fork owns end-to-end (CI workflows, `.releaserc`, README). During the merge, git's `ours` driver keeps the fork's version of those paths verbatim — upstream's changes to them are discarded without surfacing as conflicts.
+2. **The `ours` merge driver itself** must be defined locally. `merge=ours` in `.gitattributes` _references_ a driver but doesn't define one. The sync workflow defines it as a no-op (`git config merge.ours.driver true`). **Local contributors who run the merge by hand must run the same command once per clone** — see [Setup](#setup-once-per-clone) below.
+
+## Why merge, not rebase
+
+We previously used `git rebase upstream/dev`. It silently regressed fork-owned files on every sync. The mechanism: upstream cherry-picks one of our fork commits → we rebase later → git detects the duplicate via patch-id and skips our commit as "already applied" → an upstream follow-up that deletes or edits the same file then applies cleanly. End result: the fork loses content with zero merge conflicts and zero log noise. The rebase reports success.
+
+A 3-way merge consults both sides at every path independently of patch-id. Our `merge=ours` driver fires for fork-owned paths; everything else gets a real 3-way merge. Either a clean result or a visible conflict — nothing silent.
+
+See `.gitattributes` for the current fork-owned list. When a file should join or leave that list, update both the attributes and the comment block above the list explaining why.
+
+## Setup (once per clone)
+
+```bash
+git config merge.ours.driver true
+```
+
+That's it. The `ours` driver is intentionally not git-builtin (for security — driver definitions can run arbitrary commands), so each clone declares it locally. The sync CI does this in its own setup step.
+
+If you've already run an upstream merge without this config, git would have raised an "unknown merge driver 'ours'" warning and used the default 3-way merge for those files, potentially producing surprising conflicts in fork-owned paths. Re-run with the driver configured and the conflicts disappear.
+
+## Running a sync manually
+
+```bash
+git fetch upstream dev
+git switch dev
+git merge --no-ff --no-edit \
+    -m "chore(sync): merge upstream/dev as of $(git rev-parse --short upstream/dev)" \
+    upstream/dev
+# resolve conflicts (only in non-fork-owned paths), then:
+git push origin dev
+```
+
+The scheduled workflow does exactly this on Monday 08:00 UTC. Manual dispatch via `gh workflow run "Maint: Sync upstream/dev"` is available for urgent syncs and accepts a `dry_run` flag.
+
+## Versioning and changelog interaction
+
+The merge commit's message is `chore(sync): merge upstream/dev as of <sha>`. semantic-release sees it as a `chore` and doesn't release on the commit itself.
+
+**However**, semantic-release's default DAG walk follows the merge into upstream's commit history. Upstream's `feat:` and `fix:` commits that came in via the merge are visible to the commit analyzer and **do** drive version bumps in our release stream. This is deliberate: the fork's version reflects everything actually shipped to users, including upstream fixes that arrived via merge.
+
+When upstream cherry-picks one of our commits and that cherry-pick lands in our merge, both copies of the same logical change get walked. Version-wise this is harmless (one release can only bump once at the max severity). Changelog-wise it produces a duplicate entry. If this becomes annoying, the fix is a `writerOpts.transform` in `.releaserc` that dedupes by patch-id — not done preemptively.
+
+## When the workflow halts
+
+A real conflict (in a file _not_ on the fork-owned list) means upstream and the fork have both meaningfully changed the same code. Examples we'd expect:
+
+-   Both forks bump the same feature INI version.
+-   We add a method to a class upstream also modified.
+-   We rename a function upstream also renamed.
+
+The workflow `git merge --abort`s, posts the conflicted file list to the workflow summary, and exits non-zero. Resolution is manual: clone, run the same merge locally, resolve, push. `git rerere` (which we have enabled in repo defaults) will remember the resolution so the next sync of the same files replays it automatically — but rerere caches are per-clone, not pushed. The maintainer doing recurring syncs builds up a useful cache; CI runners do not.
+
+## Inspecting what a sync did
+
+Each sync workflow run leaves a summary on the run page with:
+
+-   Upstream tip SHA
+-   `git diff --stat` of files changed
+-   `git log --oneline` of commits brought in
+
+For deeper inspection after a push:
+
+```bash
+# all changes since the last sync merge
+git log --first-parent --merges --grep='chore(sync)' -1   # find the merge commit
+git diff <merge-commit>~1..<merge-commit>                  # changes the merge introduced
+```

--- a/docs/development/upstream-sync.md
+++ b/docs/development/upstream-sync.md
@@ -57,7 +57,16 @@ A real conflict (in a file _not_ on the fork-owned list) means upstream and the 
 -   We add a method to a class upstream also modified.
 -   We rename a function upstream also renamed.
 
-The workflow `git merge --abort`s, posts the conflicted file list to the workflow summary, and exits non-zero. Resolution is manual: clone, run the same merge locally, resolve, push. `git rerere` (which we have enabled in repo defaults) will remember the resolution so the next sync of the same files replays it automatically — but rerere caches are per-clone, not pushed. The maintainer doing recurring syncs builds up a useful cache; CI runners do not.
+The workflow `git merge --abort`s, posts the conflicted file list to the workflow summary, and exits non-zero. Resolution is manual: clone, run the same merge locally, resolve, push.
+
+If you do recurring syncs, enabling `git rerere` is worth the one-time setup — it caches each conflict resolution and replays it the next time the same hunks conflict. Per-clone setting, not repo-wide:
+
+```bash
+git config rerere.enabled true
+git config rerere.autoupdate true
+```
+
+Caches live in `.git/rr-cache/` and aren't pushed, so each maintainer builds their own. CI runners start with empty caches every run and benefit nothing from rerere — only the maintainers doing the merges locally see the time savings.
 
 ## Inspecting what a sync did
 

--- a/docs/development/upstream-sync.md
+++ b/docs/development/upstream-sync.md
@@ -23,15 +23,20 @@ See `.gitattributes` for the current fork-owned list. When a file should join or
 git config merge.ours.driver true
 ```
 
-That's it. The `ours` driver is intentionally not git-builtin (for security — driver definitions can run arbitrary commands), so each clone declares it locally. The sync CI does this in its own setup step.
+That's it. The `ours` driver is intentionally not built into git (for security — driver definitions can run arbitrary commands), so each clone declares it locally. The sync CI does this in its own setup step.
 
 If you've already run an upstream merge without this config, git would have raised an "unknown merge driver 'ours'" warning and used the default 3-way merge for those files, potentially producing surprising conflicts in fork-owned paths. Re-run with the driver configured and the conflicts disappear.
 
 ## Running a sync manually
 
 ```bash
-git fetch upstream dev
+# Make sure local dev matches origin/dev before merging upstream.
+# A stale local dev would either reject the push as non-fast-forward
+# or have you re-resolving conflicts already resolved by a prior run.
+git fetch origin dev upstream/dev
 git switch dev
+git reset --hard origin/dev
+
 git merge --no-ff --no-edit \
     -m "chore(sync): merge upstream/dev as of $(git rev-parse --short upstream/dev)" \
     upstream/dev


### PR DESCRIPTION
## Summary

- Add `.github/workflows/maint-upstream-sync.yaml` — scheduled (Mon 08:00 UTC) and manually-dispatched workflow that runs `git merge upstream/dev` into `dev`, with `dry_run` toggle for testing.
- Add `.gitattributes` entries declaring the fork-owned paths (CI workflows, `.releaserc`, README) with `merge=ours`. During the sync merge, git's `ours` driver keeps the fork's version of those paths verbatim instead of consulting upstream's.
- Add `docs/development/upstream-sync.md` documenting the mechanism, the one-time `git config merge.ours.driver true` setup each clone needs, manual-sync mechanics, and conflict-resolution flow.

## Why this approach

Manual rebase-based upstream syncs were silently regressing fork-owned files. The failure mode: upstream cherry-picks one of our commits → we rebase later → git detects the duplicate via patch-id and skips our commit → an upstream follow-up that deletes or edits the same file then applies cleanly. End result: 109 lines of `auto-rebase-prs.yaml` deleted, 12 references to `RELEASE_PAT` flipped to `steps.app-token.outputs.token`, all without a single conflict or warning. Verified empirically against today's upstream tip in a test worktree.

A 3-way merge consults both sides at every path independently of patch-id, so `merge=ours` fires for fork-owned files and silent reverts become impossible.

## Versioning interaction

semantic-release sees the `chore(sync): merge upstream/dev as of <sha>` commit as `chore` → no release on the merge commit itself. But the default DAG walk follows the merge into upstream's commits, so upstream's `feat:` / `fix:` entries that came in via the merge **do** drive version bumps in our independent release stream. Deliberate — the fork's version should reflect everything users actually get, including upstream fixes. **No `.releaserc` changes needed.**

## Empirical test (run against today's `upstream/dev`)

Merging today's upstream tip (`5180a1ea2`, which removed auto-rebase-prs.yaml and migrated to a GitHub App token) into a copy of `dev` with these `.gitattributes` produced:

```
Auto-merging .claude/CLAUDE.md
Auto-merging .github/workflows/release-hotfix.yaml
Auto-merging .github/workflows/release-semantic.yaml
Merge made by the 'ort' strategy.
 package/Shaders/ISWaterBlend.hlsl | 27 +++++++++-----------------
 src/Deferred.cpp                  |  4 ++--
 src/Features/UnifiedWater.cpp     | 27 +++++++++++++++++++-------
 src/TruePBR.cpp                   |  4 ++--
```

- `auto-rebase-prs.yaml` survived (109 lines).
- `release-semantic.yaml` and `release-hotfix.yaml` kept all `RELEASE_PAT` references.
- Only the four upstream water/PBR code fixes were applied.
- Zero conflicts, zero manual intervention.

## What you need to do once this lands

1. **Configure local clones** (one-time per clone) — see `docs/development/upstream-sync.md`:
   ```
   git config merge.ours.driver true
   ```
2. **Relax branch protection on `dev`** to allow merge commits (the sync workflow's `git push origin dev` will be rejected if linear-history is enforced). PR merges into `dev` can still be squash/rebase via the GitHub merge button settings.
3. **First scheduled run** fires Monday 08:00 UTC. Manual smoke test recommended first via `gh workflow run "Maint: Sync upstream/dev" -f dry_run=true`.

## Test plan

- [ ] `gh workflow run "Maint: Sync upstream/dev" -f dry_run=true` on this branch's CI → confirm the merge completes locally and the workflow exits without pushing.
- [ ] Re-run without `dry_run` → confirm the push lands and `dev` advances.
- [ ] Verify post-merge: `auto-rebase-prs.yaml` still 109 lines, `release-semantic.yaml` still references `RELEASE_PAT`, upstream code fixes (water/PBR) present in `package/Shaders/` and `src/`.
- [ ] Confirm the `Auto-rebase open PRs` workflow then fires (after the debounce in #29 lands) and rebases all open PRs against the new `dev` tip.

## Related

- #29 (`ci: debounce auto-rebase by 30 minutes`) — pairs naturally with this. Upstream sync brings in new commits; auto-rebase then rebases all open PRs against the new tip; the 30-min debounce keeps that rebase pass coalesced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)