### PR TITLE
feat(llf): restore JSON-scaled Particle Lights

### DIFF
--- a/features/Light Limit Fix/Shaders/LightLimitFix/Common.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/Common.hlsli
@@ -17,6 +17,7 @@ namespace LightFlags
 	static const uint Disabled = (1 << 9);
 	static const uint InverseSquare = (1 << 10);
 	static const uint Linear = (1 << 11);
+	static const uint Particle = (1 << 12);
 }
 
 struct ClusterAABB

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -88,7 +88,8 @@ namespace SharedData
 		// Debug (last)
 		uint EnableLightsVisualisation;
 		uint LightsVisualisationMode;
-		uint2 pad0;
+		uint EnableParticleContactShadows;
+		uint pad0;
 	};
 
 	struct WetnessEffectsSettings

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2801,8 +2801,15 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			endif
 			}
 
+			// Particle lights carry both Simple and Particle bits. Simple-only lights are
+			// clustered fallbacks (no real emitter) and never trace; particle lights trace
+			// only when the user opted in via EnableParticleContactShadows.
+			const bool isParticleLight = (light.lightFlags & LightLimitFix::LightFlags::Particle) != 0;
+			const bool canShadow = isParticleLight ?
+			                           SharedData::lightLimitFixSettings.EnableParticleContactShadows :
+			                           !(light.lightFlags & LightLimitFix::LightFlags::Simple);
 			[branch] if (
-				!(light.lightFlags & LightLimitFix::LightFlags::Simple) &&
+				canShadow &&
 				shadowComponent != 0.0 &&
 				lightAngle > 0.0 &&
 				passesIntensityGate)

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -384,6 +384,7 @@ LightLimitFix::PerFrame LightLimitFix::GetCommonBufferData()
 	};
 
 	PerFrame perFrame{};
+	perFrame.EnableContactShadows = settings.EnableContactShadows;
 	perFrame.ContactShadowMaxSteps = std::clamp<uint32_t>(settings.ContactShadowMaxSteps, 1u, 16u);
 	perFrame.ContactShadowMaxDistance = sanitizeFloat(settings.ContactShadowMaxDistance, 64.0f, 4096.0f);
 	perFrame.ContactShadowStride = sanitizeFloat(settings.ContactShadowStride, 0.5f, 8.0f);
@@ -856,8 +857,13 @@ void LightLimitFix::UpdateLights()
 	ZoneScopedN("LLF::UpdateLights");
 
 	auto context = globals::d3d::context;
-	if (!context || !lights || !lights->resource)
+	if (!context || !lights || !lights->resource) {
+		// Drop last frame's particle lights so AddParticleLightLuminance (gameplay
+		// thread) can't keep feeding stale lights into NPC detection on this early-out.
+		std::lock_guard<std::shared_mutex> lk{ cachedParticleLightsMutex };
+		cachedParticleLights.clear();
 		return;
+	}
 
 	auto smState = globals::game::smState;
 	auto& isl = globals::features::inverseSquareLighting;

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -818,7 +818,7 @@ bool LightLimitFix::IsGlobalLight(RE::BSLight* a_light)
 
 void LightLimitFix::PostPostLoad()
 {
-	globals::features::llf::particleLights.GetConfigs();
+	particleLights.GetConfigs();
 	Hooks::Install();
 	ShadowCasterManager::Init(settings.ShadowSettings);
 	ShadowCasterManager::Install(settings.ShadowSettings);

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -1,5 +1,7 @@
 #include "LightLimitFix.h"
+#include "Globals.h"
 #include "InverseSquareLighting.h"
+#include "Features/InverseSquareLighting/Common.h"
 #include "LinearLighting.h"
 #include "Utils/UI.h"
 
@@ -10,11 +12,74 @@
 #include "Util.h"
 #include "Utils/ExternalEmittance.h"
 
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <limits>
+
+namespace
+{
+	constexpr float kParticleLightsSaturationMin = 1.0f;
+	constexpr float kParticleLightsSaturationMax = 2.0f;
+	constexpr float kParticleBrightnessMin = 0.0f;
+	constexpr float kParticleBrightnessMax = 10.0f;
+	constexpr float kParticleRadiusMin = 0.0f;
+	constexpr float kParticleRadiusMax = 10.0f;
+	constexpr float kBillboardBrightnessMin = 0.0f;
+	constexpr float kBillboardBrightnessMax = 10.0f;
+	constexpr float kBillboardRadiusMin = 0.0f;
+	constexpr float kBillboardRadiusMax = 10.0f;
+	constexpr float kParticleClusterThresholdMin = 8.0f;
+	constexpr float kParticleClusterThresholdMax = 128.0f;
+	constexpr int kMaxParticlesPerEmitterMin = 32;
+	constexpr int kMaxParticlesPerEmitterMax = 2048;
+	constexpr float kMaxParticleDistanceMin = 0.0f;
+	constexpr float kMaxParticleDistanceMax = 20000.0f;
+	constexpr float kJsonPlacedLightIntensityMin = 0.0f;
+	constexpr float kJsonPlacedLightIntensityMax = 8.0f;
+
+	float ClampFiniteOrDefault(float a_value, float a_min, float a_max, float a_default)
+	{
+		if (!std::isfinite(a_value))
+			return a_default;
+		return std::clamp(a_value, a_min, a_max);
+	}
+
+	void SanitizeSettings(LightLimitFix::Settings& a_settings)
+	{
+		a_settings.ParticleLightsSaturation =
+			ClampFiniteOrDefault(a_settings.ParticleLightsSaturation, kParticleLightsSaturationMin, kParticleLightsSaturationMax, 1.0f);
+		a_settings.ParticleBrightness =
+			ClampFiniteOrDefault(a_settings.ParticleBrightness, kParticleBrightnessMin, kParticleBrightnessMax, 1.0f);
+		a_settings.ParticleRadius =
+			ClampFiniteOrDefault(a_settings.ParticleRadius, kParticleRadiusMin, kParticleRadiusMax, 1.0f);
+		a_settings.BillboardBrightness =
+			ClampFiniteOrDefault(a_settings.BillboardBrightness, kBillboardBrightnessMin, kBillboardBrightnessMax, 1.0f);
+		a_settings.BillboardRadius =
+			ClampFiniteOrDefault(a_settings.BillboardRadius, kBillboardRadiusMin, kBillboardRadiusMax, 1.0f);
+		a_settings.ParticleClusterThreshold =
+			ClampFiniteOrDefault(a_settings.ParticleClusterThreshold, kParticleClusterThresholdMin, kParticleClusterThresholdMax, 32.0f);
+		a_settings.MaxParticlesPerEmitter = std::clamp(a_settings.MaxParticlesPerEmitter, kMaxParticlesPerEmitterMin, kMaxParticlesPerEmitterMax);
+		a_settings.MaxParticleDistance =
+			ClampFiniteOrDefault(a_settings.MaxParticleDistance, kMaxParticleDistanceMin, kMaxParticleDistanceMax, 6000.0f);
+		a_settings.JsonPlacedLightIntensity =
+			ClampFiniteOrDefault(a_settings.JsonPlacedLightIntensity, kJsonPlacedLightIntensityMin, kJsonPlacedLightIntensityMax, 1.0f);
+	}
+
+	void ClearStrictLightData(LightLimitFix::StrictLightDataCB& a_data, bool a_resetRoomIndex) noexcept
+	{
+		a_data.NumStrictLights = 0;
+		a_data.ShadowBitMask = 0;
+		if (a_resetRoomIndex)
+			a_data.RoomIndex = -1;
+	}
+}
+
 // Debug visualisation state (EnableLightsVisualisation / LightsVisualisationMode)
-// is intentionally NOT in Settings -- it lives as instance members on the
-// LightLimitFix class so it resets per session and can't accidentally end
-// up in a shipped JSON config that would force every load to compile the
-// heavier LLFDEBUG shader permutation.
+// is intentionally NOT serialized -- it lives as instance members on the
+// LightLimitFix class so it resets per session and can't accidentally end up in
+// a shipped JSON config that would force every load to compile the heavier
+// LLFDEBUG shader permutation.
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	LightLimitFix::Settings,
 	EnableContactShadows,
@@ -25,13 +90,35 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ContactShadowDepthFade,
 	ContactShadowMinIntensity,
 	ShowShadowOverlay,
-	ShadowSettings)
+	ShadowSettings,
+	EnableParticleContactShadows,
+	EnableParticleLights,
+	EnableParticleLightsCulling,
+	EnableParticleLightsDetection,
+	EnableParticleLightsOptimization,
+	ParticleLightsSaturation,
+	ParticleBrightness,
+	ParticleRadius,
+	BillboardBrightness,
+	BillboardRadius,
+	ParticleClusterThreshold,
+	MaxParticlesPerEmitter,
+	MaxParticleDistance,
+	JsonPlacedLightIntensity,
+	JsonPlacedLightsInteriorsOnly,
+	JsonPlacedLightsPortalStrictOnly)
 
 void LightLimitFix::DrawSettings()
 {
 	auto shaderCache = globals::shaderCache;
 
 	ShadowCasterManager::DrawSettings(settings.ShadowSettings);
+
+	if (ImGui::TreeNodeEx("Statistics", ImGuiTreeNodeFlags_DefaultOpen)) {
+		ImGui::Text(std::format("Clustered Light Count : {}", lightCount).c_str());
+		ImGui::Text(std::format("Particle Lights Count : {}", currentParticleLights.size()).c_str());
+		ImGui::TreePop();
+	}
 
 	// ---- Active Shadow Casters --------------------------------------
 	// One cohesive section: overlay toggle, then ALL the stats grouped
@@ -56,7 +143,7 @@ void LightLimitFix::DrawSettings()
 	ShadowCasterManager::DrawShadowLightTable(true, false);
 
 	///////////////////////////////
-	ImGui::SeparatorText("Shadows");
+	ImGui::SeparatorText("Contact Shadows");
 
 	ImGui::Checkbox("Enable Contact Shadows", &settings.EnableContactShadows);
 	if (auto _tt = Util::HoverTooltipWrapper()) {
@@ -106,6 +193,98 @@ void LightLimitFix::DrawSettings()
 				"Strict lights are always raymarched regardless of this threshold. "
 				"Higher = larger perf win, may drop subtle shadows from weak lights at their reach edge.");
 		}
+
+		ImGui::TreePop();
+	}
+
+	ImGui::BeginDisabled(!settings.EnableContactShadows);
+	ImGui::Checkbox("Enable Particle Contact Shadows", &settings.EnableParticleContactShadows);
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text("Also cast contact shadows from particle lights. Larger performance impact in fire/magic-heavy scenes.");
+	}
+	ImGui::EndDisabled();
+
+	ImGui::SeparatorText("Particle Lights");
+
+	if (ImGui::TreeNodeEx("Particle Lights##particles", ImGuiTreeNodeFlags_DefaultOpen)) {
+		ImGui::Checkbox("Enable Particle Lights", &settings.EnableParticleLights);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Treat configured particle effects as dynamic light sources.");
+		}
+
+		ImGui::Separator();
+		ImGui::TextWrapped("Particle Lights Performance");
+
+		ImGui::Checkbox("Enable Culling", &settings.EnableParticleLightsCulling);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Significantly improves performance by not rendering empty textures. Only disable if you are encountering issues.");
+		}
+
+		ImGui::Checkbox("Enable Detection", &settings.EnableParticleLightsDetection);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Adds particle lights to the player light level so that NPCs detect them for stealth and gameplay.");
+		}
+
+		ImGui::Checkbox("Enable Optimization", &settings.EnableParticleLightsOptimization);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Merges vertices which are close enough to each other to improve performance.");
+		}
+
+		ImGui::SliderFloat("Cluster Threshold", &settings.ParticleClusterThreshold, kParticleClusterThresholdMin, kParticleClusterThresholdMax, "%.1f");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text(
+				"Distance+radius similarity threshold for merging particles into one light.\n"
+				"Higher = more merging, better performance, blurrier lights.\n"
+				"Lower = less merging, more precise, more expensive.");
+		}
+
+		ImGui::SliderInt("Max Particles per Emitter", &settings.MaxParticlesPerEmitter, kMaxParticlesPerEmitterMin, kMaxParticlesPerEmitterMax);
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text(
+				"Maximum number of particles sampled per emitter per frame.\n"
+				"Higher = closer to the real particle system but more CPU work.\n"
+				"Lower = faster, especially for very dense effects.");
+		}
+
+		ImGui::SliderFloat("Max Particle Distance", &settings.MaxParticleDistance, 1000.0f, kMaxParticleDistanceMax, "%.0f");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text(
+				"Particle lights beyond this distance from the camera are skipped entirely.\n"
+				"Lower = better performance, but distant effects won't contribute light.\n"
+				"Higher = more distant particle lighting, but more cost.");
+		}
+
+		ImGui::Spacing();
+		ImGui::TextWrapped("Particle Lights Customisation");
+		ImGui::SliderFloat("Saturation", &settings.ParticleLightsSaturation, kParticleLightsSaturationMin, kParticleLightsSaturationMax, "%.2f");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Particle light saturation.");
+		}
+		ImGui::SliderFloat("Particle Brightness", &settings.ParticleBrightness, kParticleBrightnessMin, kParticleBrightnessMax, "%.2f");
+		ImGui::SliderFloat("Particle Radius", &settings.ParticleRadius, kParticleRadiusMin, kParticleRadiusMax, "%.2f");
+		ImGui::SliderFloat("Billboard Brightness", &settings.BillboardBrightness, kBillboardBrightnessMin, kBillboardBrightnessMax, "%.2f");
+		ImGui::SliderFloat("Billboard Radius", &settings.BillboardRadius, kBillboardRadiusMin, kBillboardRadiusMax, "%.2f");
+
+		ImGui::TreePop();
+	}
+
+	if (ImGui::TreeNodeEx("Placed Lights (JSON)", ImGuiTreeNodeFlags_DefaultOpen)) {
+		const bool jsonPlacedLightsSupported = globals::features::inverseSquareLighting.loaded;
+		ImGui::BeginDisabled(!jsonPlacedLightsSupported);
+		ImGui::SliderFloat("Intensity Scale", &settings.JsonPlacedLightIntensity, kJsonPlacedLightIntensityMin, kJsonPlacedLightIntensityMax, "%.2f");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text(
+				"Scales intensity for attached runtime lights generated from Light records.\n"
+				"Primarily targets Light Placer-style JSON lights.\n"
+				"Requires Inverse Square Lighting runtime metadata.");
+		}
+
+		ImGui::Checkbox("Interiors Only", &settings.JsonPlacedLightsInteriorsOnly);
+		ImGui::Checkbox("Portal Strict Only", &settings.JsonPlacedLightsPortalStrictOnly);
+		ImGui::EndDisabled();
+
+		if (!jsonPlacedLightsSupported)
+			ImGui::TextDisabled("Requires Inverse Square Lighting to identify JSON-placed runtime lights.");
 
 		ImGui::TreePop();
 	}
@@ -179,7 +358,6 @@ LightLimitFix::PerFrame LightLimitFix::GetCommonBufferData()
 	};
 
 	PerFrame perFrame{};
-	perFrame.EnableContactShadows = settings.EnableContactShadows;
 	perFrame.ContactShadowMaxSteps = std::clamp<uint32_t>(settings.ContactShadowMaxSteps, 1u, 16u);
 	perFrame.ContactShadowMaxDistance = sanitizeFloat(settings.ContactShadowMaxDistance, 64.0f, 4096.0f);
 	perFrame.ContactShadowStride = sanitizeFloat(settings.ContactShadowStride, 0.5f, 8.0f);
@@ -187,6 +365,7 @@ LightLimitFix::PerFrame LightLimitFix::GetCommonBufferData()
 	perFrame.ContactShadowDepthFade = sanitizeFloat(settings.ContactShadowDepthFade, 0.0f, 1.0f);
 	perFrame.ContactShadowMinIntensity = sanitizeFloat(settings.ContactShadowMinIntensity, 0.0f, 1.0f);
 	perFrame.ShadowMapSlots = ShadowCasterManager::GetInstalledSlotCount();
+	perFrame.EnableParticleContactShadows = settings.EnableContactShadows && settings.EnableParticleContactShadows;
 	std::copy(clusterSize, clusterSize + 3, perFrame.ClusterSize);
 	perFrame.EnableLightsVisualisation = EnableLightsVisualisation;
 	perFrame.LightsVisualisationMode = LightsVisualisationMode;
@@ -293,14 +472,33 @@ void LightLimitFix::SetupResources()
 	}
 }
 
-void LightLimitFix::RestoreDefaultSettings()
+void LightLimitFix::Reset()
 {
-	settings = {};
+	std::lock_guard<std::mutex> queueLock{ particleLightsQueueMutex };
+
+	for (auto& particleLight : currentParticleLights) {
+		if (!particleLight.node)
+			continue;
+
+		if (!particleLight.billboard) {
+			if (const auto particleSystem = static_cast<RE::NiParticleSystem*>(particleLight.node)) {
+				if (auto particleData = particleSystem->GetParticlesRuntimeData().particleData.get())
+					particleData->DecRefCount();
+			}
+		}
+		particleLight.node->DecRefCount();
+	}
+	currentParticleLights.clear();
+	std::swap(currentParticleLights, queuedParticleLights);
+	// References are keyed by transient pass geometry pointers; rebuild every frame to avoid stale entries.
+	particleLightsReferences.clear();
+	jsonPlacedLightCache.clear();
 }
 
 void LightLimitFix::LoadSettings(json& o_json)
 {
 	settings = o_json;
+	SanitizeSettings(settings);
 	// iShadowMapResolution:Display is owned by Skyrim's INI, not our JSON.
 	ShadowCasterManager::LoadINISettings();
 
@@ -311,23 +509,28 @@ void LightLimitFix::LoadSettings(json& o_json)
 
 void LightLimitFix::SaveSettings(json& o_json)
 {
+	SanitizeSettings(settings);
 	o_json = settings;
 	ShadowCasterManager::SaveINISettings();
 }
 
+void LightLimitFix::RestoreDefaultSettings()
+{
+	settings = {};
+	SanitizeSettings(settings);
+}
+
 RE::NiNode* GetParentRoomNode(RE::NiAVObject* object)
 {
-	if (object == nullptr) {
+	if (object == nullptr)
 		return nullptr;
-	}
 
 	static const auto* roomRtti = REL::Relocation<const RE::NiRTTI*>{ RE::NiRTTI_BSMultiBoundRoom }.get();
 	static const auto* portalRtti = REL::Relocation<const RE::NiRTTI*>{ RE::NiRTTI_BSPortalSharedNode }.get();
 
 	const auto* rtti = object->GetRTTI();
-	if (rtti == roomRtti || rtti == portalRtti) {
+	if (rtti == roomRtti || rtti == portalRtti)
 		return static_cast<RE::NiNode*>(object);
-	}
 
 	return GetParentRoomNode(object->parent);
 }
@@ -339,84 +542,120 @@ void LightLimitFix::BSLightingShader_SetupGeometry_Before(RE::BSRenderPass* a_pa
 	if (!shaderCache->IsEnabled())
 		return;
 
-	strictLightDataTemp.NumStrictLights = 0;
-	strictLightDataTemp.ShadowBitMask = 0;
+	ClearStrictLightData(strictLightDataTemp, true);
 
-	strictLightDataTemp.RoomIndex = -1;
+	if (!a_pass || !a_pass->geometry)
+		return;
+
 	if (!roomNodes.empty()) {
 		if (RE::NiNode* roomNode = GetParentRoomNode(a_pass->geometry)) {
-			if (auto it = roomNodes.find(roomNode); it != roomNodes.cend()) {
+			if (auto it = roomNodes.find(roomNode); it != roomNodes.cend())
 				strictLightDataTemp.RoomIndex = it->second;
-			}
 		}
 	}
 }
 
 void LightLimitFix::BSLightingShader_SetupGeometry_GeometrySetupConstantPointLights(RE::BSRenderPass* a_pass)
 {
+	if (!a_pass || !a_pass->sceneLights) {
+		ClearStrictLightData(strictLightDataTemp, false);
+		return;
+	}
+
+	auto smState = globals::game::smState;
+	if (!smState) {
+		ClearStrictLightData(strictLightDataTemp, false);
+		return;
+	}
+
 	auto& isl = globals::features::inverseSquareLighting;
 
 	auto accumulator = *globals::game::currentAccumulator.get();
-	bool inWorld = accumulator->GetRuntimeData().activeShadowSceneNode == globals::game::smState->shadowSceneNode[0];
-
-	strictLightDataTemp.NumStrictLights = inWorld ? 0 : (a_pass->numLights - 1);
-
-	uint32_t writeIdx = 0;
-	for (uint32_t i = 0; i < strictLightDataTemp.NumStrictLights; i++) {
-		auto bsLight = a_pass->sceneLights[i + 1];
-		if (!bsLight)
-			continue;
-		auto niLight = bsLight->light.get();
-		if (!niLight)
-			continue;
-
-		auto& runtimeData = niLight->GetLightRuntimeData();
-
-		LightData light{};
-		light.color = { runtimeData.diffuse.red, runtimeData.diffuse.green, runtimeData.diffuse.blue };
-		light.lightFlags = std::bit_cast<LightFlags>(runtimeData.ambient.red);
-
-		if (isl.loaded) {
-			isl.ProcessLight(light, bsLight, niLight);
-		} else {
-			light.radius = runtimeData.radius.x;
-			// light.color *= runtimeData.fade;
-			light.fade = runtimeData.fade;
-		}
-
-		light.fade *= bsLight->lodDimmer;
-
-		SetLightPosition(light, niLight->world.translate, inWorld);
-
-		if (i < a_pass->numShadowLights) {
-			auto* shadowLight = static_cast<RE::BSShadowLight*>(bsLight);
-			// Use SCM's stable container-slot index instead of reading the
-			// live `shadowmapDescriptors[0].shadowmapIndex`. The descriptor
-			// field can be corrupted mid-frame by ReturnShadowmaps() (called
-			// via Hook_DisableColorMask) after ScheduleShadowCasters fixed
-			// it but before this strict-light setup runs -- a stale-but-in
-			// -range index would still pass an upper-bound check yet point
-			// strict-light shader sampling at the wrong kSHADOWMAPS slice.
-			// GetShadowSlot reads from the SCM's own pool (s_lights, set in
-			// ScheduleShadowCasters and never touched by ReturnShadowmaps),
-			// so it stays consistent with CopyShadowLightData and
-			// UpdateLights, which also key off it. Returns -1 for the sun
-			// or inactive lights; both cases skip setting the Shadow flag.
-			const int32_t slot = ShadowCasterManager::GetShadowSlot(shadowLight);
-			if (slot >= 0 && static_cast<uint32_t>(slot) < ShadowCasterManager::GetInstalledSlotCount()) {
-				light.shadowMapIndex = static_cast<uint32_t>(slot);
-				light.lightFlags.set(LightFlags::Shadow);
-			}
-		}
-
-		strictLightDataTemp.StrictLights[writeIdx++] = light;
+	if (!accumulator) {
+		ClearStrictLightData(strictLightDataTemp, false);
+		return;
 	}
-	strictLightDataTemp.NumStrictLights = writeIdx;
 
-	// Don't reinstate a build loop for strictLightDataTemp.ShadowBitMask:
-	// no shader reads it (the IsLightIgnored bit-mask branch was replaced by
-	// per-light shadowMapIndex sampling). The field stays for cbuffer ABI
-	// stability and is zero-initialised above.
+	bool inWorld = accumulator->GetRuntimeData().activeShadowSceneNode == smState->shadowSceneNode[0];
+	const bool isInterior = Util::IsInterior();
+
+	constexpr uint32_t kStrictLightCapacity = 15;
+	const uint32_t availableSceneLights = a_pass->numLights > 0 ? (a_pass->numLights - 1) : 0;
+	const uint32_t requestedStrictLights = inWorld ? 0u : availableSceneLights;
+	const uint32_t strictLightCount = std::min(requestedStrictLights, kStrictLightCapacity);
+	const uint32_t strictShadowLightCount = std::min(static_cast<uint32_t>(a_pass->numShadowLights), availableSceneLights);
+	RefreshJsonPlacedLightCacheFrame();
+
+	ClearStrictLightData(strictLightDataTemp, false);
+
+	uint32_t outIndex = 0;
+#if defined(_MSC_VER)
+	__try
+#endif
+	{
+		for (uint32_t i = 0; i < strictLightCount; i++) {
+			auto bsLight = a_pass->sceneLights[i + 1];
+			if (!bsLight)
+				continue;
+			auto niLight = bsLight->light.get();
+			if (!niLight)
+				continue;
+
+			auto& runtimeData = niLight->GetLightRuntimeData();
+
+			LightData light{};
+			light.color = { runtimeData.diffuse.red, runtimeData.diffuse.green, runtimeData.diffuse.blue };
+			light.lightFlags = std::bit_cast<LightFlags>(runtimeData.ambient.red);
+
+			if (isl.loaded) {
+				isl.ProcessLight(light, bsLight, niLight);
+			} else {
+				light.radius = runtimeData.radius.x;
+				light.fade = runtimeData.fade;
+			}
+
+			light.fade *= bsLight->lodDimmer;
+			const bool isPortalStrict = !IsGlobalLight(bsLight);
+			ApplyJsonPlacedLightIntensityScale(light, bsLight, niLight, isPortalStrict, isInterior);
+
+			SetLightPosition(light, niLight->world.translate, inWorld);
+
+			if (i < strictShadowLightCount && bsLight->IsShadowLight()) {
+				auto* shadowLight = static_cast<RE::BSShadowLight*>(bsLight);
+				// Use SCM's stable container-slot index instead of reading the
+				// live `shadowmapDescriptors[0].shadowmapIndex`. The descriptor
+				// field can be corrupted mid-frame by ReturnShadowmaps() (called
+				// via Hook_DisableColorMask) after ScheduleShadowCasters fixed
+				// it but before this strict-light setup runs -- a stale-but-in
+				// -range index would still pass an upper-bound check yet point
+				// strict-light shader sampling at the wrong kSHADOWMAPS slice.
+				// GetShadowSlot reads from the SCM's own pool (s_lights, set in
+				// ScheduleShadowCasters and never touched by ReturnShadowmaps),
+				// so it stays consistent with CopyShadowLightData and
+				// UpdateLights, which also key off it. Returns -1 for the sun
+				// or inactive lights; both cases skip setting the Shadow flag.
+				const int32_t slot = ShadowCasterManager::GetShadowSlot(shadowLight);
+				if (slot >= 0 && static_cast<uint32_t>(slot) < ShadowCasterManager::GetInstalledSlotCount()) {
+					light.shadowMapIndex = static_cast<uint32_t>(slot);
+					light.lightFlags.set(LightFlags::Shadow);
+				}
+			}
+
+			strictLightDataTemp.StrictLights[outIndex++] = light;
+		}
+		strictLightDataTemp.NumStrictLights = outIndex;
+
+		// Don't build strictLightDataTemp.ShadowBitMask: no shader reads it (the
+		// IsLightIgnored bit-mask branch was replaced by per-light shadowMapIndex
+		// sampling, set inline above). The field stays for cbuffer ABI stability
+		// and is zero-initialised by ClearStrictLightData.
+	}
+#if defined(_MSC_VER)
+	__except (1)
+	{
+		ClearStrictLightData(strictLightDataTemp, false);
+	}
+#endif
 }
 
 void LightLimitFix::BSLightingShader_SetupGeometry_After(RE::BSRenderPass*)
@@ -428,7 +667,12 @@ void LightLimitFix::BSLightingShader_SetupGeometry_After(RE::BSRenderPass*)
 	if (!shaderCache->IsEnabled())
 		return;
 
+	if (!smState || !strictLightDataCB)
+		return;
+
 	auto accumulator = *globals::game::currentAccumulator.get();
+	if (!accumulator)
+		return;
 
 	auto shadowSceneNode = smState->shadowSceneNode[0];
 
@@ -454,17 +698,65 @@ void LightLimitFix::SetLightPosition(LightLimitFix::LightData& a_light, RE::NiPo
 	for (int eyeIndex = 0; eyeIndex < eyeCount; eyeIndex++) {
 		RE::NiPoint3 eyePosition;
 
-		if (a_cached) {
+		if (a_cached)
 			eyePosition = eyePositionCached[eyeIndex];
-		} else {
+		else
 			eyePosition = Util::GetEyePosition(eyeIndex);
-		}
 
 		auto worldPos = a_initialPosition - eyePosition;
 		a_light.positionWS[eyeIndex].data.x = worldPos.x;
 		a_light.positionWS[eyeIndex].data.y = worldPos.y;
 		a_light.positionWS[eyeIndex].data.z = worldPos.z;
 	}
+}
+
+void LightLimitFix::RefreshJsonPlacedLightCacheFrame()
+{
+	if (jsonPlacedLightCacheFrameChecker.IsNewFrame())
+		jsonPlacedLightCache.clear();
+}
+
+bool LightLimitFix::IsJsonPlacedLight(RE::BSLight* a_bsLight, RE::NiLight* a_niLight)
+{
+	if (!a_bsLight || !a_niLight || !a_bsLight->pointLight)
+		return false;
+	if (!globals::features::inverseSquareLighting.loaded)
+		return false;
+	if (const auto it = jsonPlacedLightCache.find(a_niLight); it != jsonPlacedLightCache.end())
+		return it->second;
+
+	bool isJsonPlacedLight = false;
+	if (const auto ownerRef = a_niLight->GetUserData()) {
+		if (const auto ownerBase = ownerRef->GetObjectReference(); ownerBase && ownerBase->GetFormType() != RE::FormType::Light) {
+			const auto runtimeData = ISLCommon::RuntimeLightDataExt::Get(a_niLight);
+			if (runtimeData && runtimeData->lighFormId != 0) {
+				const auto lighForm = RE::TESForm::LookupByID(runtimeData->lighFormId);
+				isJsonPlacedLight = lighForm && lighForm->GetFormType() == RE::FormType::Light;
+			}
+		}
+	}
+
+	jsonPlacedLightCache.insert_or_assign(a_niLight, isJsonPlacedLight);
+	return isJsonPlacedLight;
+}
+
+void LightLimitFix::ApplyJsonPlacedLightIntensityScale(
+	LightData& a_light,
+	RE::BSLight* a_bsLight,
+	RE::NiLight* a_niLight,
+	bool a_isPortalStrict,
+	bool a_isInterior)
+{
+	if (std::abs(settings.JsonPlacedLightIntensity - 1.0f) <= 1e-4f)
+		return;
+	if (settings.JsonPlacedLightsInteriorsOnly && !a_isInterior)
+		return;
+	if (settings.JsonPlacedLightsPortalStrictOnly && !a_isPortalStrict)
+		return;
+	if (!IsJsonPlacedLight(a_bsLight, a_niLight))
+		return;
+
+	a_light.fade *= settings.JsonPlacedLightIntensity;
 }
 
 void LightLimitFix::Prepass()
@@ -495,11 +787,12 @@ bool LightLimitFix::IsValidLight(RE::BSLight* a_light)
 
 bool LightLimitFix::IsGlobalLight(RE::BSLight* a_light)
 {
-	return !(a_light->portalStrict || !a_light->portalGraph);
+	return a_light && !(a_light->portalStrict || !a_light->portalGraph);
 }
 
 void LightLimitFix::PostPostLoad()
 {
+	globals::features::llf::particleLights.GetConfigs();
 	Hooks::Install();
 	ShadowCasterManager::Init(settings.ShadowSettings);
 	ShadowCasterManager::Install(settings.ShadowSettings);
@@ -507,9 +800,12 @@ void LightLimitFix::PostPostLoad()
 
 void LightLimitFix::DataLoaded()
 {
-	auto iMagicLightMaxCount = globals::game::gameSettingCollection->GetSetting("iMagicLightMaxCount");
-	iMagicLightMaxCount->data.i = MAXINT32;
-	logger::info("[LLF] Unlocked magic light limit");
+	if (auto gameSettings = globals::game::gameSettingCollection) {
+		if (auto iMagicLightMaxCount = gameSettings->GetSetting("iMagicLightMaxCount")) {
+			iMagicLightMaxCount->data.i = MAXINT32;
+			logger::info("[LLF] Unlocked magic light limit");
+		}
+	}
 }
 
 void LightLimitFix::ClearShaderCache()
@@ -532,13 +828,37 @@ void LightLimitFix::ClearShaderCache()
 void LightLimitFix::UpdateLights()
 {
 	ZoneScopedN("LLF::UpdateLights");
+
+	auto context = globals::d3d::context;
+	if (!context || !lights || !lights->resource)
+		return;
+
 	auto smState = globals::game::smState;
 	auto& isl = globals::features::inverseSquareLighting;
+	auto clearAndUpdate = [&]() {
+		lightCount = 0;
+		// Drop last frame's particle lights too: AddParticleLightLuminance reads
+		// cachedParticleLights on the gameplay thread, so a bare early-return here
+		// would leave stale lights contributing to NPC light-level detection.
+		{
+			std::lock_guard<std::shared_mutex> lk{ cachedParticleLightsMutex };
+			cachedParticleLights.clear();
+		}
+		UpdateStructure();
+	};
+
+	if (!smState) {
+		clearAndUpdate();
+		return;
+	}
 
 	auto shadowSceneNode = smState->shadowSceneNode[0];
+	if (!shadowSceneNode) {
+		clearAndUpdate();
+		return;
+	}
 
 	// Cache data since cameraData can become invalid in first-person
-
 	for (int eyeIndex = 0; eyeIndex < eyeCount; eyeIndex++) {
 		auto eyePosition = globals::game::frameBufferCached.GetCameraPosAdjust(eyeIndex);
 		eyePositionCached[eyeIndex] = { eyePosition.x, eyePosition.y, eyePosition.z };
@@ -546,14 +866,22 @@ void LightLimitFix::UpdateLights()
 
 	eastl::vector<LightData> lightsData{};
 	lightsData.reserve(MAX_LIGHTS);
+	const bool isInterior = Util::IsInterior();
+	RefreshJsonPlacedLightCacheFrame();
 
 	// Process point lights
 
 	roomNodes.clear();
 
 	auto addRoom = [&](RE::NiNode* node, LightData& light) {
+		if (!node)
+			return;
+
+		constexpr std::size_t kMaxRoomFlags = 128;
 		uint8_t roomIndex = 0;
 		if (auto it = roomNodes.find(node); it == roomNodes.cend()) {
+			if (roomNodes.size() >= kMaxRoomFlags)
+				return;
 			roomIndex = static_cast<uint8_t>(roomNodes.size());
 			roomNodes.insert_or_assign(node, roomIndex);
 		} else {
@@ -594,23 +922,24 @@ void LightLimitFix::UpdateLights()
 						isl.ProcessLight(light, bsLight, niLight);
 					} else {
 						light.radius = runtimeData.radius.x;
-						// light.color *= runtimeData.fade;
 						light.fade = runtimeData.fade;
 					}
 
 					light.fade *= bsLight->lodDimmer;
+					const bool isPortalStrict = !IsGlobalLight(bsLight);
 
-					if (!IsGlobalLight(bsLight)) {
-						// List of BSMultiBoundRooms affected by a light
+					if (isPortalStrict) {
 						for (const auto& roomPtr : bsLight->rooms) {
-							addRoom(roomPtr, light);
+							if (roomPtr)
+								addRoom(static_cast<RE::NiNode*>(roomPtr), light);
 						}
-						// List of BSPortals affected by a light
 						for (const auto& portalPtr : bsLight->portals) {
-							addRoom(portalPtr->portalSharedNode.get(), light);
+							if (portalPtr && portalPtr->portalSharedNode)
+								addRoom(static_cast<RE::NiNode*>(portalPtr->portalSharedNode.get()), light);
 						}
 						light.lightFlags.set(LightFlags::PortalStrict);
 					}
+					ApplyJsonPlacedLightIntensityScale(light, bsLight, niLight, isPortalStrict, isInterior);
 
 					SetLightPosition(light, niLight->world.translate);
 
@@ -759,14 +1088,15 @@ void LightLimitFix::UpdateLights()
 		addLight(RE::NiPointer<RE::BSLight>(asBs));
 	});
 
-	auto context = globals::d3d::context;
+	ProcessQueuedParticleLights(lightsData);
 
 	lightCount = std::min((uint)lightsData.size(), MAX_LIGHTS);
 
 	D3D11_MAPPED_SUBRESOURCE mapped;
 	DX::ThrowIfFailed(context->Map(lights->resource.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped));
 	size_t bytes = sizeof(LightData) * lightCount;
-	memcpy_s(mapped.pData, bytes, lightsData.data(), bytes);
+	if (bytes > 0)
+		memcpy_s(mapped.pData, bytes, lightsData.data(), bytes);
 	context->Unmap(lights->resource.get(), 0);
 
 	UpdateStructure();
@@ -922,7 +1252,7 @@ void LightLimitFix::Hooks::BSEffectShader_SetupGeometry::thunk(RE::BSShader* Thi
 	auto& singleton = globals::features::lightLimitFix;
 	singleton.BSLightingShader_SetupGeometry_Before(Pass);
 	singleton.BSLightingShader_SetupGeometry_After(Pass);
-};
+}
 
 void LightLimitFix::Hooks::BSWaterShader_SetupGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
 {
@@ -930,4 +1260,5 @@ void LightLimitFix::Hooks::BSWaterShader_SetupGeometry::thunk(RE::BSShader* This
 	auto& singleton = globals::features::lightLimitFix;
 	singleton.BSLightingShader_SetupGeometry_Before(Pass);
 	singleton.BSLightingShader_SetupGeometry_After(Pass);
-};
+}
+

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -206,15 +206,22 @@ void LightLimitFix::DrawSettings()
 
 	ImGui::SeparatorText("Particle Lights");
 
-	if (ImGui::TreeNodeEx("Particle Lights##particles", ImGuiTreeNodeFlags_DefaultOpen)) {
-		ImGui::Checkbox("Enable Particle Lights", &settings.EnableParticleLights);
-		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text("Treat configured particle effects as dynamic light sources.");
-		}
+	ImGui::TextWrapped(
+		"Turns configured particle effects (candles, braziers, torches, magic) into dynamic lights. "
+		"Requires a particle-light config pack shipping Data\\ParticleLights\\*.ini (e.g. Embers HD, "
+		"Lanterns of Skyrim); with no pack installed this section has no effect.");
+	ImGui::TextWrapped(
+		"Particle lights are additive emitters and do NOT cast shadow-map shadows, so they never appear "
+		"in the shadow caster table above. Turn on \"Enable Particle Contact Shadows\" in the Contact "
+		"Shadows section for short screen-space contact shadows.");
+	ImGui::Spacing();
 
-		ImGui::Separator();
-		ImGui::TextWrapped("Particle Lights Performance");
+	ImGui::Checkbox("Enable Particle Lights", &settings.EnableParticleLights);
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text("Master toggle for the particle-light feature.");
+	}
 
+	if (ImGui::TreeNode("Performance##particles")) {
 		ImGui::Checkbox("Enable Culling", &settings.EnableParticleLightsCulling);
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Significantly improves performance by not rendering empty textures. Only disable if you are encountering issues.");
@@ -254,21 +261,42 @@ void LightLimitFix::DrawSettings()
 				"Higher = more distant particle lighting, but more cost.");
 		}
 
-		ImGui::Spacing();
-		ImGui::TextWrapped("Particle Lights Customisation");
+		ImGui::TreePop();
+	}
+
+	if (ImGui::TreeNode("Appearance##particles")) {
 		ImGui::SliderFloat("Saturation", &settings.ParticleLightsSaturation, kParticleLightsSaturationMin, kParticleLightsSaturationMax, "%.2f");
 		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text("Particle light saturation.");
+			ImGui::Text("Color saturation of particle/billboard lights. 1.0 = source color; higher = more vivid.");
 		}
 		ImGui::SliderFloat("Particle Brightness", &settings.ParticleBrightness, kParticleBrightnessMin, kParticleBrightnessMax, "%.2f");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Intensity multiplier for particle-system emitters (fire, sparks, magic).");
+		}
 		ImGui::SliderFloat("Particle Radius", &settings.ParticleRadius, kParticleRadiusMin, kParticleRadiusMax, "%.2f");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Radius multiplier for particle-system emitters. Larger = light reaches further.");
+		}
 		ImGui::SliderFloat("Billboard Brightness", &settings.BillboardBrightness, kBillboardBrightnessMin, kBillboardBrightnessMax, "%.2f");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Intensity multiplier for billboard (single-quad) emitters such as candle flames.");
+		}
 		ImGui::SliderFloat("Billboard Radius", &settings.BillboardRadius, kBillboardRadiusMin, kBillboardRadiusMax, "%.2f");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("Radius multiplier for billboard emitters. Larger = light reaches further.");
+		}
 
 		ImGui::TreePop();
 	}
 
-	if (ImGui::TreeNodeEx("Placed Lights (JSON)", ImGuiTreeNodeFlags_DefaultOpen)) {
+	ImGui::SeparatorText("Placed Lights (JSON)");
+
+	ImGui::TextWrapped(
+		"Scales the intensity of runtime lights attached from Light records by Light Placer-style mods. "
+		"Separate from particle lights; requires Inverse Square Lighting for the runtime metadata.");
+	ImGui::Spacing();
+
+	{
 		const bool jsonPlacedLightsSupported = globals::features::inverseSquareLighting.loaded;
 		ImGui::BeginDisabled(!jsonPlacedLightsSupported);
 		ImGui::SliderFloat("Intensity Scale", &settings.JsonPlacedLightIntensity, kJsonPlacedLightIntensityMin, kJsonPlacedLightIntensityMax, "%.2f");
@@ -285,8 +313,6 @@ void LightLimitFix::DrawSettings()
 
 		if (!jsonPlacedLightsSupported)
 			ImGui::TextDisabled("Requires Inverse Square Lighting to identify JSON-placed runtime lights.");
-
-		ImGui::TreePop();
 	}
 
 	///////////////////////////////

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -172,6 +172,10 @@ public:
 		std::uint64_t configVersion = 0;
 	};
 
+	// INI-driven particle-light configs (loaded in PostPostLoad). Lives on the feature
+	// rather than in globals since only LightLimitFix code consumes it.
+	ParticleLights particleLights;
+
 	eastl::hash_map<RE::BSGeometry*, ParticleLightReference> particleLightsReferences;
 	eastl::vector<ParticleLightInfo> queuedParticleLights;
 	eastl::vector<ParticleLightInfo> currentParticleLights;

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -1,8 +1,12 @@
 #pragma once
 
 #include "Buffer.h"
+#include "Features/LightLimitFix/ParticleLights.h"
 #include "LightLimitFix/ShadowCasterManager.h"
 #include "OverlayFeature.h"
+
+#include <mutex>
+#include <shared_mutex>
 
 struct LightLimitFix : OverlayFeature
 {
@@ -24,7 +28,8 @@ public:
 			{ "Removes 4-light limit",
 				"Unlimited dynamic lights",
 				"Shadow support for point and spot lights",
-				"Improved lighting quality" }
+				"Improved lighting quality",
+				"Particle lights from configurable INI" }
 		};
 	}
 
@@ -40,6 +45,7 @@ public:
 		Disabled = (1 << 9),
 		InverseSquare = (1 << 10),
 		Linear = (1 << 11),
+		Particle = (1 << 12),
 	};
 
 	struct PositionOpt
@@ -110,7 +116,8 @@ public:
 		// Debug (last)
 		uint EnableLightsVisualisation;
 		uint LightsVisualisationMode;
-		uint pad0[2];
+		uint EnableParticleContactShadows;
+		uint pad0;
 	};
 	STATIC_ASSERT_ALIGNAS_16(PerFrame);
 	// Compile-time size lock catches CPU/GPU cbuffer layout drift. STATIC_ASSERT_ALIGNAS_16
@@ -136,6 +143,46 @@ public:
 	STATIC_ASSERT_ALIGNAS_16(StrictLightDataCB);
 
 	StrictLightDataCB strictLightDataTemp;
+
+	struct CachedParticleLight
+	{
+		float grey;
+		RE::NiPoint3 position;
+		float radius;
+	};
+
+	struct ParticleLightInfo
+	{
+		bool billboard;
+		RE::BSGeometry* node;
+		RE::NiColorA color;
+		float radiusMult = 1.0f;
+	};
+
+	struct ParticleLightReference
+	{
+		bool valid = false;
+		bool billboard = false;
+		// keeps billboard effect-material/emittance tint after detection
+		bool applyEffectMaterialTint = true;
+		ParticleLights::Config config{};
+		bool hasGradientConfig = false;
+		ParticleLights::GradientConfig gradientConfig{};
+		RE::NiColorA baseColor{ 1.0f, 1.0f, 1.0f, 1.0f };
+		std::uint64_t configVersion = 0;
+	};
+
+	eastl::hash_map<RE::BSGeometry*, ParticleLightReference> particleLightsReferences;
+	eastl::vector<ParticleLightInfo> queuedParticleLights;
+	eastl::vector<ParticleLightInfo> currentParticleLights;
+	std::mutex particleLightsQueueMutex;
+
+	std::shared_mutex cachedParticleLightsMutex;
+	eastl::vector<CachedParticleLight> cachedParticleLights;
+
+	// JSON-placed light cache (rebuilt per frame); paired with InverseSquareLighting metadata.
+	eastl::hash_map<RE::NiLight*, bool> jsonPlacedLightCache;
+	Util::FrameChecker jsonPlacedLightCacheFrameChecker;
 
 	ConstantBuffer* strictLightDataCB = nullptr;
 
@@ -189,10 +236,12 @@ public:
 	std::string BuildShadowSlotColorLegend() const;
 
 	virtual void SetupResources() override;
+	virtual void Reset() override;
 
-	virtual void RestoreDefaultSettings() override;
 	virtual void LoadSettings(json& o_json) override;
 	virtual void SaveSettings(json& o_json) override;
+
+	virtual void RestoreDefaultSettings() override;
 
 	virtual void DrawSettings() override;
 	virtual void DrawOverlay() override;
@@ -207,7 +256,16 @@ public:
 	virtual void ClearShaderCache() override;
 
 	float CalculateLightDistance(float3 a_lightPosition, float a_radius);
+	void AddCachedParticleLights(eastl::vector<LightData>& lightsData, LightLimitFix::LightData& light);
 	void SetLightPosition(LightLimitFix::LightData& a_light, RE::NiPoint3 a_initialPosition, bool a_cached = true);
+	void RefreshJsonPlacedLightCacheFrame();
+	bool IsJsonPlacedLight(RE::BSLight* a_bsLight, RE::NiLight* a_niLight);
+	void ApplyJsonPlacedLightIntensityScale(
+		LightData& a_light,
+		RE::BSLight* a_bsLight,
+		RE::NiLight* a_niLight,
+		bool a_isPortalStrict,
+		bool a_isInterior);
 	void UpdateLights();
 	void UpdateStructure();
 	virtual void EarlyPrepass() override;
@@ -216,7 +274,24 @@ public:
 
 	// Shadow rendering helpers (implemented in LightLimitFix/ShadowRenderer.cpp)
 
-	static inline float3 Saturation(float3 color, float saturation);
+	float CalculateLuminance(CachedParticleLight& light, RE::NiPoint3& point);
+	void AddParticleLightLuminance(RE::NiPoint3& targetPosition, int& numHits, float& lightLevel);
+
+	ParticleLightReference GetParticleLightConfigs(RE::BSRenderPass* a_pass);
+	bool AddParticleLight(RE::BSRenderPass* a_pass, ParticleLightReference a_reference);
+	bool CheckParticleLights(RE::BSRenderPass* a_pass, uint32_t a_technique);
+	void ProcessQueuedParticleLights(eastl::vector<LightData>& lightsData);
+
+	// Inline-defined because Particle.cpp calls this; static-inline class-scope helpers must have
+	// the body visible in every translation unit that uses them.
+	static inline float3 Saturation(float3 color, float saturation)
+	{
+		const float grey = color.Dot(float3(0.3f, 0.59f, 0.11f));
+		color.x = std::max(std::lerp(grey, color.x, saturation), 0.0f);
+		color.y = std::max(std::lerp(grey, color.y, saturation), 0.0f);
+		color.z = std::max(std::lerp(grey, color.z, saturation), 0.0f);
+		return color;
+	}
 	static inline bool IsValidLight(RE::BSLight* a_light);
 	static inline bool IsGlobalLight(RE::BSLight* a_light);
 
@@ -247,6 +322,27 @@ public:
 
 		// Shadow caster scheduling (ShadowCasterManager)
 		ShadowCasterManager::Settings ShadowSettings;
+
+		bool EnableParticleContactShadows = false;
+
+		// Particle Lights.
+		bool EnableParticleLights = true;
+		bool EnableParticleLightsCulling = true;
+		bool EnableParticleLightsDetection = true;
+		bool EnableParticleLightsOptimization = true;
+		float ParticleLightsSaturation = 1.0f;
+		float ParticleBrightness = 1.0f;
+		float ParticleRadius = 1.0f;
+		float BillboardBrightness = 1.0f;
+		float BillboardRadius = 1.0f;
+		float ParticleClusterThreshold = 32.0f;
+		int MaxParticlesPerEmitter = 256;
+		float MaxParticleDistance = 6000.0f;
+
+		// JSON-placed light intensity (requires Inverse Square Lighting runtime metadata).
+		float JsonPlacedLightIntensity = 1.0f;
+		bool JsonPlacedLightsInteriorsOnly = false;
+		bool JsonPlacedLightsPortalStrictOnly = false;
 	};
 
 	uint clusterSize[3] = { 16 };
@@ -281,6 +377,18 @@ public:
 			static inline REL::Relocation<decltype(thunk)> func;
 		};
 
+		struct AIProcess_CalculateLightValue_GetLuminance
+		{
+			static float thunk(RE::ShadowSceneNode* shadowSceneNode,
+				RE::NiPoint3& targetPosition,
+				int& numHits,
+				float& sunLightLevel,
+				float& lightLevel,
+				RE::NiLight& refLight,
+				int32_t shadowBitMask);
+			static inline REL::Relocation<decltype(thunk)> func;
+		};
+
 		template <int N>
 		struct ValidLight
 		{
@@ -297,6 +405,8 @@ public:
 
 		static void Install()
 		{
+			stl::write_thunk_call<AIProcess_CalculateLightValue_GetLuminance>(
+				REL::RelocationID(38900, 39946).address() + REL::Relocate(0x1C9, 0x1D3));
 			stl::write_vfunc<0x6, BSLightingShader_SetupGeometry>(RE::VTABLE_BSLightingShader[0]);
 			stl::write_vfunc<0x6, BSEffectShader_SetupGeometry>(RE::VTABLE_BSEffectShader[0]);
 			stl::write_vfunc<0x6, BSWaterShader_SetupGeometry>(RE::VTABLE_BSWaterShader[0]);

--- a/src/Features/LightLimitFix/Particle.cpp
+++ b/src/Features/LightLimitFix/Particle.cpp
@@ -1,0 +1,755 @@
+// Particle-light recognition + JSON-placed light scaling, split from
+// LightLimitFix.cpp to keep the core clustering pipeline focused.
+
+#include "Features/LightLimitFix.h"
+
+#include "Globals.h"
+#include "Shadercache.h"
+#include "Util.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <limits>
+
+namespace
+{
+	constexpr uint MAX_LIGHTS = 1024;
+
+	char ToLowerAscii(char a_char)
+	{
+		return static_cast<char>(std::tolower(static_cast<unsigned char>(a_char)));
+	}
+
+	bool EndsWithDdsInsensitive(std::string_view a_filename)
+	{
+		if (a_filename.size() < 4)
+			return false;
+		const std::string_view ext = a_filename.substr(a_filename.size() - 4);
+		return ToLowerAscii(ext[0]) == '.' &&
+		       ToLowerAscii(ext[1]) == 'd' &&
+		       ToLowerAscii(ext[2]) == 'd' &&
+		       ToLowerAscii(ext[3]) == 's';
+	}
+
+	bool IsNearWhiteTint(const RE::NiColorA& a_color)
+	{
+		const float avg = (a_color.red + a_color.green + a_color.blue) / 3.0f;
+		return std::abs(a_color.red - avg) < 0.02f &&
+		       std::abs(a_color.green - avg) < 0.02f &&
+		       std::abs(a_color.blue - avg) < 0.02f &&
+		       avg > 0.92f;
+	}
+
+	struct EmissiveTintCandidate
+	{
+		bool valid = false;
+		float distanceSq = std::numeric_limits<float>::max();
+		float luma = -1.0f;
+		RE::NiColorA tint{};
+	};
+
+	void UpdateEmissiveTintCandidate(EmissiveTintCandidate& a_candidate, float a_distanceSq, float a_luma, const RE::NiColorA& a_tint)
+	{
+		const bool isCloser = a_distanceSq + 1e-3f < a_candidate.distanceSq;
+		const bool sameDistance = std::abs(a_distanceSq - a_candidate.distanceSq) <= 1e-3f;
+		if (!a_candidate.valid || isCloser || (sameDistance && a_luma > a_candidate.luma)) {
+			a_candidate.valid = true;
+			a_candidate.distanceSq = a_distanceSq;
+			a_candidate.luma = a_luma;
+			a_candidate.tint = a_tint;
+		}
+	}
+
+	RE::NiColorA BuildBillboardFallbackTint(
+		const ParticleLights::Config& a_config,
+		bool a_hasGradientConfig,
+		const ParticleLights::GradientConfig& a_gradientConfig)
+	{
+		RE::NiColorA fallback{ 1.0f, 1.0f, 1.0f, 1.0f };
+		if (a_hasGradientConfig) {
+			fallback.red = a_gradientConfig.color.red;
+			fallback.green = a_gradientConfig.color.green;
+			fallback.blue = a_gradientConfig.color.blue;
+		} else {
+			fallback.red = a_config.colorMult.red;
+			fallback.green = a_config.colorMult.green;
+			fallback.blue = a_config.colorMult.blue;
+		}
+		return fallback;
+	}
+
+	RE::BSLightingShaderProperty* GetLightingShaderProperty(RE::NiProperty* a_property)
+	{
+		if (!a_property || a_property->GetRTTI() != globals::rtti::BSLightingShaderPropertyRTTI.get())
+			return nullptr;
+		return static_cast<RE::BSLightingShaderProperty*>(a_property);
+	}
+
+	void ConsiderLightingEmissiveTint(
+		RE::BSGeometry* a_geometry,
+		RE::BSGeometry* a_ignoreGeometry,
+		const RE::NiPoint3& a_targetPosition,
+		EmissiveTintCandidate& a_bestAnyTint,
+		EmissiveTintCandidate& a_bestNonWhiteTint)
+	{
+		if (!a_geometry || a_geometry == a_ignoreGeometry)
+			return;
+
+		auto* lightingProperty = GetLightingShaderProperty(a_geometry->GetGeometryRuntimeData().shaderProperty.get());
+		if (!lightingProperty || !lightingProperty->emissiveColor || lightingProperty->emissiveMult <= 1e-4f)
+			return;
+
+		RE::NiColorA emissiveTint{
+			std::max(lightingProperty->emissiveColor->red, 0.0f) * lightingProperty->emissiveMult,
+			std::max(lightingProperty->emissiveColor->green, 0.0f) * lightingProperty->emissiveMult,
+			std::max(lightingProperty->emissiveColor->blue, 0.0f) * lightingProperty->emissiveMult,
+			1.0f
+		};
+
+		const float emissiveLuma =
+			std::max(emissiveTint.red, 0.0f) +
+			std::max(emissiveTint.green, 0.0f) +
+			std::max(emissiveTint.blue, 0.0f);
+		if (emissiveLuma <= 1e-4f)
+			return;
+
+		const auto& center = a_geometry->worldBound.center;
+		const float dx = center.x - a_targetPosition.x;
+		const float dy = center.y - a_targetPosition.y;
+		const float dz = center.z - a_targetPosition.z;
+		const float distanceSq = (dx * dx) + (dy * dy) + (dz * dz);
+		UpdateEmissiveTintCandidate(a_bestAnyTint, distanceSq, emissiveLuma, emissiveTint);
+		if (!IsNearWhiteTint(emissiveTint))
+			UpdateEmissiveTintCandidate(a_bestNonWhiteTint, distanceSq, emissiveLuma, emissiveTint);
+	}
+
+	void CollectNearbyLightingTint(
+		RE::NiNode* a_root,
+		RE::BSGeometry* a_ignoreGeometry,
+		std::uint32_t a_depthRemaining,
+		const RE::NiPoint3& a_targetPosition,
+		EmissiveTintCandidate& a_bestAnyTint,
+		EmissiveTintCandidate& a_bestNonWhiteTint)
+	{
+		if (!a_root)
+			return;
+
+		for (const auto& child : a_root->GetChildren()) {
+			auto* childObject = child.get();
+			if (!childObject)
+				continue;
+
+			if (auto* childGeometry = childObject->AsGeometry())
+				ConsiderLightingEmissiveTint(childGeometry, a_ignoreGeometry, a_targetPosition, a_bestAnyTint, a_bestNonWhiteTint);
+
+			if (a_depthRemaining > 0) {
+				if (auto* childNode = childObject->AsNode())
+					CollectNearbyLightingTint(childNode, a_ignoreGeometry, a_depthRemaining - 1, a_targetPosition, a_bestAnyTint, a_bestNonWhiteTint);
+			}
+		}
+	}
+
+	bool TryGetBillboardSiblingEmissiveTint(RE::BSGeometry* a_billboardGeometry, RE::NiColorA& a_outTint)
+	{
+		if (!a_billboardGeometry)
+			return false;
+
+		auto* billboardParentNode = a_billboardGeometry->parent ? a_billboardGeometry->parent->AsNode() : nullptr;
+		if (!billboardParentNode)
+			return false;
+
+		RE::NiNode* searchRoot = billboardParentNode;
+		if (auto* ownerNode = billboardParentNode->parent ? billboardParentNode->parent->AsNode() : nullptr)
+			searchRoot = ownerNode;
+
+		const RE::NiPoint3 targetPosition = a_billboardGeometry->world.translate;
+		EmissiveTintCandidate bestAnyTint{};
+		EmissiveTintCandidate bestNonWhiteTint{};
+		CollectNearbyLightingTint(searchRoot, a_billboardGeometry, 2u, targetPosition, bestAnyTint, bestNonWhiteTint);
+		if (!bestAnyTint.valid)
+			return false;
+
+		// Prefer non-white sibling emissive tint when available; fall back to closest emissive tint otherwise.
+		a_outTint = bestNonWhiteTint.valid ? bestNonWhiteTint.tint : bestAnyTint.tint;
+		return true;
+	}
+
+	RE::NiColorA BuildEffectMaterialEmissiveTint(RE::BSEffectShaderMaterial* a_material, RE::BSEffectShaderProperty* a_shaderProperty)
+	{
+		RE::NiColorA materialEmissiveTint{
+			a_material->baseColor.red * a_material->baseColorScale,
+			a_material->baseColor.green * a_material->baseColorScale,
+			a_material->baseColor.blue * a_material->baseColorScale,
+			1.0f
+		};
+		// unk88 is the runtime ExtraEmittanceSource color override (NiColor* at offset 0x88; see
+		// CommonLibSSE-NG BSEffectShaderProperty and Utils/ExternalEmittance.cpp). The game writes
+		// it for effects with kExternalEmittance — fold it in so the particle light matches the
+		// tint vanilla would render with.
+		if (auto emittance = a_shaderProperty->unk88) {
+			materialEmissiveTint.red *= emittance->red;
+			materialEmissiveTint.green *= emittance->green;
+			materialEmissiveTint.blue *= emittance->blue;
+		}
+		return materialEmissiveTint;
+	}
+
+	float GetEmissiveTintLuma(const RE::NiColorA& a_tint)
+	{
+		return std::max(a_tint.red, 0.0f) +
+		       std::max(a_tint.green, 0.0f) +
+		       std::max(a_tint.blue, 0.0f);
+	}
+
+	std::string ExtractTextureStem(std::string_view a_path)
+	{
+		if (a_path.empty())
+			return {};
+
+		auto lastSeparatorPos = a_path.find_last_of("\\/");
+		std::string_view filename = (lastSeparatorPos == std::string::npos) ? a_path : a_path.substr(lastSeparatorPos + 1);
+		if (filename.empty() || !EndsWithDdsInsensitive(filename))
+			return {};
+
+		filename.remove_suffix(4);  // Remove ".dds"
+		if (filename.empty())
+			return {};
+
+		std::string textureName{};
+		textureName.reserve(filename.size());
+		for (char c : filename)
+			textureName.push_back(ToLowerAscii(c));
+
+		return textureName;
+	}
+
+	struct VertexColor
+	{
+		std::uint8_t data[4];
+	};
+
+	bool TryGetMaxAlphaVertexColor(const std::uint8_t* a_rawVertexData, std::uint32_t a_vertexSize, std::uint32_t a_colorOffset, std::uint32_t a_vertexCount, VertexColor& a_outVertexColor)
+	{
+		if (!a_rawVertexData || a_vertexSize < sizeof(VertexColor) || a_vertexCount == 0)
+			return false;
+		if (a_colorOffset > (a_vertexSize - sizeof(VertexColor)))
+			return false;
+
+		std::uint8_t maxAlpha = 0;
+		bool found = false;
+		VertexColor bestColor{};
+
+#if defined(_MSC_VER)
+		__try
+#endif
+		{
+			for (std::uint32_t v = 0; v < a_vertexCount; ++v) {
+				const std::size_t byteOffset = static_cast<std::size_t>(a_vertexSize) * static_cast<std::size_t>(v) + static_cast<std::size_t>(a_colorOffset);
+				const auto* vertex = reinterpret_cast<const VertexColor*>(a_rawVertexData + byteOffset);
+				const std::uint8_t alpha = vertex->data[3];
+				if (alpha > maxAlpha) {
+					maxAlpha = alpha;
+					bestColor = *vertex;
+					found = true;
+				}
+			}
+		}
+#if defined(_MSC_VER)
+		__except (1)
+		{
+			return false;
+		}
+#endif
+
+		if (found)
+			a_outVertexColor = bestColor;
+		return found;
+	}
+}
+
+float LightLimitFix::CalculateLightDistance(float3 a_lightPosition, float a_radius)
+{
+	return (a_lightPosition.x * a_lightPosition.x) + (a_lightPosition.y * a_lightPosition.y) + (a_lightPosition.z * a_lightPosition.z) - (a_radius * a_radius);
+}
+
+float LightLimitFix::CalculateLuminance(CachedParticleLight& light, RE::NiPoint3& point)
+{
+	// Mirrors BSLight::CalculateLuminance — keeps NPC detection identical to the GPU lighting math.
+	auto lightDirection = light.position - point;
+	float lightDist = lightDirection.Length();
+	float intensityFactor = std::clamp(lightDist / light.radius, 0.0f, 1.0f);
+	float intensityMultiplier = 1 - intensityFactor * intensityFactor;
+	return light.grey * intensityMultiplier;
+}
+
+void LightLimitFix::AddParticleLightLuminance(RE::NiPoint3& targetPosition, int& numHits, float& lightLevel)
+{
+	auto shaderCache = globals::shaderCache;
+	if (!shaderCache->IsEnabled())
+		return;
+
+	std::shared_lock<std::shared_mutex> lk{ cachedParticleLightsMutex };
+	int particleLightsDetectionHits = 0;
+	if (settings.EnableParticleLightsDetection) {
+		for (auto& light : cachedParticleLights) {
+			auto luminance = CalculateLuminance(light, targetPosition);
+			lightLevel += luminance;
+			if (luminance > 0.0)
+				particleLightsDetectionHits++;
+		}
+	}
+	numHits += particleLightsDetectionHits;
+}
+
+LightLimitFix::ParticleLightReference LightLimitFix::GetParticleLightConfigs(RE::BSRenderPass* a_pass)
+{
+	if (!a_pass || !a_pass->geometry || !a_pass->shaderProperty)
+		return {};
+
+	auto& particleLights = globals::features::llf::particleLights;
+
+	auto cacheInvalidReference = [&](RE::BSGeometry* node) {
+		ParticleLightReference invalidReference{};
+		invalidReference.valid = false;
+		invalidReference.configVersion = particleLights.configVersion;
+		std::lock_guard<std::mutex> queueLock{ particleLightsQueueMutex };
+		particleLightsReferences[node] = invalidReference;
+		return invalidReference;
+	};
+
+	// see https://www.nexusmods.com/skyrimspecialedition/articles/1391
+	if (!settings.EnableParticleLights)
+		return {};
+
+	auto shaderProperty = a_pass->shaderProperty->GetRTTI() == globals::rtti::BSEffectShaderPropertyRTTI.get() ?
+	                          static_cast<RE::BSEffectShaderProperty*>(a_pass->shaderProperty) :
+	                          nullptr;
+	if (!shaderProperty || shaderProperty->lightData)
+		return {};
+
+	auto material = shaderProperty->GetMaterial();
+	if (!material)
+		return {};
+
+	bool billboard = a_pass->geometry->GetRTTI() != globals::rtti::NiParticleSystemRTTI.get();
+	if (billboard) {
+		auto parent = a_pass->geometry->parent;
+		if (!parent || parent->GetRTTI() != globals::rtti::NiBillboardNodeRTTI.get())
+			return {};
+	}
+
+	auto* node = a_pass->geometry;
+
+	{
+		std::lock_guard<std::mutex> queueLock{ particleLightsQueueMutex };
+		auto it = particleLightsReferences.find(node);
+		if (it != particleLightsReferences.end()) {
+			if (it->second.configVersion == particleLights.configVersion)
+				return it->second;
+			particleLightsReferences.erase(it);
+		}
+	}
+
+	if (material->sourceTexturePath.empty())
+		return {};
+
+	std::string textureName = ExtractTextureStem(material->sourceTexturePath.c_str());
+	if (textureName.empty())
+		return cacheInvalidReference(node);
+
+	auto& configs = particleLights.particleLightConfigs;
+	auto it = configs.find(textureName);
+	if (it == configs.end())
+		return cacheInvalidReference(node);
+
+	ParticleLights::Config config = it->second;
+	bool hasGradientConfig = false;
+	ParticleLights::GradientConfig gradientConfig{};
+	if (!material->greyscaleTexturePath.empty()) {
+		// Gradients are an optional override: a missing entry falls back to the base
+		// config rather than disabling the particle light entirely.
+		const std::string gradientName = ExtractTextureStem(material->greyscaleTexturePath.c_str());
+		if (!gradientName.empty()) {
+			auto& gradientConfigs = particleLights.particleLightGradientConfigs;
+			if (auto itGradient = gradientConfigs.find(gradientName); itGradient != gradientConfigs.end()) {
+				hasGradientConfig = true;
+				gradientConfig = itGradient->second;
+			}
+		}
+	}
+
+	ParticleLightReference reference{};
+	reference.valid = true;
+	reference.billboard = billboard;
+	reference.applyEffectMaterialTint = true;
+	reference.config = config;
+	reference.hasGradientConfig = hasGradientConfig;
+	reference.gradientConfig = gradientConfig;
+	reference.baseColor = { 1, 1, 1, 1 };
+	reference.configVersion = particleLights.configVersion;
+
+	if (billboard) {
+		bool hasVertexTint = false;
+		if (auto rendererData = a_pass->geometry->GetGeometryRuntimeData().rendererData) {
+			if (auto triShape = a_pass->geometry->AsTriShape()) {
+				const std::uint32_t vertexSize = rendererData->vertexDesc.GetSize();
+				if (rendererData->vertexDesc.HasFlag(RE::BSGraphics::Vertex::Flags::VF_COLORS) && rendererData->rawVertexData && vertexSize > 0u) {
+					const std::uint32_t offset = rendererData->vertexDesc.GetAttributeOffset(RE::BSGraphics::Vertex::Attribute::VA_COLOR);
+					const std::uint32_t vertexCount = static_cast<std::uint32_t>(triShape->GetTrishapeRuntimeData().vertexCount);
+
+					VertexColor maxAlphaVertexColor{};
+					if (TryGetMaxAlphaVertexColor(rendererData->rawVertexData, vertexSize, offset, vertexCount, maxAlphaVertexColor)) {
+						reference.baseColor.red *= maxAlphaVertexColor.data[0] / 255.f;
+						reference.baseColor.green *= maxAlphaVertexColor.data[1] / 255.f;
+						reference.baseColor.blue *= maxAlphaVertexColor.data[2] / 255.f;
+						hasVertexTint = true;
+						if (shaderProperty->flags.any(RE::BSShaderProperty::EShaderPropertyFlag::kVertexAlpha))
+							reference.baseColor.alpha *= maxAlphaVertexColor.data[3] / 255.f;
+					}
+				}
+			}
+		}
+
+		RE::NiColorA siblingEmissiveTint{};
+		bool hasSiblingEmissiveTint = false;
+		const bool vertexTintLooksWhite = hasVertexTint && IsNearWhiteTint(reference.baseColor);
+		if (!hasVertexTint || vertexTintLooksWhite) {
+			hasSiblingEmissiveTint = TryGetBillboardSiblingEmissiveTint(node, siblingEmissiveTint);
+			const bool siblingTintIsNonWhite = hasSiblingEmissiveTint && !IsNearWhiteTint(siblingEmissiveTint);
+
+			const RE::NiColorA materialEmissiveTint = BuildEffectMaterialEmissiveTint(material, shaderProperty);
+			const float materialEmissiveLuma = GetEmissiveTintLuma(materialEmissiveTint);
+			const bool hasMaterialEmissiveTint = materialEmissiveLuma > 1e-4f;
+			const bool materialTintIsNonWhite = hasMaterialEmissiveTint && !IsNearWhiteTint(materialEmissiveTint);
+
+			// Resolve the fallback tint from a single source so a white tint never gets re-tinted
+			// from an adjacent emissive — that double-application produces washed-out particle lights.
+			if (materialTintIsNonWhite) {
+				reference.baseColor = materialEmissiveTint;
+				reference.applyEffectMaterialTint = false;
+			} else if (siblingTintIsNonWhite) {
+				reference.baseColor = siblingEmissiveTint;
+				reference.applyEffectMaterialTint = false;
+			} else if (hasMaterialEmissiveTint) {
+				reference.baseColor = materialEmissiveTint;
+				reference.applyEffectMaterialTint = false;
+			} else if (hasSiblingEmissiveTint) {
+				reference.baseColor = siblingEmissiveTint;
+				reference.applyEffectMaterialTint = false;
+			} else {
+				reference.baseColor = BuildBillboardFallbackTint(config, hasGradientConfig, gradientConfig);
+				reference.applyEffectMaterialTint = true;
+			}
+		}
+	}
+
+	{
+		std::lock_guard<std::mutex> queueLock{ particleLightsQueueMutex };
+		particleLightsReferences[node] = reference;
+	}
+	return reference;
+}
+
+bool LightLimitFix::CheckParticleLights(RE::BSRenderPass* a_pass, uint32_t)
+{
+	if (!a_pass || !a_pass->geometry || !a_pass->shaderProperty)
+		return true;
+
+	auto shaderCache = globals::shaderCache;
+	if (!shaderCache->IsEnabled())
+		return true;
+
+	auto reference = GetParticleLightConfigs(a_pass);
+	if (reference.valid) {
+		if (AddParticleLight(a_pass, reference))
+			return !(settings.EnableParticleLightsCulling && reference.config.cull);
+	}
+	return true;
+}
+
+bool LightLimitFix::AddParticleLight(RE::BSRenderPass* a_pass, ParticleLightReference a_reference)
+{
+	if (!a_pass || !a_pass->geometry || !a_pass->shaderProperty)
+		return false;
+
+	auto shaderProperty = a_pass->shaderProperty->GetRTTI() == globals::rtti::BSEffectShaderPropertyRTTI.get() ?
+	                          static_cast<RE::BSEffectShaderProperty*>(a_pass->shaderProperty) :
+	                          nullptr;
+	if (!shaderProperty)
+		return false;
+
+	auto material = shaderProperty->GetMaterial();
+	if (!material)
+		return false;
+	const auto& config = a_reference.config;
+
+	a_pass->geometry->IncRefCount();
+
+	if (!a_reference.billboard) {
+		if (auto particleSystem = static_cast<RE::NiParticleSystem*>(a_pass->geometry)) {
+			if (auto particleData = particleSystem->GetParticlesRuntimeData().particleData.get())
+				particleData->IncRefCount();
+		}
+	}
+
+	RE::NiColorA color = a_reference.baseColor;
+	if (a_reference.applyEffectMaterialTint) {
+		color.red *= material->baseColor.red * material->baseColorScale;
+		color.green *= material->baseColor.green * material->baseColorScale;
+		color.blue *= material->baseColor.blue * material->baseColorScale;
+
+		// unk88 is the ExtraEmittanceSource override; see Utils/ExternalEmittance.cpp.
+		if (auto emittance = shaderProperty->unk88) {
+			color.red *= emittance->red;
+			color.green *= emittance->green;
+			color.blue *= emittance->blue;
+		}
+	}
+
+	if (a_reference.hasGradientConfig) {
+		auto grey = float3(config.colorMult.red, config.colorMult.green, config.colorMult.blue).Dot(float3(0.3f, 0.59f, 0.11f));
+		color.red *= grey * a_reference.gradientConfig.color.red;
+		color.green *= grey * a_reference.gradientConfig.color.green;
+		color.blue *= grey * a_reference.gradientConfig.color.blue;
+	} else {
+		color.red *= config.colorMult.red;
+		color.green *= config.colorMult.green;
+		color.blue *= config.colorMult.blue;
+	}
+	// Stash radiusMult as alpha for the downstream cluster pass.
+	color.alpha = std::max(config.radiusMult, 0.0f);
+
+	ParticleLightInfo info;
+	info.billboard = a_reference.billboard;
+	info.node = a_pass->geometry;
+	info.color = color;
+	info.radiusMult = config.radiusMult;
+
+	bool enqueued = false;
+	{
+		std::lock_guard<std::mutex> queueLock{ particleLightsQueueMutex };
+		constexpr std::size_t kMaxQueuedParticleLights = static_cast<std::size_t>(MAX_LIGHTS) * 16u;
+		if (queuedParticleLights.size() < kMaxQueuedParticleLights) {
+			queuedParticleLights.push_back(info);
+			enqueued = true;
+		}
+	}
+
+	if (!enqueued) {
+		if (!a_reference.billboard) {
+			if (auto particleSystem = static_cast<RE::NiParticleSystem*>(a_pass->geometry)) {
+				if (auto particleData = particleSystem->GetParticlesRuntimeData().particleData.get())
+					particleData->DecRefCount();
+			}
+		}
+		a_pass->geometry->DecRefCount();
+		return false;
+	}
+
+	return true;
+}
+
+void LightLimitFix::AddCachedParticleLights(eastl::vector<LightData>& lightsData, LightLimitFix::LightData& light)
+{
+	if (lightsData.size() >= MAX_LIGHTS)
+		return;
+
+	static float& lightFadeStart = *reinterpret_cast<float*>(REL::RelocationID(527668, 414582).address());
+	static float& lightFadeEnd = *reinterpret_cast<float*>(REL::RelocationID(527669, 414583).address());
+	const float3 luminanceWeights = float3(0.3f, 0.59f, 0.11f);
+
+	if (settings.MaxParticleDistance > 0.0f) {
+		const float maxDistSq = settings.MaxParticleDistance * settings.MaxParticleDistance;
+		const auto& pos = light.positionWS[0].data;  // camera-relative
+		const float distSq = (pos.x * pos.x) + (pos.y * pos.y) + (pos.z * pos.z);
+		if (distSq > maxDistSq)
+			return;
+	}
+
+	float distance = CalculateLightDistance(light.positionWS[0].data, light.radius);
+
+	float dimmer = 0.0f;
+	if (distance < lightFadeStart || lightFadeEnd == 0.0f)
+		dimmer = 1.0f;
+	else if (distance <= lightFadeEnd)
+		dimmer = 1.0f - ((distance - lightFadeStart) / (lightFadeEnd - lightFadeStart));
+	else
+		dimmer = 0.0f;
+
+	light.fade *= dimmer;
+	const float luminanceScale = light.fade;
+	if ((light.color.x + light.color.y + light.color.z) * luminanceScale > 1e-4 && light.radius > 1e-4) {
+		light.invRadius = 1.f / light.radius;
+		lightsData.push_back(light);
+
+		if (cachedParticleLights.size() < MAX_LIGHTS) {
+			CachedParticleLight cachedParticleLight{};
+			cachedParticleLight.grey = float3(light.color.x, light.color.y, light.color.z).Dot(luminanceWeights) * luminanceScale;
+			cachedParticleLight.radius = light.radius;
+			cachedParticleLight.position = {
+				light.positionWS[0].data.x + eyePositionCached[0].x,
+				light.positionWS[0].data.y + eyePositionCached[0].y,
+				light.positionWS[0].data.z + eyePositionCached[0].z
+			};
+			cachedParticleLights.push_back(cachedParticleLight);
+		}
+	}
+}
+
+void LightLimitFix::ProcessQueuedParticleLights(eastl::vector<LightData>& lightsData)
+{
+	std::lock_guard<std::shared_mutex> lk{ cachedParticleLightsMutex };
+	cachedParticleLights.clear();
+
+	LightData clusteredLight{};
+	uint32_t clusteredLights = 0;
+
+	auto flushClusteredLight = [&]() {
+		if (!clusteredLights)
+			return;
+
+		const float clusterCount = static_cast<float>(clusteredLights);
+		clusteredLight.radius /= clusterCount;
+		clusteredLight.positionWS[0].data /= clusterCount;
+		clusteredLight.positionWS[1].data = clusteredLight.positionWS[0].data;
+
+		if (eyeCount == 2) {
+			// Second-eye cache is only populated in VR; read it only here.
+			const auto eyePositionOffset = eyePositionCached[0] - eyePositionCached[1];
+			clusteredLight.positionWS[1].data.x += eyePositionOffset.x;
+			clusteredLight.positionWS[1].data.y += eyePositionOffset.y;
+			clusteredLight.positionWS[1].data.z += eyePositionOffset.z;
+		}
+
+		clusteredLight.lightFlags.set(LightFlags::Simple);
+		clusteredLight.lightFlags.set(LightFlags::Particle);
+		AddCachedParticleLights(lightsData, clusteredLight);
+
+		clusteredLights = 0;
+		clusteredLight = {};
+	};
+
+	std::lock_guard<std::mutex> queueLock{ particleLightsQueueMutex };
+	for (const auto& particleLight : currentParticleLights) {
+		if (!particleLight.node)
+			continue;
+
+		if (!particleLight.billboard) {
+			auto particleSystem = static_cast<RE::NiParticleSystem*>(particleLight.node);
+			if (particleSystem && particleSystem->GetParticlesRuntimeData().particleData.get()) {
+				auto particleData = particleSystem->GetParticlesRuntimeData().particleData.get();
+				auto& particleSystemRuntimeData = particleSystem->GetParticleSystemRuntimeData();
+				auto& particleRuntimeData = particleData->GetParticlesRuntimeData();
+
+				if (!particleRuntimeData.radii || !particleRuntimeData.sizes || !particleRuntimeData.positions)
+					continue;
+
+				std::uint32_t numVertices = static_cast<std::uint32_t>(particleData->GetActiveVertexCount());
+				const std::uint32_t runtimeMaxVertices = static_cast<std::uint32_t>(particleRuntimeData.maxNumVertices);
+				const std::uint32_t runtimeNumVertices = static_cast<std::uint32_t>(particleRuntimeData.numVertices);
+				if (runtimeMaxVertices == 0)
+					continue;
+				numVertices = std::min(numVertices, runtimeMaxVertices);
+				if (runtimeNumVertices > 0)
+					numVertices = std::min(numVertices, runtimeNumVertices);
+
+				std::uint32_t maxPerEmitter = static_cast<std::uint32_t>(std::max(1, settings.MaxParticlesPerEmitter));
+				if (numVertices > maxPerEmitter)
+					numVertices = maxPerEmitter;
+
+				for (std::uint32_t p = 0; p < numVertices; p++) {
+					float radius = particleRuntimeData.radii[p] * particleRuntimeData.sizes[p];
+
+					auto initialPosition = particleRuntimeData.positions[p];
+					if (!particleSystemRuntimeData.isWorldspace) {
+						// First-person meshes report a scaled model bound vs world bound mismatch.
+						if ((particleLight.node->GetModelData().modelBound.radius * particleLight.node->world.scale) != particleLight.node->worldBound.radius) {
+							const auto& center = particleLight.node->worldBound.center;
+							initialPosition = { initialPosition.x + center.x, initialPosition.y + center.y, initialPosition.z + center.z };
+						} else {
+							const auto& translate = particleLight.node->world.translate;
+							initialPosition = { initialPosition.x + translate.x, initialPosition.y + translate.y, initialPosition.z + translate.z };
+						}
+					}
+
+					RE::NiPoint3 positionWS{
+						initialPosition.x - eyePositionCached[0].x,
+						initialPosition.y - eyePositionCached[0].y,
+						initialPosition.z - eyePositionCached[0].z
+					};
+
+					if (clusteredLights) {
+						auto averageRadius = clusteredLight.radius / (float)clusteredLights;
+						float radiusDiff = abs(averageRadius - radius);
+
+						auto averagePosition = clusteredLight.positionWS[0].data / (float)clusteredLights;
+						float positionDiff = positionWS.GetDistance({ averagePosition.x, averagePosition.y, averagePosition.z });
+
+						if ((radiusDiff + positionDiff) > settings.ParticleClusterThreshold ||
+							!settings.EnableParticleLightsOptimization) {
+							flushClusteredLight();
+						}
+					}
+
+					float alpha = particleLight.color.alpha;
+					float3 color{
+						particleLight.color.red,
+						particleLight.color.green,
+						particleLight.color.blue
+					};
+					if (particleRuntimeData.color) {
+						alpha *= particleRuntimeData.color[p].alpha;
+						color.x *= particleRuntimeData.color[p].red;
+						color.y *= particleRuntimeData.color[p].green;
+						color.z *= particleRuntimeData.color[p].blue;
+					}
+					clusteredLight.color += Saturation(color, settings.ParticleLightsSaturation) * alpha * settings.ParticleBrightness;
+
+					clusteredLight.radius += radius * particleLight.radiusMult * settings.ParticleRadius;
+
+					clusteredLight.positionWS[0].data.x += positionWS.x;
+					clusteredLight.positionWS[0].data.y += positionWS.y;
+					clusteredLight.positionWS[0].data.z += positionWS.z;
+
+					clusteredLights++;
+				}
+			}
+		} else {
+			LightData light{};
+
+			light.color.x = particleLight.color.red;
+			light.color.y = particleLight.color.green;
+			light.color.z = particleLight.color.blue;
+
+			light.color = Saturation(light.color, settings.ParticleLightsSaturation);
+
+			light.color *= particleLight.color.alpha * settings.BillboardBrightness;
+			light.radius = particleLight.node->worldBound.radius * particleLight.radiusMult * settings.BillboardRadius * 0.5f;
+
+			auto position = particleLight.node->world.translate;
+			SetLightPosition(light, position);
+
+			light.lightFlags.set(LightFlags::Simple);
+			light.lightFlags.set(LightFlags::Particle);
+
+			AddCachedParticleLights(lightsData, light);
+		}
+	}
+
+	flushClusteredLight();
+}
+
+float LightLimitFix::Hooks::AIProcess_CalculateLightValue_GetLuminance::thunk(
+	RE::ShadowSceneNode* shadowSceneNode,
+	RE::NiPoint3& targetPosition,
+	int& numHits,
+	float& sunLightLevel,
+	float& lightLevel,
+	RE::NiLight& refLight,
+	int32_t shadowBitMask)
+{
+	auto ret = func(shadowSceneNode, targetPosition, numHits, sunLightLevel, lightLevel, refLight, shadowBitMask);
+	globals::features::lightLimitFix.AddParticleLightLuminance(targetPosition, numHits, ret);
+	return ret;
+}

--- a/src/Features/LightLimitFix/Particle.cpp
+++ b/src/Features/LightLimitFix/Particle.cpp
@@ -305,8 +305,6 @@ LightLimitFix::ParticleLightReference LightLimitFix::GetParticleLightConfigs(RE:
 	if (!a_pass || !a_pass->geometry || !a_pass->shaderProperty)
 		return {};
 
-	auto& particleLights = globals::features::llf::particleLights;
-
 	auto cacheInvalidReference = [&](RE::BSGeometry* node) {
 		ParticleLightReference invalidReference{};
 		invalidReference.valid = false;

--- a/src/Features/LightLimitFix/Particle.cpp
+++ b/src/Features/LightLimitFix/Particle.cpp
@@ -183,11 +183,9 @@ namespace
 			a_material->baseColor.blue * a_material->baseColorScale,
 			1.0f
 		};
-		// unk88 is the runtime ExtraEmittanceSource color override (NiColor* at offset 0x88; see
-		// CommonLibSSE-NG BSEffectShaderProperty and Utils/ExternalEmittance.cpp). The game writes
-		// it for effects with kExternalEmittance — fold it in so the particle light matches the
-		// tint vanilla would render with.
-		if (auto emittance = a_shaderProperty->unk88) {
+		// Fold in the runtime external-emittance override (set for kExternalEmittance effects)
+		// so the particle light matches the tint vanilla renders. See Utils/ExternalEmittance.cpp.
+		if (auto emittance = a_shaderProperty->emittanceColor) {
 			materialEmissiveTint.red *= emittance->red;
 			materialEmissiveTint.green *= emittance->green;
 			materialEmissiveTint.blue *= emittance->blue;
@@ -499,8 +497,7 @@ bool LightLimitFix::AddParticleLight(RE::BSRenderPass* a_pass, ParticleLightRefe
 		color.green *= material->baseColor.green * material->baseColorScale;
 		color.blue *= material->baseColor.blue * material->baseColorScale;
 
-		// unk88 is the ExtraEmittanceSource override; see Utils/ExternalEmittance.cpp.
-		if (auto emittance = shaderProperty->unk88) {
+		if (auto emittance = shaderProperty->emittanceColor) {
 			color.red *= emittance->red;
 			color.green *= emittance->green;
 			color.blue *= emittance->blue;

--- a/src/Features/LightLimitFix/ParticleLights.cpp
+++ b/src/Features/LightLimitFix/ParticleLights.cpp
@@ -1,0 +1,171 @@
+#include "Features/LightLimitFix/ParticleLights.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <exception>
+#include <optional>
+
+namespace
+{
+	// User-editable INI values feed light radius/color math; reject non-finite and
+	// clamp to a sane range so a malformed entry can't destabilize the pipeline.
+	float SanitizeIniFloat(double a_value, float a_min, float a_max, float a_default)
+	{
+		const float f = static_cast<float>(a_value);
+		if (!std::isfinite(f))
+			return a_default;
+		return std::clamp(f, a_min, a_max);
+	}
+}
+
+namespace
+{
+	std::optional<std::string> ExtractIniStem(const std::string& path)
+	{
+		auto lastSeparatorPos = path.find_last_of("\\/");
+		if (lastSeparatorPos == std::string::npos) {
+			logger::error("[LLF] Path incomplete");
+			return std::nullopt;
+		}
+
+		std::string filename = path.substr(lastSeparatorPos + 1);
+		if (filename.size() < 4) {
+			logger::error("[LLF] Path too short");
+			return std::nullopt;
+		}
+
+		filename.erase(filename.length() - 4);  // Remove ".ini"
+		std::transform(filename.begin(), filename.end(), filename.begin(),
+			[](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+		return filename;
+	}
+}
+
+void ParticleLights::GetConfigs()
+{
+	++configVersion;
+	particleLightConfigs.clear();
+	particleLightGradientConfigs.clear();
+
+	particleLightConfigs["default"] = Config{};
+
+	if (std::filesystem::exists("Data\\ParticleLights")) {
+		logger::info("[LLF] Loading particle lights configs");
+
+		auto configs = clib_util::distribution::get_configs("Data\\ParticleLights", "", ".ini");
+
+		if (configs.empty()) {
+			logger::warn("[LLF] No .ini files were found within the Data\\ParticleLights folder, aborting...");
+		} else {
+			logger::info("[LLF] {} matching inis found", configs.size());
+
+			for (auto& path : configs) {
+				logger::info("[LLF] loading ini : {}", path);
+
+				CSimpleIniA ini;
+				ini.SetUnicode();
+				ini.SetMultiKey();
+
+				if (const auto rc = ini.LoadFile(path.c_str()); rc < 0) {
+					logger::error("\t\t[LLF] couldn't read INI");
+					continue;
+				}
+
+				Config data{};
+
+				data.cull = ini.GetBoolValue("Light", "Cull", false);
+				data.colorMult.red = SanitizeIniFloat(ini.GetDoubleValue("Light", "ColorMultRed", 1.0), 0.0f, 16.0f, 1.0f);
+				data.colorMult.green = SanitizeIniFloat(ini.GetDoubleValue("Light", "ColorMultGreen", 1.0), 0.0f, 16.0f, 1.0f);
+				data.colorMult.blue = SanitizeIniFloat(ini.GetDoubleValue("Light", "ColorMultBlue", 1.0), 0.0f, 16.0f, 1.0f);
+				data.radiusMult = SanitizeIniFloat(ini.GetDoubleValue("Light", "RadiusMult", 1.0), 0.0f, 16.0f, 1.0f);
+
+				const auto filename = ExtractIniStem(path);
+				if (!filename) {
+					continue;
+				}
+
+				// Legacy first-win policy: keep behavior compatible with older particle light packs.
+				if (auto it = particleLightConfigs.find(*filename); it != particleLightConfigs.end()) {
+					logger::warn("[LLF] Duplicate particle config '{}'; keeping first entry, ignoring {}", *filename, path);
+					continue;
+				}
+
+				logger::debug("[LLF] Inserting {}", *filename);
+				particleLightConfigs.emplace(*filename, data);
+			}
+		}
+	}
+
+	if (std::filesystem::exists("Data\\ParticleLights\\Gradients")) {
+		logger::info("[LLF] Loading particle lights gradients configs");
+
+		auto configs = clib_util::distribution::get_configs("Data\\ParticleLights\\Gradients", "", ".ini");
+
+		if (configs.empty()) {
+			logger::warn("[LLF] No .ini files were found within the Data\\ParticleLights\\Gradients folder, aborting...");
+			return;
+		}
+
+		logger::info("[LLF] {} matching inis found", configs.size());
+
+		for (auto& path : configs) {
+			logger::info("[LLF] loading ini : {}", path);
+
+			CSimpleIniA ini;
+			ini.SetUnicode();
+			ini.SetMultiKey();
+
+			if (const auto rc = ini.LoadFile(path.c_str()); rc < 0) {
+				logger::error("\t\t[LLF] couldn't read INI");
+				continue;
+			}
+
+			GradientConfig data{};
+			constexpr std::string_view prefix1 = "0x";
+			constexpr std::string_view prefix2 = "#";
+			constexpr std::string_view cset = "0123456789ABCDEFabcdef";
+
+			const char* value = ini.GetValue("Gradient", "Color");
+			if (value && strcmp(value, "") != 0) {
+				std::string_view str = value;
+
+				if (str.starts_with(prefix1))
+					str.remove_prefix(prefix1.size());
+				if (str.starts_with(prefix2))
+					str.remove_prefix(prefix2.size());
+
+				bool matches = std::strspn(str.data(), cset.data()) == str.size();
+
+				if (matches) {
+					try {
+						uint32_t color = static_cast<uint32_t>(std::stoul(std::string(str), nullptr, 16));
+						data.color = color;
+					} catch (const std::exception&) {
+						logger::error("[LLF] invalid color");
+						continue;
+					}
+				} else {
+					logger::error("[LLF] invalid color");
+					continue;
+				}
+			} else {
+				logger::error("[LLF] missing color");
+				continue;
+			}
+
+			const auto filename = ExtractIniStem(path);
+			if (!filename) {
+				continue;
+			}
+
+			if (auto it = particleLightGradientConfigs.find(*filename); it != particleLightGradientConfigs.end()) {
+				logger::warn("[LLF] Duplicate particle gradient config '{}'; keeping first entry, ignoring {}", *filename, path);
+				continue;
+			}
+
+			logger::debug("[LLF] Inserting {}", *filename);
+			particleLightGradientConfigs.emplace(*filename, data);
+		}
+	}
+}

--- a/src/Features/LightLimitFix/ParticleLights.cpp
+++ b/src/Features/LightLimitFix/ParticleLights.cpp
@@ -17,10 +17,7 @@ namespace
 			return a_default;
 		return std::clamp(f, a_min, a_max);
 	}
-}
 
-namespace
-{
 	std::optional<std::string> ExtractIniStem(const std::string& path)
 	{
 		auto lastSeparatorPos = path.find_last_of("\\/");

--- a/src/Features/LightLimitFix/ParticleLights.h
+++ b/src/Features/LightLimitFix/ParticleLights.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+class ParticleLights
+{
+public:
+	struct Config
+	{
+		bool cull = false;
+		RE::NiColor colorMult{ 1.0f, 1.0f, 1.0f };
+		float radiusMult = 1.0f;
+	};
+
+	struct GradientConfig
+	{
+		RE::NiColor color;
+	};
+
+	ankerl::unordered_dense::map<std::string, Config> particleLightConfigs;
+	ankerl::unordered_dense::map<std::string, GradientConfig> particleLightGradientConfigs;
+	std::uint64_t configVersion = 0;
+
+	void GetConfigs();
+};

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -15,7 +15,6 @@
 #include "Features/InverseSquareLighting.h"
 #include "Features/LODBlending.h"
 #include "Features/LightLimitFix.h"
-#include "Features/LightLimitFix/ParticleLights.h"
 #include "Features/LinearLighting.h"
 #include "Features/PerformanceOverlay.h"
 #include "Features/RemoteControl.h"
@@ -97,7 +96,6 @@ namespace globals
 		{
 			void** normalDepthBuffer = nullptr;
 			void** readOnlyDepthBuffer = nullptr;
-			ParticleLights particleLights{};
 		}
 	}
 

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -15,6 +15,7 @@
 #include "Features/InverseSquareLighting.h"
 #include "Features/LODBlending.h"
 #include "Features/LightLimitFix.h"
+#include "Features/LightLimitFix/ParticleLights.h"
 #include "Features/LinearLighting.h"
 #include "Features/PerformanceOverlay.h"
 #include "Features/RemoteControl.h"
@@ -96,6 +97,7 @@ namespace globals
 		{
 			void** normalDepthBuffer = nullptr;
 			void** readOnlyDepthBuffer = nullptr;
+			ParticleLights particleLights{};
 		}
 	}
 

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -37,8 +37,6 @@ struct ExponentialHeightFog;
 struct HDRDisplay;
 struct ScreenshotFeature;
 
-class ParticleLights;
-
 class State;
 class Deferred;
 struct TruePBR;
@@ -105,7 +103,6 @@ namespace globals
 		{
 			extern void** normalDepthBuffer;
 			extern void** readOnlyDepthBuffer;
-			extern ParticleLights particleLights;
 		}
 	}
 

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -37,6 +37,8 @@ struct ExponentialHeightFog;
 struct HDRDisplay;
 struct ScreenshotFeature;
 
+class ParticleLights;
+
 class State;
 class Deferred;
 struct TruePBR;
@@ -103,6 +105,7 @@ namespace globals
 		{
 			extern void** normalDepthBuffer;
 			extern void** readOnlyDepthBuffer;
+			extern ParticleLights particleLights;
 		}
 	}
 

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -864,6 +864,62 @@ namespace Hooks
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
+	// Returns true when LightLimitFix wants to cull this render pass because the geometry was
+	// recognized as a particle light marked with `Cull = true` in its INI config. The SEH guard
+	// fails open so a transient bad render-pass pointer cannot crash a render-thread hook.
+	bool ShouldSkipRenderPassForParticleLights(RE::BSRenderPass* a_pass, uint32_t a_technique)
+	{
+#if defined(_MSC_VER)
+		__try
+#endif
+		{
+			return globals::features::lightLimitFix.loaded &&
+			       !globals::features::lightLimitFix.CheckParticleLights(a_pass, a_technique);
+		}
+#if defined(_MSC_VER)
+		__except (1)
+		{
+			return false;
+		}
+#endif
+	}
+
+	void BSBatchRenderer_RenderPassImmediately1::thunk(
+		RE::BSRenderPass* a_pass,
+		uint32_t a_technique,
+		bool a_alphaTest,
+		uint32_t a_renderFlags)
+	{
+		if (ShouldSkipRenderPassForParticleLights(a_pass, a_technique))
+			return;
+
+		func(a_pass, a_technique, a_alphaTest, a_renderFlags);
+	}
+
+	void BSBatchRenderer_RenderPassImmediately2::thunk(
+		RE::BSRenderPass* a_pass,
+		uint32_t a_technique,
+		bool a_alphaTest,
+		uint32_t a_renderFlags)
+	{
+		if (ShouldSkipRenderPassForParticleLights(a_pass, a_technique))
+			return;
+
+		func(a_pass, a_technique, a_alphaTest, a_renderFlags);
+	}
+
+	void BSBatchRenderer_RenderPassImmediately3::thunk(
+		RE::BSRenderPass* a_pass,
+		uint32_t a_technique,
+		bool a_alphaTest,
+		uint32_t a_renderFlags)
+	{
+		if (ShouldSkipRenderPassForParticleLights(a_pass, a_technique))
+			return;
+
+		func(a_pass, a_technique, a_alphaTest, a_renderFlags);
+	}
+
 	/**
 	 * @brief Installs hooks, detours, and memory patches for graphics, input, and rendering subsystems.
 	 *
@@ -964,6 +1020,14 @@ namespace Hooks
 		}
 
 		stl::write_thunk_call<BSLightingShader_SetupGeometry_GeometrySetupConstantPointLights>(REL::RelocationID(100565, 107300).address() + REL::Relocate(0x523, 0xB0E, 0x5FE));
+
+		logger::info("Hooking BSBatchRenderer::RenderPassImmediately");
+		stl::write_thunk_call<BSBatchRenderer_RenderPassImmediately1>(
+			REL::RelocationID(100877, 107673).address() + REL::Relocate(0x1E5, 0x1EE));
+		stl::write_thunk_call<BSBatchRenderer_RenderPassImmediately2>(
+			REL::RelocationID(100852, 107642).address() + REL::Relocate(0x29E, 0x28F));
+		stl::write_thunk_call<BSBatchRenderer_RenderPassImmediately3>(
+			REL::RelocationID(100871, 107667).address() + REL::Relocate(0xEE, 0xED));
 	}
 
 	void InstallEarlyHooks()

--- a/src/Hooks.h
+++ b/src/Hooks.h
@@ -19,6 +19,18 @@ namespace Hooks
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
+	struct BSBatchRenderer_RenderPassImmediately2
+	{
+		static void thunk(RE::BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	struct BSBatchRenderer_RenderPassImmediately3
+	{
+		static void thunk(RE::BSRenderPass* pass, uint32_t technique, bool alphaTest, uint32_t renderFlags);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
 	void Install();
 	void InstallEarlyHooks();
 }


### PR DESCRIPTION
## Summary

Restores the Particle Lights feature that was previously removed from upstream Community Shaders, ported from [ParticleTroned/skyrim-community-shaders@cs-1.5-PL-VR](https://github.com/ParticleTroned/skyrim-community-shaders/tree/cs-1.5-PL-VR) and adapted to our current LLF / contact-shadows shape.

- Particle effects whose source texture matches an entry in `Data\ParticleLights\*.ini` (with optional `Gradients/*.ini` overrides) are queued during render passes, clustered, and emitted as dynamic lights through LLF's existing pipeline.
- `AIProcess::CalculateLightValue` hook feeds particle lights into NPC light-level detection, so they affect stealth gameplay the way the legacy feature did.
- `BSBatchRenderer::RenderPassImmediately` hooks let an INI's `Cull = true` suppress the original particle draw once it's been recognized as a light source.
- Adds a sanitization pass (`ClampFiniteOrDefault` / `SanitizeSettings`) over all new tunables so malformed user JSON can't propagate NaN into the particle pipeline.
- Bundles JSON Placed Lights intensity scaling (gated on Inverse Square Lighting runtime metadata) and an opt-in `EnableParticleContactShadows` toggle that routes through the new `Particle` light-flag bit.
- Bumps `Light Limit Fix/Shaders/Features/LightLimitFix.ini` `3-1-0 → 3-2-0`.

### Files of note
- New: `src/Features/LightLimitFix/ParticleLights.{h,cpp}` — INI loader, legacy first-win conflict policy
- `src/Features/LightLimitFix.{h,cpp}` — queue/cluster/cache + queue, hooks, settings, sanitization, JSON-placed scaling
- `src/Hooks.{h,cpp}` — `BSBatchRenderer_RenderPassImmediately1/2/3` thunks + SEH-guarded `ShouldSkipRenderPassForParticleLights`
- `package/Shaders/Common/SharedData.hlsli` — `EnableParticleContactShadows` replaces a pad slot
- `package/Shaders/Lighting.hlsl` — particle-aware contact-shadow gate
- `features/Light Limit Fix/Shaders/LightLimitFix/Common.hlsli` — `LightFlags::Particle` bit

### Co-author
- @ParticleTroned — original implementation on `cs-1.5-PL-VR`

## Test plan

- [ ] CI build is green on SE/AE/VR presets (no Windows toolchain available in the agent container)
- [ ] In-game: drop the `Data\ParticleLights\*.ini` configs from a particle-light pack (Embers HD, Lanterns of Skyrim, etc.); verify candles/braziers/torches emit light
- [ ] In-game: confirm NPCs detect the player illuminated by a particle light (e.g., stand next to a brazier in a dark interior)
- [ ] Settings: toggle Enable Particle Lights / Culling / Detection / Optimization; verify counter in Statistics panel changes
- [ ] Cluster Threshold / Max Particles per Emitter / Max Particle Distance sliders behave as described in their tooltips
- [ ] Contact Shadows: with Enable Particle Contact Shadows ON, particle lights cast short screen-space shadows; with it OFF, they do not (other point lights unaffected)
- [ ] JSON Placed Lights: with Inverse Square Lighting loaded and a Light Placer mod, Intensity Scale 0–8 visibly scales those lights; without ISL, the controls are disabled
- [ ] No regression to the existing `Enable Contact Shadows` toggle on non-particle point lights (VR-stable noise check from #36 still holds)
- [ ] `LightLimitFix.json` round-trips with the new fields after Save/Load; malformed values (NaN, out-of-range) get clamped to defaults

## Heads-up for reviewers

- `BSEffectShaderProperty::unk88` and the two-arg `REL::Relocate` offsets on the `BSBatchRenderer::RenderPassImmediately` hooks are inherited verbatim from ParticleTroned's `cs-1.5-PL-VR` branch — they're known to work there but our `extern/CommonLibSSE-NG` revision should be confirmed to expose `unk88`.
- The existing `EffectExtensions::BSEffectShader_SetupGeometry` hook in `src/Hooks.cpp` still co-exists with `LightLimitFix::Hooks::BSEffectShader_SetupGeometry`, so `ExternalEmittance::UpdatePermutation` runs twice per effect pass. Pre-existing condition, idempotent, not addressed here — worth a follow-up to delete the LLF-side call.

https://claude.ai/code/session_01SoyystxDs66Via3eZreNfU

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoyystxDs66Via3eZreNfU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Particle light support with configurable INI-driven presets and gradients
  * JSON-placed light intensity scaling controls

* **Improvements**
  * Toggleable particle contact shadows and stricter contact-shadow gating
  * Expanded in-game UI: particle light settings, contact-shadow controls, and statistics

* **Stability/Performance**
  * Safer runtime handling and cache/queue management to reduce crashes and improve robustness

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/open-shaders/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->