### PR TITLE
test: fix cpp_tests build and add CI gate

### DIFF
--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -23,12 +23,20 @@ on:
                 description: "Run shader unit tests"
                 type: boolean
                 default: true
+            run-cpp-tests:
+                description: "Run C++ unit tests (tests/cpp)"
+                type: boolean
+                default: true
             hlsl-should-build:
                 description: "Passed to check-hlsl-changes; 'true' forces shader steps to run"
                 type: string
                 default: "true"
             shader-tests-should-build:
                 description: "Passed to check-hlsl-changes for unit tests"
+                type: string
+                default: "true"
+            cpp-tests-should-build:
+                description: "Forces cpp_tests build+run when 'true'; lets PR-checks skip it otherwise"
                 type: string
                 default: "true"
             cache-key-suffix:
@@ -255,6 +263,70 @@ jobs:
               uses: actions/upload-artifact@v7
               with:
                   name: shader-test-results
+                  path: |
+                      build/ALL/Testing/**
+                  retention-days: 7
+                  if-no-files-found: ignore
+
+    cpp-unit-tests:
+        name: Run C++ Unit Tests
+        if: inputs.run-cpp-tests
+        runs-on: windows-2025
+        permissions:
+            contents: read
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v6
+              with:
+                  ref: ${{ inputs.ref }}
+                  repository: ${{ inputs.repository }}
+                  submodules: recursive
+
+            # Inline gate (no composite action — the logic is one branch).
+            # PR events skip when no relevant files changed; push / dispatch /
+            # release always run.
+            - name: Check if cpp_tests should run
+              id: check-cpp
+              shell: bash
+              run: |
+                  if [ "${{ github.event_name }}" != "pull_request_target" ]; then
+                    echo "Non-PR event, proceeding."
+                    echo "skip=false" >> $GITHUB_OUTPUT
+                  elif [ "${{ inputs.cpp-tests-should-build }}" != "true" ]; then
+                    echo "No cpp_tests-related changes detected, skipping."
+                    echo "skip=true" >> $GITHUB_OUTPUT
+                  else
+                    echo "cpp_tests-related changes detected, proceeding."
+                    echo "skip=false" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Setup Build Environment
+              id: setup
+              if: steps.check-cpp.outputs.skip != 'true'
+              uses: ./.github/actions/setup-build-environment
+              with:
+                  cache-key-suffix: "cpp-tests${{ inputs.cache-key-suffix }}"
+                  cmake-preset: "ALL"
+                  build-dir: "build/ALL"
+
+            - name: Build cpp_tests
+              if: steps.check-cpp.outputs.skip != 'true'
+              uses: lukka/run-cmake@v10
+              with:
+                  configurePreset: ALL
+                  buildPreset: ALL
+                  buildPresetAdditionalArgs: "['--target cpp_tests']"
+
+            - name: Run C++ unit tests
+              if: steps.check-cpp.outputs.skip != 'true'
+              run: |
+                  ctest --test-dir build/ALL -C Release --output-on-failure -R CppUtilTests --timeout 60
+
+            - name: Upload test results on failure
+              if: failure() && steps.check-cpp.outputs.skip != 'true'
+              uses: actions/upload-artifact@v7
+              with:
+                  name: cpp-test-results
                   path: |
                       build/ALL/Testing/**
                   retention-days: 7

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -54,6 +54,10 @@ jobs:
             should-build: ${{ steps.changed-files.outputs.build_any_changed == 'true' || steps.changed-files.outputs.cpp_any_changed == 'true' || steps.changed-files.outputs.build_ci_any_changed == 'true' || steps.changed-files.outcome == 'failure' }}
             hlsl-should-build: ${{ steps.changed-files.outputs.hlsl_any_changed == 'true' || steps.changed-files.outputs.cmake_any_changed == 'true' || steps.changed-files.outputs.build_ci_any_changed == 'true' || steps.changed-files.outcome == 'failure' }}
             shader-tests-should-build: ${{ steps.changed-files.outputs.shader_tests_any_changed == 'true' || steps.changed-files.outputs.hlsl_any_changed == 'true' || steps.changed-files.outputs.cmake_any_changed == 'true' || steps.changed-files.outputs.build_ci_any_changed == 'true' || steps.changed-files.outcome == 'failure' }}
+            # cpp_tests target compiles src/Utils/Subrect.cpp directly (see tests/cpp/CMakeLists.txt),
+            # so any cpp_any change is conservative-but-correct. cpp_tests_any catches changes to
+            # the test sources themselves. cmake/build_ci cover CMake + CI plumbing.
+            cpp-tests-should-build: ${{ steps.changed-files.outputs.cpp_tests_any_changed == 'true' || steps.changed-files.outputs.cpp_any_changed == 'true' || steps.changed-files.outputs.cmake_any_changed == 'true' || steps.changed-files.outputs.build_ci_any_changed == 'true' || steps.changed-files.outcome == 'failure' }}
         steps:
             - uses: actions/checkout@v6
               with:
@@ -104,6 +108,8 @@ jobs:
                         - 'features/**/Shaders/**'
                       shader_tests:
                         - 'tests/shaders/**'
+                      cpp_tests:
+                        - 'tests/cpp/**'
                   base_sha: ${{ github.event.pull_request.base.sha }}
                   sha: ${{ github.event.pull_request.head.sha }}
 
@@ -125,8 +131,10 @@ jobs:
             run-cpp: ${{ needs.check-changes.outputs.should-build != 'false' }}
             run-shader-validation: ${{ needs.check-changes.outputs.hlsl-should-build != 'false' }}
             run-shader-tests: ${{ needs.check-changes.outputs.shader-tests-should-build != 'false' }}
+            run-cpp-tests: ${{ needs.check-changes.outputs.cpp-tests-should-build != 'false' }}
             hlsl-should-build: ${{ needs.check-changes.outputs.hlsl-should-build || 'true' }}
             shader-tests-should-build: ${{ needs.check-changes.outputs.shader-tests-should-build || 'true' }}
+            cpp-tests-should-build: ${{ needs.check-changes.outputs.cpp-tests-should-build || 'true' }}
 
     # Security: this job uses GITHUB_TOKEN with write permissions but does NOT execute
     # fork code — it only downloads pre-built artifacts from the build job above.

--- a/tests/cpp/test_subrect.cpp
+++ b/tests/cpp/test_subrect.cpp
@@ -215,6 +215,18 @@ TEST_CASE("Stereo SaveSettings emits right_uv for every preset", "[subrect][ster
 	// preserved" from "default fallback mirrored it back".
 	const UVRegion leftUV{ 0.10f, 0.0f, 0.40f, 1.0f };
 	const UVRegion rightUV{ 0.55f, 0.0f, 0.35f, 1.0f };
+
+	// Build the preset object via direct mutation rather than a single nested
+	// initializer list. MSVC's C++23 module-aware parse cannot disambiguate
+	// `json::array({ json{ {k,v}, {k,v} } })` from the
+	// `initializer_list<initializer_list<json>>` overload of `json`'s
+	// constructor, producing a misleading C3329 at the inner closing `)`.
+	// Building element-by-element sidesteps the ambiguity entirely.
+	json preset = json::object();
+	preset["name"] = "Asymmetric";
+	preset["uv"] = json::array({ leftUV.x, leftUV.y, leftUV.w, leftUV.h });
+	preset["right_uv"] = json::array({ rightUV.x, rightUV.y, rightUV.w, rightUV.h });
+
 	json staged = {
 		{ "CropX", leftUV.x },
 		{ "CropY", leftUV.y },
@@ -224,11 +236,7 @@ TEST_CASE("Stereo SaveSettings emits right_uv for every preset", "[subrect][ster
 		{ "CropRightY", rightUV.y },
 		{ "CropRightW", rightUV.w },
 		{ "CropRightH", rightUV.h },
-		{ "CropPresets", json::array({ json{
-			{ "name", "Asymmetric" },
-			{ "uv", json::array({ leftUV.x, leftUV.y, leftUV.w, leftUV.h }) },
-			{ "right_uv", json::array({ rightUV.x, rightUV.y, rightUV.w, rightUV.h }) } }) }
-		},
+		{ "CropPresets", json::array({ preset }) },
 		{ "SelectedPresetIndex", 0 }
 	};
 	src.LoadSettings(staged);
@@ -392,12 +400,16 @@ TEST_CASE("Malformed preset right_uv falls back to auto-mirror", "[subrect][ster
 	// With validation, malformed input is ignored and the mirror takes over.
 	Controller c;
 	c.SetStereoEnabled(true);
+
+	// Same C++23-modules-friendly construction as above (see the regression
+	// test for the rationale).
+	json badPreset = json::object();
+	badPreset["name"] = "Bad";
+	badPreset["uv"] = json::array({ 0.10f, 0.0f, 0.40f, 1.0f });
+	badPreset["right_uv"] = "not an array";  // malformed
+
 	json bad = {
-		{ "CropPresets", json::array({ json{
-							 { "name", "Bad" },
-							 { "uv", { 0.10f, 0.0f, 0.40f, 1.0f } },
-							 { "right_uv", "not an array" }  // malformed
-						 } }) },
+		{ "CropPresets", json::array({ badPreset }) },
 		{ "SelectedPresetIndex", 0 }
 	};
 	c.LoadSettings(bad);


### PR DESCRIPTION
## Summary

Two related changes — fix the broken cpp_tests build, then wire CI to catch the next regression of the same shape.

## Part 1: Make cpp_tests compile under MSVC C++23 modules

The two regression tests added in #23 (stereo `SaveSettings` preset round-trip + malformed `right_uv` fallback) don't compile under MSVC's C++23 module-aware parse. The build fails with a misleading cascade of errors starting with C3329 (`expected '}' not ')'`) at what appears to be a correctly-balanced closing paren.

**Root cause**: `json::array({ json{ {k,v}, {k,v} } })` is ambiguous between two `nlohmann::json` constructor overloads. MSVC's parser falls into the wrong overload, fails inside it, and the displayed error column points at the inner closing `)` rather than the actual ambiguity site.

**Fix**: build the preset object via direct mutation (`preset["name"] = ...`) before placing it into the outer `json::array(...)`. Identical semantics, no parse-time ambiguity.

## Part 2: Gate cpp_tests on changed files in CI

CI was green at #23's merge because the `cpp_tests` target isn't built or run by any workflow:

- [`_shared-build.yaml:246`](https://github.com/alandtse/open-shaders/blob/dev/.github/workflows/_shared-build.yaml#L246) explicitly targets `--target shader_tests` only
- The ctest filter `-R ShaderTests` would skip `CppUtilTests` even if the binary existed

Mirrored the shader_tests pattern:

**`pr-checks.yaml`**: new `cpp_tests` files_yaml category (`tests/cpp/**`) and `cpp-tests-should-build` output combining cpp_tests / cpp / cmake / build_ci changes. The `cpp` category is conservative-but-correct since `cpp_tests` compiles `src/Utils/Subrect.cpp` directly (per `tests/cpp/CMakeLists.txt`), so any cpp change could affect it.

**`_shared-build.yaml`**: new `run-cpp-tests` (boolean) and `cpp-tests-should-build` (string) inputs; new `cpp-unit-tests` job parallel to `shader-unit-tests` that builds `--target cpp_tests` and runs `ctest -R CppUtilTests`. Gated inline (no composite action — single branch isn't worth the indirection).

## Verification

- `cpp_tests.exe` builds and 54 assertions / 17 cases pass on a clean build off `origin/dev` (Part 1 fix)
- New CI job will fire on this PR since it touches `.github/workflows/**` (build_ci) and `tests/cpp/**` (cpp_tests) — self-validates the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)