### PR TITLE
feat(llf): restore contact shadows with VR-aware noise

### DIFF
--- a/features/Light Limit Fix/Shaders/Features/LightLimitFix.ini
+++ b/features/Light Limit Fix/Shaders/Features/LightLimitFix.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 3-0-3
+Version = 3-1-0
 
 [Nexus]
 autoupload = false

--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -37,6 +37,77 @@ namespace LightLimitFix
 		return true;
 	}
 
+	bool IsSaturated(float value)
+	{
+		return value == saturate(value);
+	}
+
+	bool IsSaturated(float2 value)
+	{
+		return IsSaturated(value.x) && IsSaturated(value.y);
+	}
+
+	// Chooses the contact-shadow noise sample coordinate. In VR we derive it
+	// from screenUV (which FrameBuffer::ViewToUV already returns per-eye via
+	// CameraProj[eye]) so both eyes sample the same noise pattern at the same
+	// world position — using the raw rasterized pixel position in VR makes
+	// each eye hash a different value, producing per-eye jitter that reads as
+	// flicker on contact-shadow recipients.
+	//
+	// BufferDim.x is the full packed stereo width (State::UpdateSharedData
+	// reads it from the kMAIN texture, which spans both eyes side-by-side),
+	// so we halve X in VR to match the per-eye pixel grid. Without the
+	// halving, the per-eye sample steps by ~2 pixels in X — still stereo-
+	// consistent, but at half the effective noise resolution. Flat keeps the
+	// raw pixel position to match the original implementation byte-for-byte.
+	float2 GetContactShadowNoiseCoord(float2 screenPosition, float2 screenUV)
+	{
+#if defined(VR)
+		return screenUV * float2(SharedData::BufferDim.x * 0.5, SharedData::BufferDim.y);
+#else
+		return screenPosition;
+#endif
+	}
+
+	float ContactShadows(float3 viewPosition, float noise2D, float3 lightDirectionVS, uint contactShadowSteps, uint a_eyeIndex = 0)
+	{
+		if (contactShadowSteps == 0)
+			return 1.0;
+
+		float2 depthDeltaMult = float2(0.20, 0.05);
+
+		// Extend contact shadow distance
+		lightDirectionVS *= 2.0;
+
+		// Offset starting position with interleaved gradient noise
+		viewPosition += lightDirectionVS * noise2D;
+
+		// Accumulate samples
+		float contactShadow = 0.0;
+		for (uint i = 0; i < contactShadowSteps; i++) {
+			// Step the ray
+			viewPosition += lightDirectionVS;
+
+			float2 rayUV = FrameBuffer::ViewToUV(viewPosition, true, a_eyeIndex);
+
+			// Ensure the UV coordinates are inside the screen
+			if (!IsSaturated(rayUV))
+				break;
+
+			// Compute the difference between the ray's and the camera's depth
+			float rayDepth = SharedData::GetScreenDepth(rayUV, a_eyeIndex);
+
+			// Difference between the current ray distance and the marched light
+			float depthDelta = viewPosition.z - rayDepth;
+			if (rayDepth > 16.5)  // First person
+				contactShadow = max(contactShadow, saturate(depthDelta * depthDeltaMult.x) - saturate(depthDelta * depthDeltaMult.y));
+			if (contactShadow == 1.0)
+				break;
+		}
+
+		return 1.0 - saturate(contactShadow);
+	}
+
 	bool IsLightIgnored(Light light)
 	{
 		if (light.lightFlags & LightLimitFix::LightFlags::Shadow) {

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -75,9 +75,10 @@ namespace SharedData
 
 	struct LightLimitFixSettings
 	{
+		uint EnableContactShadows;
 		uint EnableLightsVisualisation;
 		uint LightsVisualisationMode;
-		float2 pad0;
+		float pad0;
 		uint4 ClusterSize;
 	};
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2678,6 +2678,24 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		lightOffset = LightLimitFix::lightGrid[clusterIndex].offset;
 	}
 
+#			if defined(DEFERRED)
+	// Contact-shadow setup, gated on the runtime toggle so we don't pay the
+	// noise hash + step-count math for every pixel when the feature is off
+	// (it defaults off). The step count and noise are reused across every
+	// clustered light in this pixel so we hoist them out of the per-light loop.
+	uint contactShadowSteps = 0;
+	float contactShadowNoise = 0.0;
+	[branch] if (SharedData::lightLimitFixSettings.EnableContactShadows)
+	{
+		contactShadowSteps = round(4.0 * (1.0 - saturate(viewPosition.z / 1024.0)));
+		// The helper stays stereo-stable in VR — see
+		// LightLimitFix::GetContactShadowNoiseCoord for the eye-buffer math.
+		contactShadowNoise = Random::InterleavedGradientNoise(
+			LightLimitFix::GetContactShadowNoiseCoord(input.Position.xy, screenUV),
+			SharedData::FrameCount);
+	}
+#			endif
+
 	[loop] for (uint lightIndex = 0; lightIndex < totalLightCount; lightIndex++)
 	{
 		LightLimitFix::Light light;
@@ -2720,6 +2738,25 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float3 normalizedLightDirection = normalize(lightDirection);
 		float lightAngle = dot(worldNormal.xyz, normalizedLightDirection.xyz);
 
+		float contactShadow = 1.0;
+
+#			if defined(DEFERRED)
+		[branch] if (
+			SharedData::lightLimitFixSettings.EnableContactShadows &&
+			!(light.lightFlags & LightLimitFix::LightFlags::Simple) &&
+			shadowComponent != 0.0 &&
+			lightAngle > 0.0)
+		{
+			// The current LightLimitFix Light struct stores positionWS only; derive view-space
+			// from CameraView so the raymarch direction matches viewPosition. The pre-removal
+			// call site referenced light.positionVS, but that field did not exist on the Light
+			// struct even then — the original code was commented out and unreachable.
+			float3 lightPositionVS = mul(FrameBuffer::CameraView[eyeIndex], float4(light.positionWS[eyeIndex].xyz, 1)).xyz;
+			float3 normalizedLightDirectionVS = normalize(lightPositionVS - viewPosition.xyz);
+			contactShadow = LightLimitFix::ContactShadows(viewPosition, contactShadowNoise, normalizedLightDirectionVS, contactShadowSteps, eyeIndex);
+		}
+#			endif
+
 		float3 refractedLightDirection = normalizedLightDirection;
 #			if defined(TRUE_PBR) && !defined(LANDSCAPE) && !defined(LODLANDSCAPE)
 		[branch] if ((PBRFlags & PBR::Flags::InterlayerParallax) != 0)
@@ -2736,7 +2773,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 			SharedData::extendedMaterialSettings.EnableShadows &&
 			!(light.lightFlags & LightLimitFix::LightFlags::Simple) &&
 			lightAngle > 0.0 &&
-			shadowComponent != 0.0)
+			shadowComponent != 0.0 &&
+			contactShadow != 0.0)
 		{
 			float3 lightDirectionTS = normalize(mul(refractedLightDirection, tbn).xyz);
 #				if defined(PARALLAX)
@@ -2765,7 +2803,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 		DirectContext pointLightContext;
 		DirectLightingOutput pointLightOutput;
-		float pointLightShadow = lightShadow * parallaxShadow;
+		float pointLightShadow = lightShadow * parallaxShadow * contactShadow;
 #			if defined(TRUE_PBR)
 		pointLightContext = CreateDirectLightingContext(worldNormal.xyz, coatWorldNormal, vertexNormal.xyz, refractedViewDirection, viewDirection, refractedLightDirection, normalizedLightDirection, lightColor, pointLightShadow, pointLightShadow);
 #			else

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -3,10 +3,10 @@
 #include "LinearLighting.h"
 
 #include "Menu/ThemeManager.h"
-#include "Utils/ExternalEmittance.h"
 #include "Shadercache.h"
 #include "State.h"
 #include "Util.h"
+#include "Utils/ExternalEmittance.h"
 
 static constexpr uint CLUSTER_MAX_LIGHTS = 128;
 static constexpr uint MAX_LIGHTS = 1024;
@@ -19,6 +19,14 @@ void LightLimitFix::DrawSettings()
 		ImGui::Text(std::format("Clustered Light Count : {}", lightCount).c_str());
 
 		ImGui::TreePop();
+	}
+
+	///////////////////////////////
+	ImGui::SeparatorText("Shadows");
+
+	ImGui::Checkbox("Enable Contact Shadows", &settings.EnableContactShadows);
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text("All point lights (strict and clustered, except simple lights) cast short screen-space shadows. Performance impact.");
 	}
 
 	///////////////////////////////
@@ -66,6 +74,7 @@ void LightLimitFix::DrawOverlay()
 LightLimitFix::PerFrame LightLimitFix::GetCommonBufferData()
 {
 	PerFrame perFrame{};
+	perFrame.EnableContactShadows = settings.EnableContactShadows;
 	perFrame.EnableLightsVisualisation = settings.EnableLightsVisualisation;
 	perFrame.LightsVisualisationMode = settings.LightsVisualisationMode;
 	std::copy(clusterSize, clusterSize + 3, perFrame.ClusterSize);

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -94,9 +94,10 @@ public:
 
 	struct alignas(16) PerFrame
 	{
+		uint EnableContactShadows;
 		uint EnableLightsVisualisation;
 		uint LightsVisualisationMode;
-		float pad0[2];
+		float pad0;
 		uint ClusterSize[4];
 	};
 	STATIC_ASSERT_ALIGNAS_16(PerFrame);
@@ -169,6 +170,7 @@ public:
 
 	struct Settings
 	{
+		bool EnableContactShadows = false;
 		bool EnableLightsVisualisation = false;
 		uint LightsVisualisationMode = 0;
 	};


### PR DESCRIPTION
## Summary

Restores Light Limit Fix contact shadows for all point lights (strict and clustered, excluding simple emissive markers), reversing the maintainability-only removal in 347cb55a8. Adds a stereo-aware noise sample so VR doesn't flicker.

## Why now

PR #1495 (the upstream removal) cited no defect — no human discussion, no linked issue, no rationale beyond CodeRabbit's auto-summary. The shader call site in `Lighting.hlsl` was already `// `-commented out at the time of deletion, so this is reviving a dormant feature, not introducing new behaviour.

The ParticleTroned fork (`cs-1.5-PL-VR-unleashed`) has been carrying a restored implementation for months. This PR pulls just the contact-shadow piece — the fork's elaborate budgeted/cluster-aware variant requires Particle Lights to be meaningful and is deferred to a follow-up.

## Changes

- **`LightLimitFix.hlsli`** — restore `IsSaturated()` and `ContactShadows()` raymarch helper verbatim. Add `GetContactShadowNoiseCoord()` for stereo-aware noise sampling (one `#if defined(VR)` branch, leans on `FrameBuffer::ViewToUV`'s per-eye return value).
- **`Lighting.hlsl`** — hoist contact-shadow noise out of the per-light loop, compute once per pixel. Uncomment + activate the `EnableContactShadows` call site (gated to `DEFERRED`). Multiply `contactShadow` into `pointLightShadow` so it flows through the new `DirectContext`/`EvaluateLighting` path uniformly for both PBR and legacy.
- **`SharedData.hlsli`** — re-add `uint EnableContactShadows` to `LightLimitFixSettings` cbuffer (replaces one `float2 pad0` slot with `uint EnableContactShadows; float pad0`).
- **`LightLimitFix.h`** — re-add `bool EnableContactShadows = false` to `Settings`.
- **`LightLimitFix.cpp`** — restore Shadows section in `DrawSettings()` using current upstream's `///////` separator style. Did **not** restore NLOHMANN persistence — current LLF is session-only per #1834, kept that stance.
- **`LightLimitFix.ini`** — bump feature version `3-0-3 → 3-1-0` (minor: new persisted cbuffer field + user toggle).

## VR jitter fix

Concept lifted from `ParticleTroned/skyrim-community-shaders@8e615ea fix(contact-shadows): stabilize VR eye jitter`, simplified to one helper / one ifdef.

In VR, using raw `input.Position.xy` for the noise sample makes each eye hash a different value at the same world position. The helper switches to `screenUV * BufferDim.xy` in VR — `screenUV` from `FrameBuffer::ViewToUV` is already per-eye via `CameraProj[eye]`, so both eyes hash the same input and the noise stays stereo-stable. Flat keeps `input.Position.xy` to match the pre-removal implementation byte-for-byte.

## What's not in this PR

- The fork's budgeted cluster-aware contact-shadow architecture (`InsertContactShadowCandidate`, `ContactShadowFlags`, separate `contactShadowGrid`). Requires Particle Lights to be meaningful; deferred to a follow-up after PL lands.
- LLF settings persistence. #1834 removed it; this PR doesn't undo that decision — so contact shadows reset to off each session, matching the rest of LLF.

## Test plan

- [ ] Builds clean on `ALL` preset (verified locally; `CommunityShaders.dll` produced)
- [ ] CI shader validation (full hlslkit suite) passes — skipped locally per `feedback_shader_validation_scope.md`
- [ ] In-game flat SE: enable in LLF settings, confirm point lights cast short screen-space shadows on receiver geometry
- [ ] In-game VR: same as above; confirm no per-eye flicker on contact-shadow recipients
- [ ] Verify no double-darkening with EMAT shadow path (`SharedData::extendedMaterialSettings.EnableShadows`)
- [ ] Toggle on/off at runtime, no shader recompile required

## Attribution

- Original contact-shadow implementation by **jiayev** (merged via #9 prior to the 347cb55a8 removal).
- VR jitter analysis from **ParticleTroned**'s fork.

Both are credited in the commit trailers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Contact shadows feature now available, enhancing shadow depth perception and overall visual rendering quality for more realistic lighting effects
  * User-configurable setting introduced to enable or disable contact shadows based on visual preferences and performance requirements

* **Chores**
  * Version updated to 3.1.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/open-shaders/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
