### PR TITLE
build: drop CORE marker from per-feature AIO copy to avoid race

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -460,13 +460,40 @@ Follow conventional commit format for consistency:
 -   **Format**: `type(scope): description`
 -   **Title Limit**: 50 characters maximum
 -   **Body Wrap**: 72 characters per line
--   **Types**: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`
 -   **Examples**:
     -   `feat(menu): extract DrawMenuVisitor helper methods`
     -   `fix(imgui): resolve orphaned TableNextColumn calls`
     -   `refactor(constants): centralize UI constants in ThemeManager`
+    -   `ci: gate cpp_tests build on changed files`
+    -   `build: drop CORE marker from per-feature AIO copy`
+    -   `test: fix cpp_tests build under MSVC C++23 modules`
 
-Conventional commits drive semantic-release. `feat:` triggers a minor bump, `fix:` triggers a patch bump, `feat!:` or `BREAKING CHANGE:` triggers a major bump. `chore:`, `docs:`, `style:`, `test:`, `refactor:` produce no release on their own. Pick the type with the version impact in mind — a refactor mislabeled `feat:` will force a minor bump on the next release.
+**Squash-merge note.** PRs are squash-merged, so the **PR title** becomes the commit message that semantic-release reads. Getting the title's type right matters more than per-commit messages on the PR branch — those get discarded. Use `gh pr edit <num> --title "..."` to fix a stale title before merge.
+
+**Type → release impact** (the full set accepted by `amannn/action-semantic-pull-request@v5` + `@semantic-release/commit-analyzer` defaults):
+
+| Type       | Use for                                                   | Release impact          |
+| ---------- | --------------------------------------------------------- | ----------------------- |
+| `feat`     | New user-facing feature or capability                     | **minor** (1.X.0)       |
+| `fix`      | Bug fix to user-facing behavior                           | **patch** (1.5.X)       |
+| `perf`     | Performance improvement to user-facing behavior           | **patch** (1.5.X)       |
+| `revert`   | Revert of a prior commit                                  | follows reverted commit |
+| `build`    | Build system, packaging, dependencies (CMake, vcpkg, AIO) | none                    |
+| `chore`    | Maintenance, misc tooling, repo hygiene                   | none                    |
+| `ci`       | CI workflows, GitHub Actions, lint configs                | none                    |
+| `docs`     | Documentation, comments, READMEs, CLAUDE.md               | none                    |
+| `refactor` | Code restructuring with no behavior change                | none                    |
+| `style`    | Formatting, whitespace, missing semicolons                | none                    |
+| `test`     | Tests, test fixtures, test infrastructure                 | none                    |
+
+Append `!` to the type (or add a `BREAKING CHANGE:` footer) for **major** (X.0.0).
+
+**Pick the type with version impact in mind.** Common traps:
+
+-   A pure build/CI/test change mislabeled `fix:` will burn a patch release on a non-user-visible change. Use `build:`, `ci:`, or `test:` instead.
+-   A refactor mislabeled `feat:` will force a minor bump.
+-   A perf win on internal code (not exposed to users) is `refactor:`, not `perf:`.
+-   `chore:` is a catch-all; prefer the specific type when one fits.
 
 ### Release Branch Model
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -605,6 +605,12 @@ if(AUTO_PLUGIN_DEPLOYMENT OR AIO_ZIP_TO_DIST)
     # Copy feature folders (files only; copy_shaders.stamp owns Shaders/
     # to avoid racing). All features copied — autoupload filter applies
     # only at archive time.
+    #
+    # The CORE marker is excluded from the per-feature copy: every feature
+    # that has one would write to the same `${AIO_DIR}/CORE` path, and the
+    # trailing `remove` below deletes it anyway. When MSBuild runs the copy
+    # commands in parallel two features can race for the write and one
+    # fails with "Permission denied", taking PREPARE_AIO down with it.
     foreach(_fpath IN LISTS FEATURE_PATHS)
         if(EXISTS "${_fpath}")
             file(
@@ -613,11 +619,13 @@ if(AUTO_PLUGIN_DEPLOYMENT OR AIO_ZIP_TO_DIST)
                 "${_fpath}/*"
             )
             list(FILTER _feature_files EXCLUDE REGEX "/Shaders/")
+            list(FILTER _feature_files EXCLUDE REGEX "/CORE$")
             append_copy_if_different(_prepare_aio_cmds _feature_files "${_fpath}" "${AIO_DIR}")
         endif()
     endforeach()
 
-    # Remove CORE from AIO if it exists (keep rest intact)
+    # Remove CORE from AIO if it left over from a previous build that pre-
+    # dated the per-feature exclusion above. Cheap, idempotent.
     list(
         APPEND _prepare_aio_cmds
         COMMAND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,7 +624,7 @@ if(AUTO_PLUGIN_DEPLOYMENT OR AIO_ZIP_TO_DIST)
         endif()
     endforeach()
 
-    # Remove CORE from AIO if it left over from a previous build that pre-
+    # Remove CORE from AIO if it's left over from a previous build that pre-
     # dated the per-feature exclusion above. Cheap, idempotent.
     list(
         APPEND _prepare_aio_cmds


### PR DESCRIPTION
## Summary

Two changes — the immediate build race fix, plus a docs update so contributors don't run into adjacent commit-type confusion that already cost a round trip on this PR.

## Part 1: PREPARE_AIO CORE race condition

PREPARE_AIO's per-feature copy loop has a race that bites contributors building locally with `BuildRelease.bat` on a parallel MSBuild. Every feature with a `CORE` marker file writes it to the same destination path, and a trailing `remove` deletes it at the end — meaning the per-feature copy is both wasted work and a write-contention hazard.

### Repro

Run `.\BuildRelease.bat ALL-WITH-AUTO-DEPLOYMENT` (or `ALL`) on a parallel MSBuild and the race triggers intermittently:

```
Error copying file (if different) from "features/Dynamic Cubemaps/CORE"
to "build/ALL/aio/CORE": Permission denied
MSBUILD : error MSB8066: Custom build for '...prepare_aio.stamp.rule'
exited with code 1.
```

The destination is the same `${AIO_DIR}/CORE` for every feature; concurrent writes collide and one fails. The `cmake -E remove "${AIO_DIR}/CORE"` at the end of `_prepare_aio_cmds` (line 620) deletes it anyway, so this work is purely race-bait.

### Fix

Add a `list(FILTER _feature_files EXCLUDE REGEX "/CORE$")` to the per-feature copy loop. Same pattern the loop already uses to exclude `Shaders/` (the comment one line above literally says "to avoid racing"). The trailing `remove` stays as a no-op safety net for stale state from older builds.

```diff
 list(FILTER _feature_files EXCLUDE REGEX "/Shaders/")
+list(FILTER _feature_files EXCLUDE REGEX "/CORE$")
 append_copy_if_different(_prepare_aio_cmds _feature_files "${_fpath}" "${AIO_DIR}")
```

## Part 2: docs(claude) — full conventional commit type set

The existing `Commit Message Standards` section in `.claude/CLAUDE.md` listed 7 types (`feat`/`fix`/`refactor`/`docs`/`style`/`test`/`chore`). The actual validator (`amannn/action-semantic-pull-request@v5` with default config) accepts the full Conventional Commits standard: 11 types including `build`, `ci`, `perf`, `revert`. Recent dev history confirms `ci:` and `build:` are in active use.

Adds to CLAUDE.md:
- Full type table with release impact (`feat`/`fix`/`perf` trigger releases; the rest don't)
- Squash-merge note: the PR **title** becomes the commit message that semantic-release reads, not the per-commit messages on the PR branch
- Common-traps list covering the cases that already tripped contributors (e.g., `fix:` on a build-only change burns a patch release for nothing)

## Smoke test

`PREPARE_AIO` target builds clean on a fresh `cmake --preset ALL` off `dev`. `${AIO_DIR}/CORE` is correctly not created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)