### PR TITLE
fix(slf): VR shadow-mask OOB CTD

### DIFF
--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -3579,18 +3579,53 @@ namespace ShadowCasterManager
 		}
 
 		// ---- Screen-space shadow-mask pass: clamp to vanilla 4 slices ---------
-		// Detour RenderShadowLightsWithUtilityShader (100423/107141). The wrapper
-		// runs vanilla but writes a null sentinel into shadowLightsAccum at the
-		// 4-slice cutoff so the engine's loop never OOB-reads the 4-entry
-		// per-slot blend-mode table for any extended-mode slot. The mask's R
-		// channel (sun cascades) is the only channel LIGHT_LIMIT_FIX consumes;
-		// extended shadow casters are served by LLF's cluster pipeline reading
-		// kSHADOWMAPS directly. See the Hook_RenderShadowLightsWithUtilityShader
-		// definition above for the full rationale, including the previous
-		// Hook_DisableColorMask's misread (it patched out the inner call, not a
-		// color-mask call -- verified via Ghidra).
-		stl::detour_thunk<Hook_RenderShadowLightsWithUtilityShader>(
-			REL::RelocationID(100423, 107141));
+		// Suppress the engine's screen-space shadow-mask inner loop. With
+		// extended slot counts SLF can produce maskIndex >= 4, which makes
+		// the loop OOB-read the 4-entry per-slot blend-mode table
+		// (DAT_141861380); the mask's R channel (sun cascades) is the only
+		// channel LIGHT_LIMIT_FIX consumes anyway -- extended shadow casters
+		// are served by LLF's cluster pipeline reading kSHADOWMAPS directly.
+		// See Hook_RenderShadowLightsWithUtilityShader above for the full
+		// rationale, including the previous Hook_DisableColorMask's misread
+		// (it patched out the inner call, not a color-mask call -- verified
+		// via Ghidra).
+		if (globals::game::isVR) {
+			// VR's Main::RenderShadowmasks (100422) inlines the inner loop
+			// instead of calling the standalone 100423, so the detour below
+			// would never fire. NOP the near-CALL at +0x9E directly. Only
+			// needed when extended slot counts can produce maskIndex >= 4;
+			// vanilla 4-slice VR doesn't trip the OOB.
+			if (settings.ShadowLightCount > 4) {
+				// Site verification: the call at +0x9E must be `E8 rel32`
+				// targeting the inlined helper at +0xC0 (rel32 = 0xC0 -
+				// next-instruction-addr = 0xC0 - 0xA3 = 0x1D). If either the
+				// opcode or the target drifts, fail closed -- clamp the
+				// scheduler back to vanilla 4 slots so a drifted binary
+				// degrades to "no extended shadows" rather than the original
+				// CTD path this patch protects.
+				static REL::RelocationID renderShadowmasks(100422, 107140);
+				constexpr std::uint8_t kCallOffset = 0x9E;
+				constexpr std::uint8_t kCallOpcode = 0xE8;  // near CALL rel32
+				constexpr std::int32_t kExpectedRel32 = 0x1D;
+				const auto site = renderShadowmasks.address() + kCallOffset;
+				const auto opcode = *reinterpret_cast<const std::uint8_t*>(site);
+				const auto rel32 = *reinterpret_cast<const std::int32_t*>(site + 1);
+				if (opcode != kCallOpcode || rel32 != kExpectedRel32) {
+					logger::warn("[SCM] VR shadow-mask site drift: expected E8 rel32=0x{:X} at RenderShadowmasks+0x{:X}, "
+								 "found 0x{:02X} rel32=0x{:X}. Clamping ShadowLightCount to 4 (vanilla) to avoid OOB CTD.",
+						kExpectedRel32, kCallOffset, opcode, rel32);
+					s_installedShadowLightCount = 4;
+				} else {
+					REL::safe_fill(site, REL::NOP, 5);
+					logger::info("[SCM] VR: NOPed inner shadow-mask call at RenderShadowmasks+0x{:X}", kCallOffset);
+				}
+			}
+		} else {
+			// Flat (SE/AE): RenderShadowmasks calls the standalone 100423,
+			// so detour that function to a no-op.
+			stl::detour_thunk<Hook_RenderShadowLightsWithUtilityShader>(
+				REL::RelocationID(100423, 107141));
+		}
 
 		// ---- Shadow caster selection -----------------------------------------
 


### PR DESCRIPTION
## Summary

VR's `Main::RenderShadowmasks` (100422) inlines the screen-space mask inner loop rather than calling the standalone `RenderShadowLightsWithUtilityShader` (100423). The existing `Hook_RenderShadowLightsWithUtilityShader` detour never fires on VR — so SLF's extended scheduler can drive `maskIndex >= 4` and the engine OOB-reads the 4-entry `DAT_141861380` blend-mode table, polluting `g_RendererShadowState`. A few frames later that surfaces as a corrupted technique index inside `BSGraphics::SetDirtyStates`.

Verified crash [2026-05-26-20-52-06]: `rdx=0x56E94D1C` at `SkyrimVR.exe+0xDC3244`, BSShadowParabolicLight in render path.

## Fix

Patch the near-`CALL` at `RenderShadowmasks +0x9E` with five NOPs:

- gated on `globals::game::isVR && settings.ShadowLightCount > 4` (vanilla 4-slice VR untouched)
- opcode-checked: reads the byte and only writes if it's `0xE8`; logs warn-and-skip otherwise so binary drift can't silently corrupt

## Test plan

- [ ] VR session with `ShadowLightCount > 4` does not CTD in the shadow-mask path
- [ ] VR session with `ShadowLightCount <= 4` is unchanged
- [ ] Flat (SE/AE) is unchanged (gated on `isVR`)
- [ ] Sun shadows + cluster-path point/spot shadows still render under LIGHT_LIMIT_FIX

## Notes

While reproducing locally I also hit a pre-existing dev build breakage: `ShadowCasterManager.cpp` includes `exprtk.hpp` (17K-line single-header) and trips C1128 without `/bigobj` on a clean build. Flagged as a separate concern — not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shadow rendering stability issues in VR when using extended shadow light configurations, preventing crashes with higher shadow settings.
  * Maintained existing shadow rendering optimizations for standard game editions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/open-shaders/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->