### PR TITLE
build: drop /XO from robocopy auto-deploy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -765,11 +765,12 @@ if(AUTO_PLUGIN_DEPLOYMENT)
     # Detect git HEAD changes (branch switch or new commit) and invalidate stale
     # deploy state. BuildRelease.bat always reconfigures, so this runs on every
     # build invocation. When HEAD changes we:
-    #   1. Touch all AIO files so robocopy /XO sees them as newer than any
-    #      previously-deployed files (including manual package installs).
+    #   1. Clear the AIO directory so PREPARE_AIO re-copies everything with
+    #      fresh timestamps (catches content-identical files cmake's
+    #      copy_if_different would otherwise skip).
     #   2. Delete deploy stamps so CMake re-runs the robocopy commands.
-    # Files the user intentionally edited in-game remain protected by /XO on
-    # subsequent builds (same HEAD = no touch, same stamp file exists).
+    # Per-build incremental relies on robocopy's default name+size+timestamp
+    # detection to copy any file whose size or mtime differs from dest.
     execute_process(
         COMMAND git rev-parse --short HEAD
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
@@ -792,10 +793,10 @@ if(AUTO_PLUGIN_DEPLOYMENT)
             # Delete the entire AIO directory so PREPARE_AIO re-copies everything
             # with fresh timestamps. Without this, copy_if_different skips
             # content-identical files (shaders, textures, configs, etc.) and
-            # leaves them with old timestamps that deployed files (e.g. from a
-            # manual package install) may beat under /XO. The DLL is always
-            # rebuilt fresh by the C++ compile step so it doesn't need special
-            # handling.
+            # leaves them with old timestamps that previously-deployed files
+            # (e.g. from a manual package install) can beat on timestamp delta.
+            # The DLL is always rebuilt fresh by the C++ compile step so it
+            # doesn't need special handling.
             file(REMOVE_RECURSE "${AIO_DIR}")
             # Also clear the PREPARE_AIO / COPY_SHADERS stamps so cmake --build
             # actually re-runs those targets.
@@ -833,10 +834,18 @@ if(AUTO_PLUGIN_DEPLOYMENT)
             add_custom_command(
                 OUTPUT ${DEPLOY_TARGET_HASH}_deploy.stamp
                 COMMAND ${CMAKE_COMMAND} -E make_directory "${DEPLOY_TARGET}"
+                # No /XO: a previous manual or external deploy can leave dest
+                # files with mtime > source. /XO then skips them even when the
+                # source file changed (different size and/or content), so build
+                # output silently diverges from what runs in-game. Without /XO,
+                # robocopy's default name+size+timestamp delta catches both
+                # newer-source and size-mismatch cases. The git-HEAD-change
+                # block above handles bulk-redeploy when checking out a new
+                # branch; this command handles the per-build incremental.
                 COMMAND
                     ${ROBOCOPY_WRAPPER} "${AIO_DIR}" "${DEPLOY_TARGET}" "/E"
-                    "/XD" "${AIO_DIR}/Shaders" "/COPY:DAT" "/XO" "/R:1" "/W:1"
-                    "/NFL" "/NDL" "/NJH" "/NJS"
+                    "/XD" "${AIO_DIR}/Shaders" "/COPY:DAT" "/R:1" "/W:1" "/NFL"
+                    "/NDL" "/NJH" "/NJS"
                 COMMAND
                     ${CMAKE_COMMAND} -E touch ${DEPLOY_TARGET_HASH}_deploy.stamp
                 DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/prepare_aio.stamp
@@ -876,10 +885,11 @@ if(AUTO_PLUGIN_DEPLOYMENT)
                 COMMAND
                     ${CMAKE_COMMAND} -E make_directory
                     "${DEPLOY_TARGET}/Shaders"
+                # See /XO rationale above on the main deploy block.
                 COMMAND
                     ${ROBOCOPY_WRAPPER} "${AIO_DIR}/Shaders"
-                    "${DEPLOY_TARGET}/Shaders" "/E" "/COPY:DAT" "/XO" "/R:1"
-                    "/W:1" "/NFL" "/NDL" "/NJH" "/NJS"
+                    "${DEPLOY_TARGET}/Shaders" "/E" "/COPY:DAT" "/R:1" "/W:1"
+                    "/NFL" "/NDL" "/NJH" "/NJS"
                 COMMAND
                     ${CMAKE_COMMAND} -E touch
                     ${DEPLOY_TARGET_HASH}_shaders_only.stamp
@@ -899,10 +909,11 @@ if(AUTO_PLUGIN_DEPLOYMENT)
                 COMMAND
                     ${CMAKE_COMMAND} -E make_directory
                     "${DEPLOY_TARGET}/Shaders"
+                # See /XO rationale above on the main deploy block.
                 COMMAND
                     ${ROBOCOPY_WRAPPER} "${AIO_DIR}/Shaders"
-                    "${DEPLOY_TARGET}/Shaders" "/E" "/COPY:DAT" "/XO" "/R:1"
-                    "/W:1" "/NFL" "/NDL" "/NJH" "/NJS"
+                    "${DEPLOY_TARGET}/Shaders" "/E" "/COPY:DAT" "/R:1" "/W:1"
+                    "/NFL" "/NDL" "/NJH" "/NJS"
                 COMMAND
                     ${CMAKE_COMMAND} -E touch
                     ${DEPLOY_TARGET_HASH}_shaders_full.stamp


### PR DESCRIPTION
## Summary

- Drop `/XO` (eXclude Older) from the three robocopy invocations under `AUTO_PLUGIN_DEPLOYMENT` so changed source files actually reach the install
- Update inline comments to document the trap (any prior touch to dest can give it a newer mtime than git-checkout source, which silently disables deploy)

## Why

`/XO` skips files where source is older than dest. In a normal git workflow that's usually safe — but as soon as anything *else* touches the destination (a manual `cp` during debugging, a package install, even a previous build that ran later in wall time than the source's git checkout), dest gets a newer mtime and `/XO` then refuses to overwrite even when the source file's **size and content** have changed.

## Concrete failure that prompted this

While debugging SLF I had RunGrass.hlsl fixed in source (commit `f11bfaa32`, source size 33287 bytes with the corrected ShadowSampling include order), but the deployed file stayed at the previous 31877 bytes across multiple full builds. Mtime on dest (from a manual `cp` during earlier diagnostics) was newer than the git-checkout mtime on source, so `/XO` skipped the copy. Grass and Particle pixel shaders failed to compile in-game:

> `LightLimitFix/LightLimitFix.hlsli(85,3-28): error X3000: unrecognized identifier 'DirectionalShadowLightData'`

Same shape of bug can hit any contributor who: tests a package install over their dev build, copies files manually for any reason, or just has clock skew across filesystem boundaries.

## What this changes

| Before | After |
|---|---|
| \`/E /XD ... /COPY:DAT /XO /R:1 /W:1 ...\` | \`/E /XD ... /COPY:DAT /R:1 /W:1 ...\` |

Without `/XO`, robocopy uses its default name + size + timestamp delta — copies whenever **any** of those differ. Catches both newer-source and size-mismatch cases. The git-HEAD-change block above the deploy commands already clears AIO and deploy stamps on branch switch, so the bulk-redeploy story is unchanged.

## Trade-off

The property `/XO` nominally provided ("don't clobber files the user intentionally edited in-game between builds at the same HEAD") was fragile anyway — broken by any external touch to dest. Removing it costs ~100ms of extra IO per build on unchanged files (robocopy still skips matching name+size+timestamp). Correctness wins.

## Test plan

- [ ] \`BuildRelease.bat ALL-WITH-AUTO-DEPLOYMENT\` produces a deployed install that matches \`build/<preset>/aio\` byte-for-byte
- [ ] Manually \`touch\` a file in the deployed install to give it a newer mtime, rebuild, confirm the source file overwrites it
- [ ] Verify unchanged files still skip on subsequent builds (robocopy's default behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted Windows plugin deployment configuration to improve synchronization between deployed and built files. Updated build system documentation comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/open-shaders/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->