### PR TITLE
feat(llf): expose contact-shadow settings

### DIFF
--- a/features/Light Limit Fix/Shaders/Features/LightLimitFix.ini
+++ b/features/Light Limit Fix/Shaders/Features/LightLimitFix.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 3-1-0
+Version = 3-2-0
 
 [Nexus]
 autoupload = false

--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -73,17 +73,24 @@ namespace LightLimitFix
 	// linearized value; reject occluders there since the viewmodel isn't in the world.
 	static const float CONTACT_SHADOW_FIRST_PERSON_MAX_DEPTH = 16.5;
 
+	// Reference view-space depth for perspective-correct stride. At/below this depth,
+	// stride matches its prior view-space meaning; beyond it, stride and the depth-delta
+	// band scale linearly with depth so each step covers ~constant screen-space distance
+	// and the shadow-thickness band tracks the same screen-space extent.
+	static const float CONTACT_SHADOW_REFERENCE_DEPTH = 100.0;
+
 	float ContactShadows(float3 viewPosition, float noise2D, float3 lightDirectionVS, uint contactShadowSteps, uint a_eyeIndex = 0)
 	{
 		if (contactShadowSteps == 0)
 			return 1.0;
 
-		float depthDeltaThickness = SharedData::lightLimitFixSettings.ContactShadowThickness;
-		float depthDeltaFade = SharedData::lightLimitFixSettings.ContactShadowDepthFade;
-
-		// Scale per-step march length in view-space units. Larger -> longer shadow reach,
-		// coarser detail. Tunable so users can trade reach vs. precision.
-		lightDirectionVS *= SharedData::lightLimitFixSettings.ContactShadowStride;
+		// Perspective-correct stride: scale view-space step length with depth so each step
+		// covers ~constant screen-space distance. Inverse-scale the thickness/fade band so
+		// the depth-delta window tracks the same screen-space extent across depths.
+		float perspectiveScale = max(viewPosition.z, CONTACT_SHADOW_REFERENCE_DEPTH) / CONTACT_SHADOW_REFERENCE_DEPTH;
+		float depthDeltaThickness = SharedData::lightLimitFixSettings.ContactShadowThickness / perspectiveScale;
+		float depthDeltaFade = SharedData::lightLimitFixSettings.ContactShadowDepthFade / perspectiveScale;
+		lightDirectionVS *= SharedData::lightLimitFixSettings.ContactShadowStride * perspectiveScale;
 
 		// Offset starting position with interleaved gradient noise
 		viewPosition += lightDirectionVS * noise2D;

--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -69,11 +69,8 @@ namespace LightLimitFix
 #endif
 	}
 
-	// Skyrim's first-person viewmodel is rendered in a compressed depth range
-	// (linearized depth < this value). Contact shadows against viewmodel geometry
-	// produce wrong results (the viewmodel doesn't sit in the world), so we reject
-	// occluders whose depth falls in that range. A proper viewmodel stencil pass
-	// would be more robust but is out of scope here.
+	// Skyrim's first-person viewmodel renders in a compressed depth range below this
+	// linearized value; reject occluders there since the viewmodel isn't in the world.
 	static const float CONTACT_SHADOW_FIRST_PERSON_MAX_DEPTH = 16.5;
 
 	float ContactShadows(float3 viewPosition, float noise2D, float3 lightDirectionVS, uint contactShadowSteps, uint a_eyeIndex = 0)

--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -69,15 +69,24 @@ namespace LightLimitFix
 #endif
 	}
 
+	// Skyrim's first-person viewmodel is rendered in a compressed depth range
+	// (linearized depth < this value). Contact shadows against viewmodel geometry
+	// produce wrong results (the viewmodel doesn't sit in the world), so we reject
+	// occluders whose depth falls in that range. A proper viewmodel stencil pass
+	// would be more robust but is out of scope here.
+	static const float CONTACT_SHADOW_FIRST_PERSON_MAX_DEPTH = 16.5;
+
 	float ContactShadows(float3 viewPosition, float noise2D, float3 lightDirectionVS, uint contactShadowSteps, uint a_eyeIndex = 0)
 	{
 		if (contactShadowSteps == 0)
 			return 1.0;
 
-		float2 depthDeltaMult = float2(0.20, 0.05);
+		float depthDeltaThickness = SharedData::lightLimitFixSettings.ContactShadowThickness;
+		float depthDeltaFade = SharedData::lightLimitFixSettings.ContactShadowDepthFade;
 
-		// Extend contact shadow distance
-		lightDirectionVS *= 2.0;
+		// Scale per-step march length in view-space units. Larger -> longer shadow reach,
+		// coarser detail. Tunable so users can trade reach vs. precision.
+		lightDirectionVS *= SharedData::lightLimitFixSettings.ContactShadowStride;
 
 		// Offset starting position with interleaved gradient noise
 		viewPosition += lightDirectionVS * noise2D;
@@ -99,8 +108,8 @@ namespace LightLimitFix
 
 			// Difference between the current ray distance and the marched light
 			float depthDelta = viewPosition.z - rayDepth;
-			if (rayDepth > 16.5)  // First person
-				contactShadow = max(contactShadow, saturate(depthDelta * depthDeltaMult.x) - saturate(depthDelta * depthDeltaMult.y));
+			if (rayDepth > CONTACT_SHADOW_FIRST_PERSON_MAX_DEPTH)
+				contactShadow = max(contactShadow, saturate(depthDelta * depthDeltaThickness) - saturate(depthDelta * depthDeltaFade));
 			if (contactShadow == 1.0)
 				break;
 		}

--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -47,19 +47,17 @@ namespace LightLimitFix
 		return IsSaturated(value.x) && IsSaturated(value.y);
 	}
 
-	// Chooses the contact-shadow noise sample coordinate. In VR we derive it
-	// from screenUV (which FrameBuffer::ViewToUV already returns per-eye via
-	// CameraProj[eye]) so both eyes sample the same noise pattern at the same
-	// world position — using the raw rasterized pixel position in VR makes
-	// each eye hash a different value, producing per-eye jitter that reads as
-	// flicker on contact-shadow recipients.
+	// Per-eye stereo-stable IGN coord. In VR we use screenUV (per-eye via
+	// CameraProj[eye]) instead of SV_Position so both eyes hash the same
+	// value at the same world pixel — SV_Position differs between eyes in
+	// a packed stereo buffer, producing per-eye jitter that reads as flicker
+	// on contact-shadow recipients.
 	//
-	// BufferDim.x is the full packed stereo width (State::UpdateSharedData
-	// reads it from the kMAIN texture, which spans both eyes side-by-side),
-	// so we halve X in VR to match the per-eye pixel grid. Without the
-	// halving, the per-eye sample steps by ~2 pixels in X — still stereo-
-	// consistent, but at half the effective noise resolution. Flat keeps the
-	// raw pixel position to match the original implementation byte-for-byte.
+	// BufferDim.x is the full packed stereo width (kMAIN spans both eyes
+	// side-by-side), so the 0.5 factor lands us on the per-eye integer
+	// pixel grid — same IGN frequency as flat mode for a buffer sized
+	// (BufferDim.x/2, BufferDim.y). Do not drop the 0.5: that over-samples
+	// IGN by ~2x in X, giving a higher-frequency noise pattern, not lower.
 	float2 GetContactShadowNoiseCoord(float2 screenPosition, float2 screenUV)
 	{
 #if defined(VR)

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -76,9 +76,17 @@ namespace SharedData
 	struct LightLimitFixSettings
 	{
 		uint EnableContactShadows;
+		uint ContactShadowMaxSteps;
+		float ContactShadowMaxDistance;
+		float ContactShadowStride;
+		float ContactShadowThickness;
+		float ContactShadowDepthFade;
+		float ContactShadowMinIntensity;
 		uint EnableLightsVisualisation;
 		uint LightsVisualisationMode;
 		float pad0;
+		float pad1;
+		float pad2;
 		uint4 ClusterSize;
 	};
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2758,8 +2758,16 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		// lights should always raymarch regardless of falloff to preserve close, weak
 		// strict-light contact under bias.
 		const bool isClusteredLight = lightIndex >= LightLimitFix::NumStrictLights;
+#			if defined(ISL)
+		// ISL's GetAttenuation isn't [0,1]-normalized; derive a matching normalized
+		// 1 - (d/r)^2 falloff just for the MinIntensity gate so the threshold has
+		// the same semantics as the non-ISL path.
 		float falloffFactor = saturate(lightDist * light.invRadius);
 		float normalizedFalloff = 1.0 - falloffFactor * falloffFactor;
+#			else
+		// Non-ISL intensityMultiplier above already IS the normalized 1 - (d/r)^2.
+		float normalizedFalloff = intensityMultiplier;
+#			endif
 		const bool passesIntensityGate = !isClusteredLight ||
 		                                 (normalizedFalloff > SharedData::lightLimitFixSettings.ContactShadowMinIntensity);
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2688,7 +2688,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	[branch] if (SharedData::lightLimitFixSettings.EnableContactShadows)
 	{
 		contactShadowSteps = round(SharedData::lightLimitFixSettings.ContactShadowMaxSteps *
-		                           (1.0 - saturate(viewPosition.z / SharedData::lightLimitFixSettings.ContactShadowMaxDistance)));
+								   (1.0 - saturate(viewPosition.z / SharedData::lightLimitFixSettings.ContactShadowMaxDistance)));
 		// The helper stays stereo-stable in VR — see
 		// LightLimitFix::GetContactShadowNoiseCoord for the eye-buffer math.
 		contactShadowNoise = Random::InterleavedGradientNoise(
@@ -2743,14 +2743,32 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 #			if defined(DEFERRED)
 		// contactShadowSteps > 0 implies the feature is on AND viewPosition is closer than
-		// MaxDistance; the MinIntensity gate skips weak lights whose shadow contribution is
-		// already dimmed past visibility, avoiding the matrix multiply + raymarch for them.
+		// MaxDistance. The MinIntensity gate skips weak clustered lights whose shadow
+		// contribution is already dimmed past visibility, avoiding the matrix multiply +
+		// raymarch for them.
+		//
+		// Use a SEPARATE normalized falloff for the cutoff -- intensityMultiplier above
+		// is path-dependent (ISL returns a non-normalized GetAttenuation() while non-ISL
+		// returns a normalized 1-(d/r)^2). Comparing intensityMultiplier against a 0..1
+		// threshold would mean different things in the two permutations. The normalized
+		// falloff below is the same `1 - (lightDist/radius)^2` clamped to [0,1] across
+		// both paths, so the threshold's semantics stay consistent.
+		//
+		// Gating is scoped to CLUSTERED lights (lightIndex >= NumStrictLights) -- strict
+		// lights should always raymarch regardless of falloff to preserve close, weak
+		// strict-light contact under bias.
+		const bool isClusteredLight = lightIndex >= LightLimitFix::NumStrictLights;
+		float normalizedFalloff = saturate(1.0 - lightDist * light.invRadius);
+		normalizedFalloff *= normalizedFalloff;
+		const bool passesIntensityGate = !isClusteredLight ||
+		                                 (normalizedFalloff > SharedData::lightLimitFixSettings.ContactShadowMinIntensity);
+
 		[branch] if (
 			contactShadowSteps > 0 &&
 			!(light.lightFlags & LightLimitFix::LightFlags::Simple) &&
 			shadowComponent != 0.0 &&
 			lightAngle > 0.0 &&
-			intensityMultiplier > SharedData::lightLimitFixSettings.ContactShadowMinIntensity)
+			passesIntensityGate)
 		{
 			// Derive view-space position via CameraView; the Light struct only carries positionWS
 			// (camera-relative) so the matrix multiply here is the cheapest path until positionVS

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2742,22 +2742,19 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float contactShadow = 1.0;
 
 #			if defined(DEFERRED)
-		// Skip contact-shadow raymarch for lights too weak at this pixel to produce a visible
-		// shadow. intensityMultiplier already captures (1 - (lightDist/radius)^2); when it
-		// drops below MinIntensity, the shadow contribution is dominated by the dimming and
-		// not worth the per-step depth fetches. Typical clustered scenes have many lights at
-		// their reach edge — this cutoff skips them before the matrix multiply and raymarch.
+		// contactShadowSteps > 0 implies the feature is on AND viewPosition is closer than
+		// MaxDistance; the MinIntensity gate skips weak lights whose shadow contribution is
+		// already dimmed past visibility, avoiding the matrix multiply + raymarch for them.
 		[branch] if (
-			SharedData::lightLimitFixSettings.EnableContactShadows &&
+			contactShadowSteps > 0 &&
 			!(light.lightFlags & LightLimitFix::LightFlags::Simple) &&
 			shadowComponent != 0.0 &&
 			lightAngle > 0.0 &&
 			intensityMultiplier > SharedData::lightLimitFixSettings.ContactShadowMinIntensity)
 		{
-			// The current LightLimitFix Light struct stores positionWS only; derive view-space
-			// from CameraView so the raymarch direction matches viewPosition. The pre-removal
-			// call site referenced light.positionVS, but that field did not exist on the Light
-			// struct even then — the original code was commented out and unreachable.
+			// Derive view-space position via CameraView; the Light struct only carries positionWS
+			// (camera-relative) so the matrix multiply here is the cheapest path until positionVS
+			// is added to the struct + populated CPU-side.
 			float3 lightPositionVS = mul(FrameBuffer::CameraView[eyeIndex], float4(light.positionWS[eyeIndex].xyz, 1)).xyz;
 			float3 normalizedLightDirectionVS = normalize(lightPositionVS - viewPosition.xyz);
 			contactShadow = LightLimitFix::ContactShadows(viewPosition, contactShadowNoise, normalizedLightDirectionVS, contactShadowSteps, eyeIndex);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2758,8 +2758,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		// lights should always raymarch regardless of falloff to preserve close, weak
 		// strict-light contact under bias.
 		const bool isClusteredLight = lightIndex >= LightLimitFix::NumStrictLights;
-		float normalizedFalloff = saturate(1.0 - lightDist * light.invRadius);
-		normalizedFalloff *= normalizedFalloff;
+		float falloffFactor = saturate(lightDist * light.invRadius);
+		float normalizedFalloff = 1.0 - falloffFactor * falloffFactor;
 		const bool passesIntensityGate = !isClusteredLight ||
 		                                 (normalizedFalloff > SharedData::lightLimitFixSettings.ContactShadowMinIntensity);
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2742,48 +2742,43 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float contactShadow = 1.0;
 
 #			if defined(DEFERRED)
-		// contactShadowSteps > 0 implies the feature is on AND viewPosition is closer than
-		// MaxDistance. The MinIntensity gate skips weak clustered lights whose shadow
-		// contribution is already dimmed past visibility, avoiding the matrix multiply +
-		// raymarch for them.
-		//
-		// Use a SEPARATE normalized falloff for the cutoff -- intensityMultiplier above
-		// is path-dependent (ISL returns a non-normalized GetAttenuation() while non-ISL
-		// returns a normalized 1-(d/r)^2). Comparing intensityMultiplier against a 0..1
-		// threshold would mean different things in the two permutations. The normalized
-		// falloff below is the same `1 - (lightDist/radius)^2` clamped to [0,1] across
-		// both paths, so the threshold's semantics stay consistent.
-		//
-		// Gating is scoped to CLUSTERED lights (lightIndex >= NumStrictLights) -- strict
-		// lights should always raymarch regardless of falloff to preserve close, weak
-		// strict-light contact under bias.
-		const bool isClusteredLight = lightIndex >= LightLimitFix::NumStrictLights;
-#			if defined(ISL)
-		// ISL's GetAttenuation isn't [0,1]-normalized; derive a matching normalized
-		// 1 - (d/r)^2 falloff just for the MinIntensity gate so the threshold has
-		// the same semantics as the non-ISL path.
-		float falloffFactor = saturate(lightDist * light.invRadius);
-		float normalizedFalloff = 1.0 - falloffFactor * falloffFactor;
-#			else
-		// Non-ISL intensityMultiplier above already IS the normalized 1 - (d/r)^2.
-		float normalizedFalloff = intensityMultiplier;
-#			endif
-		const bool passesIntensityGate = !isClusteredLight ||
-		                                 (normalizedFalloff > SharedData::lightLimitFixSettings.ContactShadowMinIntensity);
-
-		[branch] if (
-			contactShadowSteps > 0 &&
-			!(light.lightFlags & LightLimitFix::LightFlags::Simple) &&
-			shadowComponent != 0.0 &&
-			lightAngle > 0.0 &&
-			passesIntensityGate)
+		// Outer guard: contactShadowSteps > 0 covers both "feature off" and "pixel past
+		// MaxDistance", so all per-light intensity-gate math is paid only when a raymarch
+		// is actually possible. Without this, the falloff math fires for every clustered
+		// light even in the default-off case.
+		[branch] if (contactShadowSteps > 0)
 		{
-			// Derive view-space position via CameraView; the Light struct only carries positionWS
-			// (camera-relative) so the matrix multiply here is the cheapest path until positionVS
-			// is added to the struct + populated CPU-side.
-			float3 lightPositionVS = mul(FrameBuffer::CameraView[eyeIndex], float4(light.positionWS[eyeIndex].xyz, 1)).xyz;
-			float3 normalizedLightDirectionVS = normalize(lightPositionVS - viewPosition.xyz);
-			contactShadow = LightLimitFix::ContactShadows(viewPosition, contactShadowNoise, normalizedLightDirectionVS, contactShadowSteps, eyeIndex);
+			// Strict lights always raymarch -- skip the falloff math for them entirely.
+			// Clustered lights need a normalized falloff to compare against MinIntensity;
+			// derive it from intensityMultiplier on the non-ISL path (where it IS already
+			// 1 - (d/r)^2) and re-compute on the ISL path (where GetAttenuation isn't
+			// [0,1]-normalized, so the threshold would mean different things otherwise).
+			const bool isClusteredLight = lightIndex >= LightLimitFix::NumStrictLights;
+			bool passesIntensityGate = !isClusteredLight;
+			if (isClusteredLight) {
+#			if defined(ISL)
+				float falloffFactor = saturate(lightDist * light.invRadius);
+				passesIntensityGate = (1.0 - falloffFactor * falloffFactor) >
+				                      SharedData::lightLimitFixSettings.ContactShadowMinIntensity;
+#			else
+				passesIntensityGate = intensityMultiplier >
+				                      SharedData::lightLimitFixSettings.ContactShadowMinIntensity;
+#			endif
+			}
+
+			[branch] if (
+				!(light.lightFlags & LightLimitFix::LightFlags::Simple) &&
+				shadowComponent != 0.0 &&
+				lightAngle > 0.0 &&
+				passesIntensityGate)
+			{
+				// Derive view-space position via CameraView; the Light struct only carries positionWS
+				// (camera-relative) so the matrix multiply here is the cheapest path until positionVS
+				// is added to the struct + populated CPU-side.
+				float3 lightPositionVS = mul(FrameBuffer::CameraView[eyeIndex], float4(light.positionWS[eyeIndex].xyz, 1)).xyz;
+				float3 normalizedLightDirectionVS = normalize(lightPositionVS - viewPosition.xyz);
+				contactShadow = LightLimitFix::ContactShadows(viewPosition, contactShadowNoise, normalizedLightDirectionVS, contactShadowSteps, eyeIndex);
+			}
 		}
 #			endif
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2687,7 +2687,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float contactShadowNoise = 0.0;
 	[branch] if (SharedData::lightLimitFixSettings.EnableContactShadows)
 	{
-		contactShadowSteps = round(4.0 * (1.0 - saturate(viewPosition.z / 1024.0)));
+		contactShadowSteps = round(SharedData::lightLimitFixSettings.ContactShadowMaxSteps *
+		                           (1.0 - saturate(viewPosition.z / SharedData::lightLimitFixSettings.ContactShadowMaxDistance)));
 		// The helper stays stereo-stable in VR — see
 		// LightLimitFix::GetContactShadowNoiseCoord for the eye-buffer math.
 		contactShadowNoise = Random::InterleavedGradientNoise(
@@ -2741,11 +2742,17 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float contactShadow = 1.0;
 
 #			if defined(DEFERRED)
+		// Skip contact-shadow raymarch for lights too weak at this pixel to produce a visible
+		// shadow. intensityMultiplier already captures (1 - (lightDist/radius)^2); when it
+		// drops below MinIntensity, the shadow contribution is dominated by the dimming and
+		// not worth the per-step depth fetches. Typical clustered scenes have many lights at
+		// their reach edge — this cutoff skips them before the matrix multiply and raymarch.
 		[branch] if (
 			SharedData::lightLimitFixSettings.EnableContactShadows &&
 			!(light.lightFlags & LightLimitFix::LightFlags::Simple) &&
 			shadowComponent != 0.0 &&
-			lightAngle > 0.0)
+			lightAngle > 0.0 &&
+			intensityMultiplier > SharedData::lightLimitFixSettings.ContactShadowMinIntensity)
 		{
 			// The current LightLimitFix Light struct stores positionWS only; derive view-space
 			// from CameraView so the raymarch direction matches viewPosition. The pre-removal

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -30,7 +30,13 @@ void LightLimitFix::DrawSettings()
 	}
 
 	if (settings.EnableContactShadows && ImGui::TreeNode("Contact Shadow Tuning")) {
-		ImGui::SliderInt("Max Steps", (int*)&settings.ContactShadowMaxSteps, 1, 16, "%d", ImGuiSliderFlags_AlwaysClamp);
+		// SliderScalar with ImGuiDataType_U32 instead of `SliderInt + (int*)cast`:
+		// the cast violates strict aliasing (UB) and would also misinterpret any
+		// transient negative value inside ImGui before clamp. SliderScalar
+		// reads/writes the uint storage directly with explicit min/max bounds.
+		constexpr uint32_t kMinSteps = 1, kMaxSteps = 16;
+		ImGui::SliderScalar("Max Steps", ImGuiDataType_U32, &settings.ContactShadowMaxSteps,
+			&kMinSteps, &kMaxSteps, "%u", ImGuiSliderFlags_AlwaysClamp);
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Raymarch steps at zero depth. Higher = longer / more accurate contact shadows, linearly more cost.\nVR users should consider 2 to halve per-eye cost.");
 		}
@@ -57,7 +63,11 @@ void LightLimitFix::DrawSettings()
 
 		ImGui::SliderFloat("Min Light Intensity", &settings.ContactShadowMinIntensity, 0.0f, 1.0f, "%.2f");
 		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text("Skip contact shadows for clustered lights whose normalized intensity at the pixel is below this threshold. Higher = larger perf win, may drop subtle shadows from weak lights at their reach edge.");
+			ImGui::Text(
+				"Skip contact shadows for CLUSTERED lights whose normalized distance falloff "
+				"`1 - (lightDist/radius)^2` at the pixel is below this threshold. "
+				"Strict lights are always raymarched regardless of this threshold. "
+				"Higher = larger perf win, may drop subtle shadows from weak lights at their reach edge.");
 		}
 
 		ImGui::TreePop();
@@ -107,14 +117,23 @@ void LightLimitFix::DrawOverlay()
 
 LightLimitFix::PerFrame LightLimitFix::GetCommonBufferData()
 {
+	// Clamp contact-shadow settings to the slider ranges before they hit the
+	// constant buffer. The sliders enforce ImGuiSliderFlags_AlwaysClamp, but a
+	// malformed JSON config (hand-edited, mod conflict, or migration from a
+	// previous schema) can still arrive here with out-of-range values that
+	// would break shader math -- in particular ContactShadowMaxDistance is
+	// compared against a view-space depth, ContactShadowStride scales the
+	// raymarch length, and ContactShadowMaxSteps gates the loop count.
+	// Negative / NaN / wildly large values produce divisions, infinite loops,
+	// or visual corruption; clamp here so the shader can assume sane inputs.
 	PerFrame perFrame{};
 	perFrame.EnableContactShadows = settings.EnableContactShadows;
-	perFrame.ContactShadowMaxSteps = settings.ContactShadowMaxSteps;
-	perFrame.ContactShadowMaxDistance = settings.ContactShadowMaxDistance;
-	perFrame.ContactShadowStride = settings.ContactShadowStride;
-	perFrame.ContactShadowThickness = settings.ContactShadowThickness;
-	perFrame.ContactShadowDepthFade = settings.ContactShadowDepthFade;
-	perFrame.ContactShadowMinIntensity = settings.ContactShadowMinIntensity;
+	perFrame.ContactShadowMaxSteps = std::clamp<uint32_t>(settings.ContactShadowMaxSteps, 1u, 16u);
+	perFrame.ContactShadowMaxDistance = std::clamp(settings.ContactShadowMaxDistance, 64.0f, 4096.0f);
+	perFrame.ContactShadowStride = std::clamp(settings.ContactShadowStride, 0.5f, 8.0f);
+	perFrame.ContactShadowThickness = std::clamp(settings.ContactShadowThickness, 0.0f, 1.0f);
+	perFrame.ContactShadowDepthFade = std::clamp(settings.ContactShadowDepthFade, 0.0f, 1.0f);
+	perFrame.ContactShadowMinIntensity = std::clamp(settings.ContactShadowMinIntensity, 0.0f, 1.0f);
 	perFrame.EnableLightsVisualisation = settings.EnableLightsVisualisation;
 	perFrame.LightsVisualisationMode = settings.LightsVisualisationMode;
 	std::copy(clusterSize, clusterSize + 3, perFrame.ClusterSize);

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -8,6 +8,11 @@
 #include "Util.h"
 #include "Utils/ExternalEmittance.h"
 
+// EnableLightsVisualisation / LightsVisualisationMode are intentionally NOT
+// persisted -- they're debug toggles, and a user who enabled visualization
+// to inspect something shouldn't get stuck with it on after restart. The
+// _WITH_DEFAULT variant of the macro means omitted fields fall back to the
+// struct's default-member-initializers on load, which is the desired reset.
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	LightLimitFix::Settings,
 	EnableContactShadows,
@@ -16,9 +21,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ContactShadowStride,
 	ContactShadowThickness,
 	ContactShadowDepthFade,
-	ContactShadowMinIntensity,
-	EnableLightsVisualisation,
-	LightsVisualisationMode)
+	ContactShadowMinIntensity)
 
 static constexpr uint CLUSTER_MAX_LIGHTS = 128;
 static constexpr uint MAX_LIGHTS = 1024;

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -117,23 +117,30 @@ void LightLimitFix::DrawOverlay()
 
 LightLimitFix::PerFrame LightLimitFix::GetCommonBufferData()
 {
-	// Clamp contact-shadow settings to the slider ranges before they hit the
-	// constant buffer. The sliders enforce ImGuiSliderFlags_AlwaysClamp, but a
-	// malformed JSON config (hand-edited, mod conflict, or migration from a
-	// previous schema) can still arrive here with out-of-range values that
-	// would break shader math -- in particular ContactShadowMaxDistance is
-	// compared against a view-space depth, ContactShadowStride scales the
-	// raymarch length, and ContactShadowMaxSteps gates the loop count.
-	// Negative / NaN / wildly large values produce divisions, infinite loops,
-	// or visual corruption; clamp here so the shader can assume sane inputs.
+	// Sanitize contact-shadow settings before they hit the constant buffer. The
+	// sliders enforce ImGuiSliderFlags_AlwaysClamp, but a malformed JSON config
+	// (hand-edited, mod conflict, or migration from a previous schema) can still
+	// arrive here with out-of-range values that would break shader math --
+	// ContactShadowMaxDistance is compared against view-space depth,
+	// ContactShadowStride scales the raymarch length, and ContactShadowMaxSteps
+	// gates the loop count.
+	//
+	// std::clamp passes NaN through unchanged (every NaN comparison is false),
+	// so a NaN in the config would still poison the cbuffer. Reject non-finite
+	// values explicitly first; fall back to the lower bound on NaN/inf -- a
+	// corrupt config produces degraded but stable behavior rather than UB.
+	auto sanitizeFloat = [](float v, float lo, float hi) {
+		return std::isfinite(v) ? std::clamp(v, lo, hi) : lo;
+	};
+
 	PerFrame perFrame{};
 	perFrame.EnableContactShadows = settings.EnableContactShadows;
 	perFrame.ContactShadowMaxSteps = std::clamp<uint32_t>(settings.ContactShadowMaxSteps, 1u, 16u);
-	perFrame.ContactShadowMaxDistance = std::clamp(settings.ContactShadowMaxDistance, 64.0f, 4096.0f);
-	perFrame.ContactShadowStride = std::clamp(settings.ContactShadowStride, 0.5f, 8.0f);
-	perFrame.ContactShadowThickness = std::clamp(settings.ContactShadowThickness, 0.0f, 1.0f);
-	perFrame.ContactShadowDepthFade = std::clamp(settings.ContactShadowDepthFade, 0.0f, 1.0f);
-	perFrame.ContactShadowMinIntensity = std::clamp(settings.ContactShadowMinIntensity, 0.0f, 1.0f);
+	perFrame.ContactShadowMaxDistance = sanitizeFloat(settings.ContactShadowMaxDistance, 64.0f, 4096.0f);
+	perFrame.ContactShadowStride = sanitizeFloat(settings.ContactShadowStride, 0.5f, 8.0f);
+	perFrame.ContactShadowThickness = sanitizeFloat(settings.ContactShadowThickness, 0.0f, 1.0f);
+	perFrame.ContactShadowDepthFade = sanitizeFloat(settings.ContactShadowDepthFade, 0.0f, 1.0f);
+	perFrame.ContactShadowMinIntensity = sanitizeFloat(settings.ContactShadowMinIntensity, 0.0f, 1.0f);
 	perFrame.EnableLightsVisualisation = settings.EnableLightsVisualisation;
 	perFrame.LightsVisualisationMode = settings.LightsVisualisationMode;
 	std::copy(clusterSize, clusterSize + 3, perFrame.ClusterSize);

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -56,27 +56,30 @@ void LightLimitFix::DrawSettings()
 			ImGui::Text("Raymarch steps at zero depth. Higher = longer / more accurate contact shadows, linearly more cost.\nVR users should consider 2 to halve per-eye cost.");
 		}
 
-		ImGui::SliderFloat("Max Distance", &settings.ContactShadowMaxDistance, 64.0f, 4096.0f, "%.0f");
+		// AlwaysClamp on every float slider too: without it, Ctrl+Click text entry can
+		// land arbitrary out-of-range values in settings before GetCommonBufferData's
+		// boundary clamp catches them at the GPU side.
+		ImGui::SliderFloat("Max Distance", &settings.ContactShadowMaxDistance, 64.0f, 4096.0f, "%.0f", ImGuiSliderFlags_AlwaysClamp);
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("View-space depth at which contact shadows fade to zero steps. Avoids paying for shadows on distant surfaces where they don't read.");
 		}
 
-		ImGui::SliderFloat("Stride", &settings.ContactShadowStride, 0.5f, 8.0f, "%.2f");
+		ImGui::SliderFloat("Stride", &settings.ContactShadowStride, 0.5f, 8.0f, "%.2f", ImGuiSliderFlags_AlwaysClamp);
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Per-step march length in view-space units at near depth (auto-scales linearly past ~100 units so far surfaces don't undersample). Larger = longer screen-space reach with coarser detail.");
 		}
 
-		ImGui::SliderFloat("Thickness", &settings.ContactShadowThickness, 0.0f, 1.0f, "%.3f");
+		ImGui::SliderFloat("Thickness", &settings.ContactShadowThickness, 0.0f, 1.0f, "%.3f", ImGuiSliderFlags_AlwaysClamp);
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Depth-delta multiplier for shadow onset. Larger = darker contact at occluder edges.");
 		}
 
-		ImGui::SliderFloat("Depth Fade", &settings.ContactShadowDepthFade, 0.0f, 1.0f, "%.3f");
+		ImGui::SliderFloat("Depth Fade", &settings.ContactShadowDepthFade, 0.0f, 1.0f, "%.3f", ImGuiSliderFlags_AlwaysClamp);
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Depth-delta multiplier for shadow falloff. Larger = shadows truncate sooner behind thick occluders.");
 		}
 
-		ImGui::SliderFloat("Min Light Intensity", &settings.ContactShadowMinIntensity, 0.0f, 1.0f, "%.2f");
+		ImGui::SliderFloat("Min Light Intensity", &settings.ContactShadowMinIntensity, 0.0f, 1.0f, "%.2f", ImGuiSliderFlags_AlwaysClamp);
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
 				"Skip contact shadows for CLUSTERED lights whose normalized distance falloff "

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -117,18 +117,17 @@ void LightLimitFix::DrawOverlay()
 
 LightLimitFix::PerFrame LightLimitFix::GetCommonBufferData()
 {
-	// Sanitize contact-shadow settings before they hit the constant buffer. The
-	// sliders enforce ImGuiSliderFlags_AlwaysClamp, but a malformed JSON config
-	// (hand-edited, mod conflict, or migration from a previous schema) can still
-	// arrive here with out-of-range values that would break shader math --
-	// ContactShadowMaxDistance is compared against view-space depth,
-	// ContactShadowStride scales the raymarch length, and ContactShadowMaxSteps
-	// gates the loop count.
+	// Defensive sanitization before the values hit the constant buffer. The
+	// sliders enforce ImGuiSliderFlags_AlwaysClamp at the UI, but Settings
+	// can be mutated through other paths (future persistence, mod overrides,
+	// remote-control / MCP server, or just an internal logic bug) -- a few
+	// of these fields will produce divisions, infinite loops, or visual
+	// corruption if they arrive non-finite or out-of-range, so we re-validate
+	// at the shader boundary rather than trusting upstream callers.
 	//
 	// std::clamp passes NaN through unchanged (every NaN comparison is false),
-	// so a NaN in the config would still poison the cbuffer. Reject non-finite
-	// values explicitly first; fall back to the lower bound on NaN/inf -- a
-	// corrupt config produces degraded but stable behavior rather than UB.
+	// so reject non-finite values explicitly first; fall back to the lower
+	// bound on NaN/inf to produce degraded but stable behavior.
 	auto sanitizeFloat = [](float v, float lo, float hi) {
 		return std::isfinite(v) ? std::clamp(v, lo, hi) : lo;
 	};

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -8,6 +8,18 @@
 #include "Util.h"
 #include "Utils/ExternalEmittance.h"
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+	LightLimitFix::Settings,
+	EnableContactShadows,
+	ContactShadowMaxSteps,
+	ContactShadowMaxDistance,
+	ContactShadowStride,
+	ContactShadowThickness,
+	ContactShadowDepthFade,
+	ContactShadowMinIntensity,
+	EnableLightsVisualisation,
+	LightsVisualisationMode)
+
 static constexpr uint CLUSTER_MAX_LIGHTS = 128;
 static constexpr uint MAX_LIGHTS = 1024;
 
@@ -119,7 +131,7 @@ LightLimitFix::PerFrame LightLimitFix::GetCommonBufferData()
 {
 	// Defensive sanitization before the values hit the constant buffer. The
 	// sliders enforce ImGuiSliderFlags_AlwaysClamp at the UI, but Settings
-	// can be mutated through other paths (future persistence, mod overrides,
+	// can be mutated through other paths (JSON persistence, mod overrides,
 	// remote-control / MCP server, or just an internal logic bug) -- a few
 	// of these fields will produce divisions, infinite loops, or visual
 	// corruption if they arrive non-finite or out-of-range, so we re-validate
@@ -249,6 +261,16 @@ void LightLimitFix::SetupResources()
 void LightLimitFix::RestoreDefaultSettings()
 {
 	settings = {};
+}
+
+void LightLimitFix::LoadSettings(json& o_json)
+{
+	settings = o_json;
+}
+
+void LightLimitFix::SaveSettings(json& o_json)
+{
+	o_json = settings;
 }
 
 RE::NiNode* GetParentRoomNode(RE::NiAVObject* object)

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -29,6 +29,40 @@ void LightLimitFix::DrawSettings()
 		ImGui::Text("All point lights (strict and clustered, except simple lights) cast short screen-space shadows. Performance impact.");
 	}
 
+	if (settings.EnableContactShadows && ImGui::TreeNode("Contact Shadow Tuning")) {
+		ImGui::SliderInt("Max Steps", (int*)&settings.ContactShadowMaxSteps, 1, 16, "%d", ImGuiSliderFlags_AlwaysClamp);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Raymarch steps at zero depth. Higher = longer / more accurate contact shadows, linearly more cost.\nVR users should consider 2 to halve per-eye cost.");
+		}
+
+		ImGui::SliderFloat("Max Distance", &settings.ContactShadowMaxDistance, 64.0f, 4096.0f, "%.0f");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("View-space depth at which contact shadows fade to zero steps. Avoids paying for shadows on distant surfaces where they don't read.");
+		}
+
+		ImGui::SliderFloat("Stride", &settings.ContactShadowStride, 0.5f, 8.0f, "%.2f");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Per-step march length in view-space units. Larger = longer shadow reach with coarser detail; smaller = tighter contact, shorter reach.");
+		}
+
+		ImGui::SliderFloat("Thickness", &settings.ContactShadowThickness, 0.0f, 1.0f, "%.3f");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Depth-delta multiplier for shadow onset. Larger = darker contact at occluder edges.");
+		}
+
+		ImGui::SliderFloat("Depth Fade", &settings.ContactShadowDepthFade, 0.0f, 1.0f, "%.3f");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Depth-delta multiplier for shadow falloff. Larger = shadows truncate sooner behind thick occluders.");
+		}
+
+		ImGui::SliderFloat("Min Light Intensity", &settings.ContactShadowMinIntensity, 0.0f, 1.0f, "%.2f");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Skip contact shadows for clustered lights whose normalized intensity at the pixel is below this threshold. Higher = larger perf win, may drop subtle shadows from weak lights at their reach edge.");
+		}
+
+		ImGui::TreePop();
+	}
+
 	///////////////////////////////
 	ImGui::SeparatorText("Debug");
 
@@ -75,6 +109,12 @@ LightLimitFix::PerFrame LightLimitFix::GetCommonBufferData()
 {
 	PerFrame perFrame{};
 	perFrame.EnableContactShadows = settings.EnableContactShadows;
+	perFrame.ContactShadowMaxSteps = settings.ContactShadowMaxSteps;
+	perFrame.ContactShadowMaxDistance = settings.ContactShadowMaxDistance;
+	perFrame.ContactShadowStride = settings.ContactShadowStride;
+	perFrame.ContactShadowThickness = settings.ContactShadowThickness;
+	perFrame.ContactShadowDepthFade = settings.ContactShadowDepthFade;
+	perFrame.ContactShadowMinIntensity = settings.ContactShadowMinIntensity;
 	perFrame.EnableLightsVisualisation = settings.EnableLightsVisualisation;
 	perFrame.LightsVisualisationMode = settings.LightsVisualisationMode;
 	std::copy(clusterSize, clusterSize + 3, perFrame.ClusterSize);

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -42,7 +42,7 @@ void LightLimitFix::DrawSettings()
 
 		ImGui::SliderFloat("Stride", &settings.ContactShadowStride, 0.5f, 8.0f, "%.2f");
 		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text("Per-step march length in view-space units. Larger = longer shadow reach with coarser detail; smaller = tighter contact, shorter reach.");
+			ImGui::Text("Per-step march length in view-space units at near depth (auto-scales linearly past ~100 units so far surfaces don't undersample). Larger = longer screen-space reach with coarser detail.");
 		}
 
 		ImGui::SliderFloat("Thickness", &settings.ContactShadowThickness, 0.0f, 1.0f, "%.3f");

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -110,12 +110,12 @@ public:
 	// Compile-time size lock catches CPU/GPU cbuffer layout drift. STATIC_ASSERT_ALIGNAS_16
 	// only enforces the 16-byte alignment / multiple-of-16 contract that HLSL constant
 	// buffers require; it doesn't notice if a field is added, removed, or resized in a
-	// way that still happens to land on a 16-byte boundary. The shader's PerFrameLLF
-	// cbuffer declaration must mirror this layout exactly, so any change here without
-	// the corresponding shader update is a silent bug. Update both sides when the layout
-	// changes, then bump this constant.
+	// way that still happens to land on a 16-byte boundary. The shader-side mirror is
+	// SharedData::LightLimitFixSettings in package/Shaders/Common/SharedData.hlsli
+	// (embedded in the shared FeatureData cbuffer at b6), and must match this layout
+	// field-for-field. Update both sides when the layout changes, then bump this constant.
 	static_assert(sizeof(PerFrame) == 64,
-		"LightLimitFix::PerFrame layout drifted -- update the shader-side PerFrameLLF cbuffer to match, then update this assert.");
+		"LightLimitFix::PerFrame layout drifted -- update SharedData::LightLimitFixSettings in package/Shaders/Common/SharedData.hlsli to match, then update this assert.");
 
 	PerFrame GetCommonBufferData();
 

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -95,9 +95,15 @@ public:
 	struct alignas(16) PerFrame
 	{
 		uint EnableContactShadows;
+		uint ContactShadowMaxSteps;
+		float ContactShadowMaxDistance;
+		float ContactShadowStride;
+		float ContactShadowThickness;
+		float ContactShadowDepthFade;
+		float ContactShadowMinIntensity;
 		uint EnableLightsVisualisation;
 		uint LightsVisualisationMode;
-		float pad0;
+		float pad0[3];
 		uint ClusterSize[4];
 	};
 	STATIC_ASSERT_ALIGNAS_16(PerFrame);
@@ -171,6 +177,19 @@ public:
 	struct Settings
 	{
 		bool EnableContactShadows = false;
+		// Max raymarch steps at zero depth; linearly ramps to 0 at MaxDistance.
+		uint ContactShadowMaxSteps = 4;
+		// View-space depth at which contact shadows fade fully off.
+		float ContactShadowMaxDistance = 1024.0f;
+		// Per-step march length in view-space units. Larger -> longer shadows, coarser detail.
+		float ContactShadowStride = 2.0f;
+		// Depth-delta multiplier for shadow onset (higher -> darker contact).
+		float ContactShadowThickness = 0.20f;
+		// Depth-delta multiplier for shadow falloff (higher -> shorter shadow).
+		float ContactShadowDepthFade = 0.05f;
+		// Skip contact shadows for lights below this normalized intensity at the pixel
+		// (intensityMultiplier = 1 - (lightDist/radius)^2). 0 = never skip; 1 = always skip.
+		float ContactShadowMinIntensity = 0.25f;
 		bool EnableLightsVisualisation = false;
 		uint LightsVisualisationMode = 0;
 	};

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -107,6 +107,15 @@ public:
 		uint ClusterSize[4];
 	};
 	STATIC_ASSERT_ALIGNAS_16(PerFrame);
+	// Compile-time size lock catches CPU/GPU cbuffer layout drift. STATIC_ASSERT_ALIGNAS_16
+	// only enforces the 16-byte alignment / multiple-of-16 contract that HLSL constant
+	// buffers require; it doesn't notice if a field is added, removed, or resized in a
+	// way that still happens to land on a 16-byte boundary. The shader's PerFrameLLF
+	// cbuffer declaration must mirror this layout exactly, so any change here without
+	// the corresponding shader update is a silent bug. Update both sides when the layout
+	// changes, then bump this constant.
+	static_assert(sizeof(PerFrame) == 64,
+		"LightLimitFix::PerFrame layout drifted -- update the shader-side PerFrameLLF cbuffer to match, then update this assert.");
 
 	PerFrame GetCommonBufferData();
 

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -196,8 +196,9 @@ public:
 		float ContactShadowThickness = 0.20f;
 		// Depth-delta multiplier for shadow falloff (higher -> shorter shadow).
 		float ContactShadowDepthFade = 0.05f;
-		// Skip contact shadows for lights below this normalized intensity at the pixel
-		// (intensityMultiplier = 1 - (lightDist/radius)^2). 0 = never skip; 1 = always skip.
+		// Skip contact shadows for CLUSTERED lights whose normalized distance falloff
+		// (1 - (lightDist/radius)^2) at the pixel is below this threshold. Strict
+		// lights always raymarch. 0 = never skip; 1 = always skip.
 		float ContactShadowMinIntensity = 0.25f;
 		bool EnableLightsVisualisation = false;
 		uint LightsVisualisationMode = 0;

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -164,6 +164,8 @@ public:
 	virtual void SetupResources() override;
 
 	virtual void RestoreDefaultSettings() override;
+	virtual void LoadSettings(json& o_json) override;
+	virtual void SaveSettings(json& o_json) override;
 
 	virtual void DrawSettings() override;
 	virtual void DrawOverlay() override;


### PR DESCRIPTION
## Summary

Polish on the contact-shadow feature restored in #36. Settings exposure, perspective-correct ray marching, per-light intensity cutoff, and review fixes.

## What's in this PR

| Commit | Change |
|---|---|
| `feat(llf): expose contact-shadow settings and skip distant lights` | New "Contact Shadow Tuning" UI: MaxSteps, MaxDistance, Stride, Thickness, DepthFade, MinIntensity. Adds per-light intensity cutoff for clustered lights too weak at the pixel to cast a visible shadow. |
| `refactor(llf): dedupe EnableContactShadows gate, tighten comments` | DRY: replaces the redundant inner gate with `contactShadowSteps > 0` (also catches the past-MaxDistance case so the matrix-multiply is skipped there too). Comment cleanup. |
| `perf(llf): perspective-correct contact-shadow stepping` | Stride and thickness/fade band both scale linearly with view-space depth past a reference of 100 units, so each step covers ~constant screen-space distance instead of disappearing into sub-pixel jitters at distance. Defaults preserved at near depth. |
| `fix(llf): address PR #43 contact-shadow review feedback` | Path-uniform normalized-falloff gate (ISL/non-ISL semantic divergence), clustered-only scoping for `MinIntensity`, `SliderScalar` for the uint setting (strict-aliasing), settings clamping in `GetCommonBufferData`, `static_assert(sizeof(PerFrame) == 64)`. |
| `docs(llf): correct VR contact-shadow noise coord comment` | Comment-only: the previous wording claimed "half resolution" without the 0.5 factor; in fact dropping it would over-sample IGN, not under-sample. Rewritten as a regression-risk warning. |
| `fix(llf): correct normalized falloff formula and handle NaN configs` | Falloff formula was `(saturate(1 - d/r))^2`, now matches the non-ISL `intensityMultiplier` formula `1 - (saturate(d/r))^2`. `std::clamp` passes NaN through, so add an explicit `std::isfinite` check before clamping. |

## Perf / quality expectations

- **Perf:** Positive when contact shadows are enabled. The `MinIntensity` cutoff skips the matrix-multiply + raymarch for clustered lights whose normalized falloff at the pixel drops below 0.25 (default). Strict lights always march. Neutral when contact shadows are off.
- **Quality at default:** Slight, intentional regression on clustered lights past ~50% of their radius (where contribution was already dim). Set `MinIntensity = 0` to exactly preserve prior behavior. Quality improvement at distance from the perspective-correct stride.
- **VR:** Tooltip suggests `MaxSteps = 2` to halve per-eye raymarch cost. No automatic VR-specific defaults (single setting easier to reason about than a split).

## Test plan

- [x] CI builds Flatrim + VR shader presets, C++ unit tests, shader unit tests, CodeQL
- [x] Feature Version Audit passes (3-1-0 → 3-2-0)
- [x] Compile-time cbuffer-drift assert (`static_assert(sizeof(PerFrame) == 64)`)
- [ ] In-game side-by-side comparison at a dense interior (e.g. Riften Bee and Barb) before/after with `MinIntensity` slider
- [ ] VR session check at `MaxSteps = 2` to confirm cost reduction

https://claude.ai/code/session_01QhBc5srHV2VBA1qFNBooJs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contact shadow configuration UI with adjustable parameters for fine-tuning shadow behavior.

* **Improvements**
  * Enhanced contact shadow rendering with perspective-correct depth-dependent ray marching for improved visual quality across varying distances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/open-shaders/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->