### PR TITLE
refactor(BootSnapshot): allow non-trivially-copyable Settings

### DIFF
--- a/src/Utils/BootSnapshot.h
+++ b/src/Utils/BootSnapshot.h
@@ -32,19 +32,20 @@ namespace Util::Settings
 			table_(table.data()), tableSize_(N)
 		{
 			static_assert(std::is_standard_layout_v<SettingsT>, "BootSnapshot requires standard-layout Settings for offsetof-based tables.");
-			static_assert(std::is_trivially_copyable_v<SettingsT>, "BootSnapshot requires trivially-copyable Settings.");
+			static_assert(std::is_copy_assignable_v<SettingsT>, "BootSnapshot requires copy-assignable Settings.");
 		}
 
-		void Latch(const SettingsT& live) noexcept
+		void Latch(const SettingsT& live)
 		{
-			// Byte-wise copy so padding bytes are reproduced verbatim. Assignment
-			// of a trivially-copyable struct copies the object representation
-			// (which the C++ standard guarantees for trivially-copyable types),
-			// but memcpy makes that intent explicit and removes any compiler
-			// latitude that might leave padding indeterminate — `HasPendingChange`
-			// uses memcmp on field slices, so any padding-byte drift would
-			// surface as a false-positive diff.
-			std::memcpy(&bootCopy_, &live, sizeof(SettingsT));
+			// Copy-assign so non-trivial members (e.g. std::string formula
+			// fields in ShadowCasterManager::Settings) deep-copy correctly.
+			// Trivially-copyable Settings work the same way -- the compiler
+			// emits memcpy-equivalent code for trivially-copyable assignment.
+			// Registered RESTART fields are still expected to be trivially
+			// comparable (the per-field HasPendingChange uses memcmp on the
+			// offset+size slice), but unregistered non-trivial members are
+			// free to live alongside them in the outer Settings struct.
+			bootCopy_ = live;
 			latched_ = true;
 		}
 

--- a/src/Utils/BootSnapshot.h
+++ b/src/Utils/BootSnapshot.h
@@ -7,6 +7,7 @@
 #include <span>
 #include <string_view>
 #include <type_traits>
+#include <utility>
 
 namespace Util::Settings
 {
@@ -33,23 +34,31 @@ namespace Util::Settings
 		{
 			static_assert(std::is_standard_layout_v<SettingsT>, "BootSnapshot requires standard-layout Settings for offsetof-based tables.");
 			static_assert(std::is_copy_assignable_v<SettingsT>, "BootSnapshot requires copy-assignable Settings.");
+			static_assert(std::is_default_constructible_v<SettingsT>,
+				"BootSnapshot requires default-constructible Settings (bootCopy_ default-inits and detail::MemberOffset constructs a temporary).");
 		}
 
-		void Latch(const SettingsT& live)
+		void Latch(const SettingsT& live) noexcept(std::is_nothrow_copy_assignable_v<SettingsT>)
 		{
-			// Copy-assign so non-trivial members (e.g. std::string formula
-			// fields in ShadowCasterManager::Settings) deep-copy correctly.
-			// Trivially-copyable Settings work the same way -- the compiler
-			// emits memcpy-equivalent code for trivially-copyable assignment.
-			// Registered RESTART fields are still expected to be trivially
-			// comparable (the per-field HasPendingChange uses memcmp on the
-			// offset+size slice), but unregistered non-trivial members are
-			// free to live alongside them in the outer Settings struct.
-			bootCopy_ = live;
+			if constexpr (std::is_trivially_copyable_v<SettingsT>) {
+				// Trivially-copyable fast path: memcpy preserves padding bytes
+				// verbatim. Matters when a registered restart field's *type*
+				// contains padding -- HasPendingChange's memcmp would otherwise
+				// see false-positive diffs from uninitialized padding bytes.
+				std::memcpy(&bootCopy_, &live, sizeof(SettingsT));
+			} else {
+				// Copy-assign for Settings with non-trivial members (e.g. the
+				// std::string formula fields in ShadowCasterManager::Settings).
+				// Registered restart fields must still be trivially comparable
+				// for HasPendingChange's per-field memcmp to be meaningful;
+				// std::string in the outer struct is fine as long as it isn't
+				// registered (it isn't -- formulas are runtime-tunable).
+				bootCopy_ = live;
+			}
 			latched_ = true;
 		}
 
-		void LatchIfNeeded(const SettingsT& live) noexcept
+		void LatchIfNeeded(const SettingsT& live) noexcept(noexcept(std::declval<BootSnapshot&>().Latch(live)))
 		{
 			if (!latched_) {
 				Latch(live);

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -4,8 +4,8 @@
 #include <cstdio>
 #include <functional>
 #include <imgui.h>
-#include <string>
 #include <span>
+#include <string>
 #include <type_traits>
 #include <vector>
 #include <windows.h>  // For WPARAM and virtual key constants
@@ -964,7 +964,7 @@ namespace Util
 	namespace UI
 	{
 		template <typename SettingsT, typename T>
-		inline void DrawSettingDiff(const Util::Settings::BootSnapshot<SettingsT>& snapshot, const SettingsT& live, T SettingsT::*field)
+		inline void DrawSettingDiff(const Util::Settings::BootSnapshot<SettingsT>& snapshot, const SettingsT& live, T SettingsT::* field)
 		{
 			if (!snapshot.IsLatched()) {
 				return;
@@ -1023,6 +1023,36 @@ namespace Util
 					Util::Text::RestartNeeded("Pending restart: %s changed.", field.label);
 				}
 			}
+		}
+
+		// One-call wrapper for a restart-gated ImGui control. Call IMMEDIATELY
+		// AFTER the control (Checkbox / SliderInt / Combo / etc.) so
+		// ImGui::IsItemHovered targets that control. Does two things:
+		//   1. If hovered, sets a tooltip with the standard
+		//      "Requires a game restart to change." suffix appended to
+		//      `tooltipBody` (pass nullptr/empty for suffix-only).
+		//   2. Calls DrawSettingDiff to render the "Pending restart" banner
+		//      when the live value diverges from the boot snapshot.
+		//
+		// Saves three lines of boilerplate per call site and prevents the
+		// standard suffix or the diff-banner call from being forgotten /
+		// drifting in wording. Use plain DrawSettingDiff for controls whose
+		// tooltip needs custom formatting (e.g. dynamic VRAM projections)
+		// where the standard suffix doesn't fit cleanly.
+		template <typename SettingsT, typename T>
+		inline void RestartGatedAnnotate(const Util::Settings::BootSnapshot<SettingsT>& snapshot,
+			const SettingsT& live,
+			T SettingsT::* field,
+			const char* tooltipBody = nullptr)
+		{
+			if (ImGui::IsItemHovered()) {
+				if (tooltipBody && tooltipBody[0]) {
+					ImGui::SetTooltip("%s\nRequires a game restart to change.", tooltipBody);
+				} else {
+					ImGui::SetTooltip("Requires a game restart to change.");
+				}
+			}
+			DrawSettingDiff(snapshot, live, field);
 		}
 	}
 

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <algorithm>
 #include <cfloat>  // For FLT_MAX
+#include <concepts>
 #include <cstdio>
 #include <functional>
 #include <imgui.h>
@@ -1026,31 +1027,53 @@ namespace Util
 		}
 
 		// One-call wrapper for a restart-gated ImGui control. Call IMMEDIATELY
-		// AFTER the control (Checkbox / SliderInt / Combo / etc.) so
-		// ImGui::IsItemHovered targets that control. Does two things:
-		//   1. If hovered, sets a tooltip with the standard
-		//      "Requires a game restart to change." suffix appended to
-		//      `tooltipBody` (pass nullptr/empty for suffix-only).
-		//   2. Calls DrawSettingDiff to render the "Pending restart" banner
-		//      when the live value diverges from the boot snapshot.
+		// AFTER the control (Checkbox / SliderInt / Combo / etc.) so the
+		// HoverTooltipWrapper attaches to that control. Does two things:
+		//   1. If hovered, renders a tooltip via HoverTooltipWrapper (the
+		//      codebase's dominant tooltip pattern, used 296+ times -- gives
+		//      a consistent Subtext font role and viewport-clamped placement)
+		//      with the standard "Requires a game restart to change." suffix
+		//      appended after the caller-supplied body.
+		//   2. Calls DrawSettingDiff outside the hover scope to render the
+		//      "Pending restart" banner when the live value diverges from
+		//      the boot snapshot.
 		//
-		// Saves three lines of boilerplate per call site and prevents the
-		// standard suffix or the diff-banner call from being forgotten /
-		// drifting in wording. Use plain DrawSettingDiff for controls whose
-		// tooltip needs custom formatting (e.g. dynamic VRAM projections)
-		// where the standard suffix doesn't fit cleanly.
+		// Two overloads:
+		//   - `const char* body` for the simple single-string case.
+		//   - Callable `body` for multi-line tooltips that already use
+		//     HoverTooltipWrapper-style content (multiple ImGui::Text /
+		//     TextWrapped calls). The callable runs inside the
+		//     HoverTooltipWrapper RAII scope so callers can use any ImGui
+		//     text primitive.
+		//
+		// Pass nullptr / empty body to render just the suffix.
 		template <typename SettingsT, typename T>
 		inline void RestartGatedAnnotate(const Util::Settings::BootSnapshot<SettingsT>& snapshot,
 			const SettingsT& live,
 			T SettingsT::* field,
 			const char* tooltipBody = nullptr)
 		{
-			if (ImGui::IsItemHovered()) {
+			if (auto _tt = Util::HoverTooltipWrapper()) {
 				if (tooltipBody && tooltipBody[0]) {
-					ImGui::SetTooltip("%s\nRequires a game restart to change.", tooltipBody);
-				} else {
-					ImGui::SetTooltip("Requires a game restart to change.");
+					ImGui::TextUnformatted(tooltipBody);
+					ImGui::Spacing();
 				}
+				ImGui::TextUnformatted("Requires a game restart to change.");
+			}
+			DrawSettingDiff(snapshot, live, field);
+		}
+
+		template <typename SettingsT, typename T, typename Body>
+			requires std::invocable<Body>
+		inline void RestartGatedAnnotate(const Util::Settings::BootSnapshot<SettingsT>& snapshot,
+			const SettingsT& live,
+			T SettingsT::* field,
+			Body&& body)
+		{
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				body();
+				ImGui::Spacing();
+				ImGui::TextUnformatted("Requires a game restart to change.");
 			}
 			DrawSettingDiff(snapshot, live, field);
 		}

--- a/tests/cpp/test_bootsnapshot.cpp
+++ b/tests/cpp/test_bootsnapshot.cpp
@@ -5,6 +5,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <cstdint>
+#include <string>
 
 namespace
 {
@@ -60,4 +61,56 @@ TEST_CASE("BootSnapshot exposes field metadata by member", "[bootsnapshot]")
 	REQUIRE(info != nullptr);
 	REQUIRE(std::string(info->jsonKey) == "enabled");
 	REQUIRE(std::string(info->label) == "Enabled");
+}
+
+namespace
+{
+	// Settings with a non-trivial member (std::string) -- not trivially-
+	// copyable but still copy-assignable. Mirrors real cases like
+	// ShadowCasterManager::Settings which carries exprtk formula strings
+	// alongside the POD restart-gated fields.
+	struct SettingsWithString
+	{
+		int32_t shadowLightCount = 0;
+		bool enabled = false;
+		std::string formula = "default";  // not registered as restart-gated
+	};
+
+	inline constexpr Util::Settings::RestartTable<SettingsWithString, 2> kStringFields{ {
+		UTIL_RESTART_FIELD(SettingsWithString, shadowLightCount, "Shadow Light Count"),
+		UTIL_RESTART_FIELD(SettingsWithString, enabled, "Enabled"),
+	} };
+}
+
+TEST_CASE("BootSnapshot deep-copies non-trivial members on Latch", "[bootsnapshot]")
+{
+	// Regression: the original BootSnapshot static_asserted trivially-copyable
+	// and Latch() used memcpy, which would shallow-copy std::string internals
+	// (corrupting the boot snapshot's string when the live string later
+	// reallocated). After the relaxation, Latch uses copy-assign so the
+	// non-trivial member is deep-copied. The POD restart-gated fields still
+	// drive HasPendingChange via memcmp.
+	Util::Settings::BootSnapshot<SettingsWithString> snap{ kStringFields };
+	SettingsWithString boot{};
+	boot.shadowLightCount = 16;
+	boot.enabled = true;
+	boot.formula = "lightradius * lightintensity";
+
+	snap.Latch(boot);
+	REQUIRE(snap.IsLatched());
+	REQUIRE(snap.Boot(&SettingsWithString::shadowLightCount) == 16);
+	REQUIRE(snap.Boot(&SettingsWithString::enabled) == true);
+
+	// Mutating the live struct (including reallocating its string) must NOT
+	// disturb the boot copy or produce false-positive diffs for unregistered
+	// fields. Force a string reallocation by growing it well past SSO size.
+	SettingsWithString live = boot;
+	live.formula = std::string(256, 'x');
+	REQUIRE_FALSE(snap.HasPendingChange(live, &SettingsWithString::shadowLightCount));
+	REQUIRE_FALSE(snap.HasPendingChange(live, &SettingsWithString::enabled));
+
+	// Now flip a registered POD field; the diff fires.
+	live.shadowLightCount = 32;
+	REQUIRE(snap.HasPendingChange(live, &SettingsWithString::shadowLightCount));
+	REQUIRE_FALSE(snap.HasPendingChange(live, &SettingsWithString::enabled));
 }

--- a/tests/cpp/test_bootsnapshot.cpp
+++ b/tests/cpp/test_bootsnapshot.cpp
@@ -94,23 +94,34 @@ TEST_CASE("BootSnapshot deep-copies non-trivial members on Latch", "[bootsnapsho
 	SettingsWithString boot{};
 	boot.shadowLightCount = 16;
 	boot.enabled = true;
-	boot.formula = "lightradius * lightintensity";
+	const std::string originalFormula = "lightradius * lightintensity";
+	boot.formula = originalFormula;
 
 	snap.Latch(boot);
 	REQUIRE(snap.IsLatched());
 	REQUIRE(snap.Boot(&SettingsWithString::shadowLightCount) == 16);
 	REQUIRE(snap.Boot(&SettingsWithString::enabled) == true);
+	// Read the snapshot's std::string directly. Catches shallow-copy
+	// regressions: if Latch were still doing a memcpy of SettingsWithString,
+	// the boot copy would hold a stale pointer into live.formula's heap
+	// buffer, and reading it (especially after live.formula reallocates)
+	// would crash or return garbage. The POD-only assertions don't cover
+	// this on their own.
+	REQUIRE(snap.Boot(&SettingsWithString::formula) == originalFormula);
 
 	// Mutating the live struct (including reallocating its string) must NOT
 	// disturb the boot copy or produce false-positive diffs for unregistered
-	// fields. Force a string reallocation by growing it well past SSO size.
+	// fields. Force a string reallocation by growing it well past SSO size,
+	// then verify the boot copy's string is unchanged.
 	SettingsWithString live = boot;
 	live.formula = std::string(256, 'x');
 	REQUIRE_FALSE(snap.HasPendingChange(live, &SettingsWithString::shadowLightCount));
 	REQUIRE_FALSE(snap.HasPendingChange(live, &SettingsWithString::enabled));
+	REQUIRE(snap.Boot(&SettingsWithString::formula) == originalFormula);
 
 	// Now flip a registered POD field; the diff fires.
 	live.shadowLightCount = 32;
 	REQUIRE(snap.HasPendingChange(live, &SettingsWithString::shadowLightCount));
 	REQUIRE_FALSE(snap.HasPendingChange(live, &SettingsWithString::enabled));
+	REQUIRE(snap.Boot(&SettingsWithString::formula) == originalFormula);
 }


### PR DESCRIPTION
## Summary

Two related changes to make `Util::Settings::BootSnapshot` and the restart-gated UI flow easier to adopt across features.

### 1. Allow non-trivially-copyable Settings

- Relax `BootSnapshot`'s `static_assert(is_trivially_copyable_v)` to `is_copy_assignable_v` so `Settings` structs with non-POD members (e.g. `std::string`) can be used.
- Switch `Latch` from `memcpy` to copy-assign so non-trivial members deep-copy correctly. Compilers still emit memcpy-equivalent code for trivially-copyable assignment, so existing adopters (Upscaling, VolumetricLighting, DynamicCubemaps, etc.) are unaffected.
- Add a regression test that latches a struct containing a `std::string`, reallocates the live string past SSO, and confirms the boot copy and registered POD fields stay independent.

**Motivation:** `ShadowCasterManager::Settings` carries three exprtk formula strings (`ScoreFormula`, `RedrawIntervalFormula`, `RedrawBudgetFormula`) alongside its restart-gated POD fields (`Enabled`, `ShadowLightCount`). The original trivially-copyable requirement blocked adoption — `memcpy` of the Settings struct would shallow-copy `std::string` internals and leave the boot copy pointing at the live string's heap buffer.

After this change, BootSnapshot works for any Settings type that satisfies the standard's copy-assignable concept. Registered restart fields are still expected to be trivially comparable (per-field `HasPendingChange` uses memcmp on the offset+size slice), but unregistered non-trivial members can coexist freely.

### 2. Add `Util::UI::RestartGatedAnnotate` helper

One-call wrapper that pairs the standard `"Requires a game restart to change."` tooltip suffix with the `DrawSettingDiff` pending banner. Sits next to `DrawSettingDiff` / `DrawPendingBanners`.

**Before:**
```cpp
ImGui::Checkbox("Convert Excess", &settings.field);
if (ImGui::IsItemHovered())
    ImGui::SetTooltip("Body text. Requires a game restart to change.");
Util::UI::DrawSettingDiff(snapshot, settings, &Settings::field);
```

**After:**
```cpp
ImGui::Checkbox("Convert Excess", &settings.field);
Util::UI::RestartGatedAnnotate(snapshot, settings, &Settings::field, "Body text.");
```

Saves three lines per restart-gated control, enforces the standard suffix (no per-feature wording drift), and the diff banner can't be forgotten. Plain `DrawSettingDiff` stays available for controls whose tooltip needs custom formatting (e.g. live VRAM projections).

## Test plan

- [x] New `BootSnapshot deep-copies non-trivial members on Latch` test: latches a struct with a `std::string` member, mutates the live string past SSO (256 chars), and asserts:
  - Boot snapshot of POD fields is unchanged
  - `HasPendingChange` for unmodified POD fields returns false
  - `HasPendingChange` fires only when a registered POD field changes
- [x] All 21 cpp_tests pass (73 assertions)
- [x] `RestartGatedAnnotate` is a thin composition of `DrawSettingDiff` (data-tested) and ImGui tooltip — no new logic to test in isolation; covered indirectly by the BootSnapshot tests.

## Follow-up

A separate PR on `shadow-limit-fix` adopts both pieces in `ShadowCasterManager` — replacing the manual `s_bootEnabled` / `s_bootEnabledCaptured` pair with a `BootSnapshot<Settings>`, wiring `LightLimitFix`'s Feature.h restart-introspection virtuals to it, and using `RestartGatedAnnotate` at 6 call sites in DrawSettings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips and status indicators for settings requiring a game restart, informing users when changes will take effect.

* **Improvements**
  * Enhanced settings management to correctly handle complex data types, improving system robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/open-shaders/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->