### PR TITLE
ci: address CodeQL security findings (cache poisoning + permissions)

### DIFF
--- a/.github/actions/setup-build-environment/action.yaml
+++ b/.github/actions/setup-build-environment/action.yaml
@@ -96,8 +96,36 @@ runs:
           with:
               vcpkgJsonGlob: vcpkg.json
 
-        - name: Cache CMake build output
+        # Cache strategy is split by event trust level to avoid the
+        # pull_request_target cache-poisoning class of bug (CodeQL rule
+        # `actions/cache-poisoning/poisonable-step`):
+        #
+        # - Trusted events (push to dev/main, workflow_dispatch, workflow_call
+        #   from a release pipeline): use the combined `actions/cache` which
+        #   restores at this step and auto-saves at job-end. Cache writes only
+        #   happen from these trusted contexts.
+        # - Untrusted events (pull_request_target, pull_request): use the
+        #   restore-only sub-action. PR builds still benefit from caches
+        #   warmed by trusted runs but cannot themselves write back, so a
+        #   malicious PR cannot poison a cache that a later default-branch
+        #   run would consume.
+        #
+        # Both steps use the same key / restore-keys so cache hits cross the
+        # trust boundary in the allowed direction (trusted-saved → untrusted-restore).
+
+        - name: Cache CMake build output (trusted, restore + save)
+          if: github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
           uses: actions/cache@v5
+          with:
+              path: ${{ inputs.build-dir }}
+              key: ${{ runner.os }}-cmake-msvc-${{ steps.msvc_version.outputs.version }}-${{ inputs.cache-key-suffix }}-${{ github.event.inputs.cache-key-suffix || 'default' }}-${{ hashFiles('.gitmodules', 'extern/**', 'CMakePresets.json', 'vcpkg.json', 'vcpkg-configuration.json') }}
+              restore-keys: |
+                  ${{ runner.os }}-cmake-msvc-${{ steps.msvc_version.outputs.version }}-${{ inputs.cache-key-suffix }}-${{ github.event.inputs.cache-key-suffix || 'default' }}-
+                  ${{ runner.os }}-cmake-msvc-${{ steps.msvc_version.outputs.version }}-${{ inputs.cache-key-suffix }}-
+
+        - name: Restore CMake build cache (untrusted PR, restore-only)
+          if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+          uses: actions/cache/restore@v5
           with:
               path: ${{ inputs.build-dir }}
               key: ${{ runner.os }}-cmake-msvc-${{ steps.msvc_version.outputs.version }}-${{ inputs.cache-key-suffix }}-${{ github.event.inputs.cache-key-suffix || 'default' }}-${{ hashFiles('.gitmodules', 'extern/**', 'CMakePresets.json', 'vcpkg.json', 'vcpkg-configuration.json') }}

--- a/.github/workflows/maint-todo-issues.yaml
+++ b/.github/workflows/maint-todo-issues.yaml
@@ -10,6 +10,14 @@ on:
             MANUAL_BASE_REF:
                 description: "By default, the commit entered above is compared to the one directly before it; to go back further, enter an earlier SHA here"
                 required: false
+
+# Least-privilege scope: alstr/todo-to-issue-action creates issues from TODO/
+# FIXME comments it finds in the diff. `issues: write` for the create call,
+# `contents: read` for the checkout step.
+permissions:
+    contents: read
+    issues: write
+
 jobs:
     build:
         runs-on: "ubuntu-latest"

--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -86,6 +86,13 @@ on:
             UNEX_APIKEY:
                 required: false
 
+# Least-privilege for the whole workflow: every job here only reads from
+# GitHub (release listing via `gh api`, asset download via `gh release
+# download`) and writes only to Nexus via the UNEX_* secrets. No mutation
+# of repo state.
+permissions:
+    contents: read
+
 jobs:
     prepare-nexus-matrix:
         runs-on: ubuntu-latest

--- a/.github/workflows/pr-wip.yaml
+++ b/.github/workflows/pr-wip.yaml
@@ -3,6 +3,13 @@ on:
     pull_request:
         types: [opened, synchronize, reopened, edited]
 
+# Least-privilege scope for the wip/action: it sets a commit status on the PR
+# head (statuses: write) and reads PR metadata (pull-requests: read). No other
+# repo writes happen here.
+permissions:
+    statuses: write
+    pull-requests: read
+
 jobs:
     wip:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Addresses all 14 open code-scanning alerts surfaced after CodeQL was enabled.

- **7 High** — `actions/cache-poisoning/poisonable-step` in `pr-checks.yaml` and `_shared-build.yaml`. PR builds running under `pull_request_target` had write access to a cache later restored by trusted default-branch runs.
- **7 Medium** — `actions/missing-workflow-permissions` in `nexus-upload.yaml`, `pr-wip.yaml`, `maint-todo-issues.yaml`. Workflows ran with implicit full-scope `GITHUB_TOKEN`.

## Cache poisoning fix

`setup-build-environment/action.yaml`: split the single combined cache step into two conditionally-invoked steps that share the same key:

| Event class | Step | Behavior |
|---|---|---|
| Trusted (`push`, `workflow_dispatch`, `workflow_call`) | `actions/cache@v5` | restore + auto-save at job-end |
| Untrusted (`pull_request`, `pull_request_target`) | `actions/cache/restore@v5` | restore-only |

PR builds still get the cache speedup (restoring caches warmed by trusted runs) but can't write back to them. Trust crosses the boundary in only the safe direction.

## Permissions fix

Per-workflow least-privilege blocks:

| Workflow | Permissions added | Why |
|---|---|---|
| `nexus-upload.yaml` | `contents: read` (workflow-level) | Reads releases via `gh api` / `gh release download`. Writes go to Nexus via UNEX_* secrets, not GitHub. |
| `pr-wip.yaml` | `statuses: write`, `pull-requests: read` | wip/action sets a commit status on the PR head and reads PR metadata. |
| `maint-todo-issues.yaml` | `contents: read`, `issues: write` | alstr/todo-to-issue-action creates GitHub issues from TODO comments in the diff. |

## Verification

Once merged, the 14 alerts should auto-close on the next CodeQL run against `dev`. No other alerts expected from this change.

## Test plan

- [ ] Open this PR → confirm `pr-checks.yaml` runs and the PR build still gets a cache restore (look for `Cache restored from key:` in the `Restore CMake build cache (untrusted PR, restore-only)` step).
- [ ] Verify the PR build does NOT save back: should see `Cache CMake build output (trusted, restore + save)` skipped in the step list.
- [ ] After merge to `dev`, the next push-triggered build should populate/save the cache normally.
- [ ] Subsequent CodeQL run on `dev` shows 0 open alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)