### PR TITLE
fix(vr): full-resolution underwater mask

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1881,6 +1881,14 @@ void Upscaling::UpscaleDepth()
 
 	state->BeginPerfEvent("Render Target Upscaling");
 
+	// Unbind any prior render targets before issuing CopyResource on depth/
+	// depthCopy. Upscale() does this for the standard upscale path, but
+	// UpscaleDepth() can now be invoked standalone from Main_PostProcessing
+	// (kNONE/kTAA VR path) without going through Upscale() first — match the
+	// same precondition here to avoid a debug-layer hazard when depth happens
+	// to still be bound as a DSV from a prior pass.
+	context->OMSetRenderTargets(0, nullptr, nullptr);
+
 	// Set up Input Assembler for fullscreen triangle (no vertex/index buffers needed)
 	context->IASetInputLayout(nullptr);
 	context->IASetVertexBuffers(0, 0, nullptr, nullptr, nullptr);
@@ -2002,7 +2010,7 @@ void Upscaling::UpscaleDepth()
 	// Propagate the upscaled depth to kMAIN_COPY so downstream VR passes see
 	// it. Skipped on the full-resolution path because the else branch above
 	// already refreshed depthCopy from depth and nothing has touched it since.
-	if (globals::game::isVR && depthUpscaleActive) {
+	if (isVR && depthUpscaleActive) {
 		TracyD3D11Zone(globals::state->tracyCtx, "Upscaling - Depth VR Propagate");
 		copyIfNonAliased(depthCopy.texture, depth.texture);
 	}

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1819,7 +1819,20 @@ void Upscaling::UpscaleDepth()
 	// 3) Resource copies are skipped for aliased src/dst to reduce copy churn.
 
 	// (1) Early validation exits
-	if (!IsUpscalingActive()) {
+	const bool depthUpscaleActive = IsUpscalingActive();
+	const auto upscaleMethod = GetUpscaleMethod();
+	const bool isVR = globals::game::isVR;
+	const bool vendorUpscaler = upscaleMethod == UpscaleMethod::kDLSS || upscaleMethod == UpscaleMethod::kFSR;
+	const bool fullResolutionMaskPath =
+		upscaleMethod == UpscaleMethod::kNONE ||
+		upscaleMethod == UpscaleMethod::kTAA ||
+		(vendorUpscaler && settings.qualityMode == 0);
+	const bool repairVRFullResolutionMask =
+		isVR &&
+		fullResolutionMaskPath &&
+		!depthUpscaleActive;
+
+	if (!depthUpscaleActive && !repairVRFullResolutionMask) {
 		return;
 	}
 
@@ -1827,7 +1840,8 @@ void Upscaling::UpscaleDepth()
 	auto renderer = globals::game::renderer;
 	auto context = globals::d3d::context;
 	auto deferred = globals::deferred;
-	if (!state || !renderer || !context || !deferred || !deferred->linearSampler || !jitterCB || !upscaleRasterizerState || !upscaleBlendState || !upscaleDepthStencilState) {
+	if (!state || !renderer || !context || !deferred || !deferred->linearSampler || !jitterCB || !upscaleRasterizerState || !upscaleBlendState ||
+		(depthUpscaleActive && !upscaleDepthStencilState)) {
 		return;
 	}
 
@@ -1842,19 +1856,25 @@ void Upscaling::UpscaleDepth()
 	auto& saoCameraZ = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGET::kSAO_CAMERAZ];
 	auto& underwaterMask = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGET::kUNDERWATER_MASK];
 
-	if (!depth.texture || !depth.views[0] || !depthCopy.texture || !depthCopy.depthSRV ||
-		!refractionNormals.texture || !refractionNormals.textureCopy || !refractionNormals.SRVCopy || !refractionNormals.RTV || !saoCameraZ.RTV ||
+	if (!depth.texture || !depthCopy.texture || !depthCopy.depthSRV ||
 		!underwaterMask.texture || !underwaterMask.textureCopy || !underwaterMask.SRVCopy || !underwaterMask.RTV) {
 		return;
 	}
-	if (globals::game::isVR && (!depthCopy.views[0] || !depthCopy.stencilSRV)) {
+	if (depthUpscaleActive &&
+		(!depth.views[0] || !refractionNormals.texture || !refractionNormals.textureCopy || !refractionNormals.SRVCopy || !refractionNormals.RTV || !saoCameraZ.RTV)) {
+		return;
+	}
+	if (isVR && !depthCopy.stencilSRV) {
+		return;
+	}
+	if (depthUpscaleActive && isVR && !depthCopy.views[0]) {
 		return;
 	}
 
 	auto* fullscreenVS = GetUpscaleVS();
-	auto* depthUpscalePS = GetDepthRefractionUpscalePS();
+	auto* depthUpscalePS = depthUpscaleActive ? GetDepthRefractionUpscalePS() : nullptr;
 	auto* underwaterMaskPS = GetUnderwaterMaskUpscalePS();
-	if (!fullscreenVS || !depthUpscalePS || !underwaterMaskPS) {
+	if (!fullscreenVS || !underwaterMaskPS || (depthUpscaleActive && !depthUpscalePS)) {
 		return;
 	}
 
@@ -1887,10 +1907,10 @@ void Upscaling::UpscaleDepth()
 	context->PSSetSamplers(0, ARRAYSIZE(samplers), samplers);
 
 	// Set up jitter/depth-kernel constant buffer for upscaling
-	JitterCB jitterData;
+	JitterCB jitterData{};
 	jitterData.jitter = jitter;
 	// (2) Wide-kernel hysteresis
-	{
+	if (depthUpscaleActive) {
 		constexpr float kEnterWideKernelRatio = 1.55f;
 		constexpr float kExitWideKernelRatio = 1.45f;
 		const float minScale = std::max(std::min(resolutionScale.x, resolutionScale.y), FLT_EPSILON);
@@ -1907,7 +1927,6 @@ void Upscaling::UpscaleDepth()
 		}
 
 		jitterData.useWideKernel = depthUpscaleUseWideKernel ? 1.0f : 0.0f;
-		jitterData.pad0 = 0.0f;
 	}
 
 	jitterCB->Update(jitterData);
@@ -1921,7 +1940,7 @@ void Upscaling::UpscaleDepth()
 		}
 	};
 
-	{
+	if (depthUpscaleActive) {
 		TracyD3D11Zone(globals::state->tracyCtx, "Upscaling - Depth Upscale");
 
 		// Sometimes this is not already copied e.g. map menu.
@@ -1929,7 +1948,7 @@ void Upscaling::UpscaleDepth()
 		copyIfNonAliased(depthCopy.texture, depth.texture);
 
 		// Clear stencil to be 0xFF
-		if (globals::game::isVR) {
+		if (isVR) {
 			context->ClearDepthStencilView(depthCopy.views[0], D3D11_CLEAR_STENCIL, 1.0f, 0xFF);
 		}
 
@@ -1944,11 +1963,16 @@ void Upscaling::UpscaleDepth()
 		// kSAO_CAMERAZ is at quarter-stereo resolution in VR; the full-stereo viewport would
 		// corrupt only the top-left quarter. The engine's ISSAOCameraZ pass populates it correctly.
 		ID3D11RenderTargetView* rtvs[] = { refractionNormals.RTV,
-			globals::game::isVR ? nullptr : saoCameraZ.RTV };
+			isVR ? nullptr : saoCameraZ.RTV };
 		context->OMSetRenderTargets(2, rtvs, depth.views[0]);
 
 		context->PSSetShader(depthUpscalePS, nullptr, 0);
 		context->Draw(3, 0);
+	} else {
+		TracyD3D11Zone(globals::state->tracyCtx, "Upscaling - Full Resolution Underwater Mask Depth Copy");
+
+		// Full-resolution paths only need to refresh the underwater mask depth source.
+		copyIfNonAliased(depthCopy.texture, depth.texture);
 	}
 
 	{
@@ -2045,8 +2069,11 @@ void Upscaling::Main_PostProcessing::thunk(RE::ImageSpaceManager* a_this, uint32
 	if (upscaling.ShouldUseFrameGenerationThisFrame())
 		upscaling.CopySharedD3D12Resources();
 
-	if (upscaleMethod != UpscaleMethod::kNONE && upscaleMethod != UpscaleMethod::kTAA)
+	if (upscaleMethod != UpscaleMethod::kNONE && upscaleMethod != UpscaleMethod::kTAA) {
 		upscaling.PerformUpscaling();
+	} else if (globals::game::isVR) {
+		upscaling.UpscaleDepth();
+	}
 
 	if (upscaleMethod == UpscaleMethod::kDLSS)
 		upscaling.ApplySharpening();

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1864,10 +1864,11 @@ void Upscaling::UpscaleDepth()
 		(!depth.views[0] || !refractionNormals.texture || !refractionNormals.textureCopy || !refractionNormals.SRVCopy || !refractionNormals.RTV || !saoCameraZ.RTV)) {
 		return;
 	}
-	if (isVR && !depthCopy.stencilSRV) {
-		return;
-	}
-	if (depthUpscaleActive && isVR && !depthCopy.views[0]) {
+	// stencilSRV + views[0] are both upscale-path-only: the depth-upscale
+	// draw binds depthCopy as a stencil SRV input and depth.views[0] as DSV.
+	// The full-resolution mask repair never touches either, so don't disable
+	// the VR fix on setups where stencil SRV creation is unavailable.
+	if (depthUpscaleActive && isVR && (!depthCopy.stencilSRV || !depthCopy.views[0])) {
 		return;
 	}
 

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1998,8 +1998,10 @@ void Upscaling::UpscaleDepth()
 		context->Draw(3, 0);
 	}
 
-	// Now propagate the upscaled depth to kMAIN_COPY so downstream VR passes see it.
-	if (globals::game::isVR) {
+	// Propagate the upscaled depth to kMAIN_COPY so downstream VR passes see
+	// it. Skipped on the full-resolution path because the else branch above
+	// already refreshed depthCopy from depth and nothing has touched it since.
+	if (globals::game::isVR && depthUpscaleActive) {
 		TracyD3D11Zone(globals::state->tracyCtx, "Upscaling - Depth VR Propagate");
 		copyIfNonAliased(depthCopy.texture, depth.texture);
 	}


### PR DESCRIPTION
## Summary

Cherry-picks `b2a9b0e49` from `ParticleTroned/cs-1.5-PL-VR` — the underwater mask repair pass currently bails when `IsUpscalingActive()` is false (DLAA, TAA, or no upscaler), so VR users on those paths see a broken underwater mask. ParticleTroned's fix lets `UpscaleDepth()` run in the **full-resolution mask path** (vendor upscaler at `qualityMode=0` / TAA / kNONE in VR) to refresh the depth source the analytical mask needs, then dispatches the existing underwater-mask repair draw.

Authorship preserved via `git cherry-pick -x` — original commit is by @ParticleTroned, the cherry-pick adds a `(cherry picked from commit b2a9b0e49)` trailer.

## What it changes

`src/Features/Upscaling.cpp::UpscaleDepth`:

- Early-exit broadens: was `if (!IsUpscalingActive()) return;`. Now also runs when `isVR && fullResolutionMaskPath && !depthUpscaleActive`, where `fullResolutionMaskPath` covers kNONE / kTAA / vendor-upscaler-at-DLAA.
- Resource-presence guard split: `upscaleDepthStencilState`, `refractionNormals.*`, `saoCameraZ.RTV`, and `depth.views[0]` are only required when `depthUpscaleActive` (the full-res mask path doesn't draw the depth-refinement pass, just the mask draw).
- Wide-kernel hysteresis block + the original depth-refinement draw move under `if (depthUpscaleActive)`.
- New `else` branch refreshes `depthCopy.texture` from `depth.texture` so the underwater mask PS gets fresh depth.
- `Main_PostProcessing` now also calls `UpscaleDepth()` in the VR-kNONE / VR-kTAA branch (where `PerformUpscaling` isn't called).

## Why this isn't already on dev

`b2a9b0e49` lives only on ParticleTroned's `cs-1.5-PL-VR` / `cs-1.5-PL-VR-unleashed` branches and was never opened upstream. Surfacing it here so the fork has it on dev.

## Test plan

- [ ] VR + DLSS DLAA: underwater scene shows correct tint mask
- [ ] VR + TAA: same
- [ ] VR + no upscaler: same
- [ ] VR + DLSS Quality/Balanced/Performance: behavior unchanged (already covered by `depthUpscaleActive` branch)
- [ ] Non-VR builds: behavior unchanged (the new branch is `isVR &&`-gated)

## Credit

@ParticleTroned for the original fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked depth upscaling and VR rendering paths to be more robust and efficient, improving stability and maintainability.
* **Bug Fixes**
  * Improved validation and conditional handling so depth/underwater-mask upscaling and VR full-resolution repair run only when needed, reducing visual artifacts and unnecessary work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/open-shaders/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->