### PR TITLE
feat(VR): add foveated extras for dlss

### DIFF
--- a/features/Upscaling/Shaders/Upscaling/FoveatedRender/PeripheryTemporalSmoothCS.hlsl
+++ b/features/Upscaling/Shaders/Upscaling/FoveatedRender/PeripheryTemporalSmoothCS.hlsl
@@ -1,0 +1,55 @@
+// Temporal accumulation filter for the periphery background.
+// Runs on render-resolution SBS layout. Blends current frame with reprojected
+// history using motion vectors. EMA with motion-adaptive alpha and luma
+// rejection to suppress ghosting during movement while keeping strong
+// flicker reduction in the non-focal periphery when stationary.
+
+cbuffer TemporalSmoothCB : register(b0)
+{
+	uint TexWidth;     // SBS width (render-res)
+	uint TexHeight;    // SBS height (render-res)
+	float BlendAlpha;  // Current-frame weight (0.05 = very smooth, 0.5 = less smooth)
+	uint _pad;
+};
+
+Texture2D<float4> CurrentTex : register(t0);   // vrRenderSBS snapshot (current frame)
+Texture2D<float4> HistoryTex : register(t1);   // Previous frame smoothed (ping-pong read)
+Texture2D<float4> MvecTex : register(t2);      // Motion vectors (per-eye UV delta, current→previous)
+SamplerState BilinearSampler : register(s0);   // For history reprojection
+RWTexture2D<float4> OutputTex : register(u0);  // New history (ping-pong write)
+
+[numthreads(8, 8, 1)] void main(uint3 tid : SV_DispatchThreadID) {
+	if (tid.x >= TexWidth || tid.y >= TexHeight)
+		return;
+
+	uint2 pos = tid.xy;
+	float4 current = CurrentTex.Load(int3(pos, 0));
+
+	// Motion vector is per-eye UV delta (current → previous), range ≈ ±small.
+	// In SBS layout the x axis spans two eyes, so x-component must be halved.
+	float2 mv = MvecTex.Load(int3(pos, 0)).xy;
+	float2 currentUV = (float2(pos) + 0.5) / float2(TexWidth, TexHeight);
+	float2 reprojUV = currentUV + mv * float2(0.5, 1.0);
+
+	// ── SBS eye-boundary clamp ──
+	// Prevent reprojection from crossing into the other eye's half.
+	// Left eye: x ∈ [0, 0.5), right eye: x ∈ [0.5, 1.0).
+	float halfW = 0.5;
+	float eyeMinX = (currentUV.x < halfW) ? 0.0 : halfW;
+	float eyeMaxX = eyeMinX + halfW;
+	float texelHalfX = 0.5 / (float)TexWidth;
+	reprojUV.x = clamp(reprojUV.x, eyeMinX + texelHalfX, eyeMaxX - texelHalfX);
+	reprojUV.y = clamp(reprojUV.y, 0.0, 1.0);
+
+	// Bilinear sample history at reprojected position
+	float4 history = HistoryTex.SampleLevel(BilinearSampler, reprojUV, 0);
+
+	// ── Anti-ghosting: motion-adaptive alpha (squared for soft ramp) ──
+	// Increased sensitivity (*10): VR head sway still low enough to keep smoothing,
+	// but moderate movement now ramps up faster to reduce ghosting.
+	float motionRaw = saturate(length(mv) * 10.0);
+	float finalAlpha = max(BlendAlpha, motionRaw * motionRaw);
+
+	// Exponential moving average with adaptive weight
+	OutputTex[pos] = lerp(history, current, finalAlpha);
+}

--- a/features/Upscaling/Shaders/Upscaling/FoveatedRender/PeripheryTemporalSmoothCS.hlsl
+++ b/features/Upscaling/Shaders/Upscaling/FoveatedRender/PeripheryTemporalSmoothCS.hlsl
@@ -38,8 +38,9 @@ RWTexture2D<float4> OutputTex : register(u0);  // New history (ping-pong write)
 	float eyeMinX = (currentUV.x < halfW) ? 0.0 : halfW;
 	float eyeMaxX = eyeMinX + halfW;
 	float texelHalfX = 0.5 / (float)TexWidth;
+	float texelHalfY = 0.5 / (float)TexHeight;
 	reprojUV.x = clamp(reprojUV.x, eyeMinX + texelHalfX, eyeMaxX - texelHalfX);
-	reprojUV.y = clamp(reprojUV.y, 0.0, 1.0);
+	reprojUV.y = clamp(reprojUV.y, texelHalfY, 1.0 - texelHalfY);
 
 	// Bilinear sample history at reprojected position
 	float4 history = HistoryTex.SampleLevel(BilinearSampler, reprojUV, 0);

--- a/features/Upscaling/Shaders/Upscaling/FoveatedRender/PeripheryTemporalSmoothCS.hlsl
+++ b/features/Upscaling/Shaders/Upscaling/FoveatedRender/PeripheryTemporalSmoothCS.hlsl
@@ -1,8 +1,8 @@
 // Temporal accumulation filter for the periphery background.
 // Runs on render-resolution SBS layout. Blends current frame with reprojected
-// history using motion vectors. EMA with motion-adaptive alpha and luma
-// rejection to suppress ghosting during movement while keeping strong
-// flicker reduction in the non-focal periphery when stationary.
+// history using motion vectors. EMA with motion-adaptive alpha to suppress
+// ghosting during movement while keeping strong flicker reduction in the
+// non-focal periphery when stationary.
 
 cbuffer TemporalSmoothCB : register(b0)
 {

--- a/features/Upscaling/Shaders/Upscaling/FoveatedRender/SubrectBlendCS.hlsl
+++ b/features/Upscaling/Shaders/Upscaling/FoveatedRender/SubrectBlendCS.hlsl
@@ -1,0 +1,78 @@
+// Blends DLSS subrect output back onto the stretched background in kMAIN.
+// Replaces the hard CopySubresourceRegion with a feathered transition at the
+// subrect boundary.  Two blend modes:
+//   0 = Feather  – smoothstep alpha ramp over FeatherWidth pixels
+//   1 = Dither   – noise-perturbed gradient in feather band (DitherStrength controls noise)
+
+cbuffer BlendCB : register(b0)
+{
+	uint DstOffsetX;       // SBS destination X for this eye (0 or eyeWidthOut)
+	uint DstOffsetY;       // SBS destination Y (usually 0, non-zero if subrect offset)
+	uint SubWidth;         // DLSS output width  (subrect)
+	uint SubHeight;        // DLSS output height (subrect)
+	uint BlendMode;        // 0 = Feather, 1 = Dither
+	float FeatherWidth;    // Feather band in pixels (default ~8)
+	uint FrameIndex;       // For dither noise animation
+	uint SrcOffsetX;       // Source X offset (0 for most modes, non-zero for Extreme strip)
+	float DitherStrength;  // 0 = pure smooth gradient, 1 = natural noise, 2 = aggressive dither
+};
+
+Texture2D<float4> SrcTex : register(t0);    // DLSS subrect output
+RWTexture2D<float4> DstTex : register(u0);  // kMAIN (already has stretched background)
+
+// Simple hash-based blue noise (no texture needed, near zero cost)
+float BlueNoise(uint2 pos, uint frame)
+{
+	// Interleaved gradient noise (Jimenez 2014) — good spatial distribution
+	float x = float(pos.x) + 5.588238 * float(frame);
+	float y = float(pos.y) + 5.588238 * float(frame);
+	return frac(52.9829189 * frac(0.06711056 * x + 0.00583715 * y));
+}
+
+[numthreads(8, 8, 1)] void main(uint3 tid : SV_DispatchThreadID) {
+	if (tid.x >= SubWidth || tid.y >= SubHeight)
+		return;
+
+	uint2 srcPos = uint2(tid.x + SrcOffsetX, tid.y);
+	uint2 dstPos = uint2(tid.x + DstOffsetX, tid.y + DstOffsetY);
+
+	float4 dlss = SrcTex.Load(int3(srcPos, 0));
+
+	// Distance from nearest edge of the SUBRECT in subrect-local pixel space.
+	//
+	// Bot-flagged Major bug (CodeRabbit + Copilot on the original PR): the
+	// previous implementation used `srcPos.x` for distL/distR. In Extreme
+	// strip mode, SrcOffsetX != 0 (each eye reads its half of a horizontally-
+	// concatenated SBS strip), so srcPos.x = tid.x + SrcOffsetX could exceed
+	// SubWidth, making distR negative and breaking the feather band entirely
+	// — the strip would never blend correctly with the background. Use the
+	// dispatch-local tid.xy so distances are in [0, SubWidth-1] regardless
+	// of the source-side offset.
+	float distL = (float)tid.x;
+	float distR = (float)(SubWidth - 1 - tid.x);
+	float distT = (float)tid.y;
+	float distB = (float)(SubHeight - 1 - tid.y);
+	float edgeDist = min(min(distL, distR), min(distT, distB));
+
+	if (edgeDist >= FeatherWidth) {
+		// Interior: pure DLSS (fast path, skips background read)
+		DstTex[dstPos] = dlss;
+		return;
+	}
+
+	// We're in the feather band — need background
+	float4 bg = DstTex[dstPos];
+
+	if (BlendMode == 1) {
+		// Dither: noise-perturbed continuous gradient
+		// Noise shifts the blend threshold per-pixel → natural irregular boundary
+		float t = edgeDist / FeatherWidth;  // 0 at edge, 1 at band end
+		float noise = BlueNoise(srcPos, FrameIndex);
+		float alpha = saturate(t + (noise - 0.5) * DitherStrength);
+		DstTex[dstPos] = lerp(bg, dlss, alpha);
+	} else {
+		// Feather (default): smooth alpha ramp
+		float alpha = smoothstep(0.0, FeatherWidth, edgeDist);
+		DstTex[dstPos] = lerp(bg, dlss, alpha);
+	}
+}

--- a/features/Upscaling/Shaders/Upscaling/FoveatedRender/SubrectBlendCS.hlsl
+++ b/features/Upscaling/Shaders/Upscaling/FoveatedRender/SubrectBlendCS.hlsl
@@ -11,7 +11,7 @@ cbuffer BlendCB : register(b0)
 	uint SubWidth;         // DLSS output width  (subrect)
 	uint SubHeight;        // DLSS output height (subrect)
 	uint BlendMode;        // 0 = Feather, 1 = Dither
-	float FeatherWidth;    // Feather band in pixels (default ~8)
+	float FeatherWidth;    // Feather band in pixels (default ~64)
 	uint FrameIndex;       // For dither noise animation
 	uint SrcOffsetX;       // Source X offset (0 for most modes, non-zero for Extreme strip)
 	float DitherStrength;  // 0 = pure smooth gradient, 1 = natural noise, 2 = aggressive dither

--- a/src/Features/Upscaling/FoveatedRender.cpp
+++ b/src/Features/Upscaling/FoveatedRender.cpp
@@ -82,7 +82,7 @@ void FoveatedRender::RestoreDefaultSettings()
 void FoveatedRender::ClampSettings()
 {
 	settings.enabled = std::min(settings.enabled, 1u);
-	settings.dlssMode = std::min(settings.dlssMode, 2u);
+	settings.dlssMode = std::min(settings.dlssMode, 1u);
 	settings.stretchMode = std::min(settings.stretchMode, 2u);
 	settings.debugVisualize = std::min(settings.debugVisualize, 1u);
 	settings.peripheryAAMode = std::min(settings.peripheryAAMode, 1u);
@@ -142,7 +142,6 @@ bool FoveatedRender::IsPresetCompatibleWithMode(uint presetIndex) const
 {
 	// Preset indices: 0=Default, 1=J, 2=K, 3=L, 4=M, 5=F
 	// Faster mode: J(1) and K(2) are incompatible.
-	// Extreme mode: all presets allowed (matches original PR's permissive stance).
 	if (GetDlssMode() == DlssMode::kFaster) {
 		return presetIndex != 1 && presetIndex != 2;
 	}
@@ -228,10 +227,7 @@ void FoveatedRender::DrawSettings()
 
 		static const char* dlssModes[] = { "Default", "Faster" };
 		uint prevMode = settings.dlssMode;
-		// Clamp to 1 in the slider — kExtreme (2) is reserved for future work.
-		uint sliderMode = std::min(settings.dlssMode, 1u);
-		if (ImGui::SliderInt("DLSS Mode", reinterpret_cast<int*>(&sliderMode), 0, 1, dlssModes[sliderMode]))
-			settings.dlssMode = sliderMode;
+		ImGui::SliderInt("DLSS Mode", reinterpret_cast<int*>(&settings.dlssMode), 0, 1, dlssModes[std::min(settings.dlssMode, 1u)]);
 		if (settings.dlssMode != prevMode) {
 			const uint prevPreset = globals::features::upscaling.settings.presetDLSS;
 			ClampPresetToMode();

--- a/src/Features/Upscaling/FoveatedRender.cpp
+++ b/src/Features/Upscaling/FoveatedRender.cpp
@@ -13,7 +13,13 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	enabled,
 	dlssMode,
 	stretchMode,
-	debugVisualize);
+	peripheryBlurRadius,
+	debugVisualize,
+	peripheryAAMode,
+	peripheryTemporalAlpha,
+	subrectBlendMode,
+	subrectFeatherWidth,
+	subrectDitherStrength);
 
 // ============================================================================
 // Lifecycle
@@ -76,9 +82,15 @@ void FoveatedRender::RestoreDefaultSettings()
 void FoveatedRender::ClampSettings()
 {
 	settings.enabled = std::min(settings.enabled, 1u);
-	settings.dlssMode = std::min(settings.dlssMode, 1u);
+	settings.dlssMode = std::min(settings.dlssMode, 2u);
 	settings.stretchMode = std::min(settings.stretchMode, 2u);
 	settings.debugVisualize = std::min(settings.debugVisualize, 1u);
+	settings.peripheryAAMode = std::min(settings.peripheryAAMode, 1u);
+	settings.subrectBlendMode = std::min(settings.subrectBlendMode, 2u);
+	settings.peripheryBlurRadius = std::clamp(settings.peripheryBlurRadius, 0.5f, 4.0f);
+	settings.peripheryTemporalAlpha = std::clamp(settings.peripheryTemporalAlpha, 0.05f, 0.5f);
+	settings.subrectFeatherWidth = std::clamp(settings.subrectFeatherWidth, 2.0f, 128.0f);
+	settings.subrectDitherStrength = std::clamp(settings.subrectDitherStrength, 0.0f, 2.0f);
 	// Preset clamping reads from Upscaling::Settings now.
 	auto& sharedPreset = globals::features::upscaling.settings.presetDLSS;
 	sharedPreset = std::min(sharedPreset, 5u);
@@ -130,6 +142,7 @@ bool FoveatedRender::IsPresetCompatibleWithMode(uint presetIndex) const
 {
 	// Preset indices: 0=Default, 1=J, 2=K, 3=L, 4=M, 5=F
 	// Faster mode: J(1) and K(2) are incompatible.
+	// Extreme mode: all presets allowed (matches original PR's permissive stance).
 	if (GetDlssMode() == DlssMode::kFaster) {
 		return presetIndex != 1 && presetIndex != 2;
 	}
@@ -191,7 +204,6 @@ void FoveatedRender::DrawEnable()
 
 void FoveatedRender::DrawSettings()
 {
-	static const char* dlssModes[] = { "Default", "Faster" };
 	static const char* stretchModes[] = { "Bilinear", "Point", "Gaussian Blur" };
 
 	ClampSettings();
@@ -218,16 +230,20 @@ void FoveatedRender::DrawSettings()
 				"DLSS reads kMAIN directly via extent offsets, so bilinear sampling can touch 1-2\n"
 				"texels of the neighboring eye near the SBS midline. We snapshot kMAIN once and\n"
 				"clear the HMD hidden-area ring to prevent sky-blue bleed on fast head motion.\n"
-				"Presets J and K are unavailable — switching here auto-clamps preset to L.");
+				"Presets J and K are unavailable — switching here auto-clamps preset to L.\n"
+				"\n"
+				"Extreme — experimental: both eyes merged into one strip texture, 1 DLSS evaluate.\n"
+				"Saves DLSS dispatch overhead but artifacts are likely. Not recommended for regular use.");
 		}
 
+		static const char* dlssModes[] = { "Default", "Faster", "Extreme (not recommended)" };
 		uint prevMode = settings.dlssMode;
-		ImGui::SliderInt("DLSS Mode", reinterpret_cast<int*>(&settings.dlssMode), 0, 1, dlssModes[settings.dlssMode]);
+		ImGui::SliderInt("DLSS Mode", reinterpret_cast<int*>(&settings.dlssMode), 0, 2, dlssModes[std::min(settings.dlssMode, 2u)]);
 		if (settings.dlssMode != prevMode) {
 			const uint prevPreset = globals::features::upscaling.settings.presetDLSS;
 			ClampPresetToMode();
 			if (globals::features::upscaling.settings.presetDLSS != prevPreset) {
-				logger::info("[FOVEATED] DLSS preset clamped from {} to {} after Faster switch (J/K incompatible)",
+				logger::info("[FOVEATED] DLSS preset clamped from {} to {} after mode switch (J/K incompatible with Faster)",
 					prevPreset, globals::features::upscaling.settings.presetDLSS);
 			}
 		}
@@ -237,6 +253,11 @@ void FoveatedRender::DrawSettings()
 			break;
 		case DlssMode::kFaster:
 			ImGui::TextWrapped("SBS viewport: 1 snapshot + 2 mask clears, 2 evaluates. Presets J/K unavailable.");
+			break;
+		case DlssMode::kExtreme:
+			ImGui::PushStyleColor(ImGuiCol_Text, Util::Colors::GetWarning());
+			ImGui::TextWrapped("Combined strip: 1 evaluate. Artifacts likely — not recommended.");
+			ImGui::PopStyleColor();
 			break;
 		}
 
@@ -282,6 +303,62 @@ void FoveatedRender::DrawSettings()
 					"\n"
 					"Visual artifact: noticeable blur in the periphery. If your subrect is large this\n"
 					"is barely visible; if small, the blur is the dominant visual signal.");
+			}
+			ImGui::SliderFloat("Blur Radius", &settings.peripheryBlurRadius, 0.5f, 4.0f, "%.1f texels");
+			break;
+		}
+
+		// ── Periphery AA ──
+		ImGui::Separator();
+		ImGui::Text("Periphery AA");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text(
+				"Anti-flicker for the stretched periphery.\n"
+				"Temporal Smooth blends with motion-reprojected history to reduce shimmer.");
+		}
+		{
+			static const char* peripheryAAModes[] = { "None", "Temporal Smooth" };
+			ImGui::SliderInt("AA Mode", reinterpret_cast<int*>(&settings.peripheryAAMode), 0, 1, peripheryAAModes[settings.peripheryAAMode]);
+		}
+		switch (GetPeripheryAAMode()) {
+		case PeripheryAAMode::kNone:
+			ImGui::TextWrapped("No periphery anti-aliasing.");
+			break;
+		case PeripheryAAMode::kTemporalSmooth:
+			ImGui::TextWrapped("Motion-compensated temporal accumulation.");
+			ImGui::SliderFloat("Temporal Alpha", &settings.peripheryTemporalAlpha, 0.05f, 0.5f, "%.2f");
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("Current-frame blend weight. Lower = smoother (more history). Higher = more responsive.");
+			}
+			break;
+		}
+
+		// ── Subrect Blend ──
+		ImGui::Separator();
+		ImGui::Text("Subrect Blend");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text(
+				"How the DLSS subrect is composited back onto the stretched background.\n"
+				"Feather/Dither hide the seam at subrect edges.");
+		}
+		{
+			static const char* blendModes[] = { "Hard Copy", "Feather", "Dither" };
+			ImGui::SliderInt("Blend Mode", reinterpret_cast<int*>(&settings.subrectBlendMode), 0, 2, blendModes[std::min(settings.subrectBlendMode, 2u)]);
+		}
+		switch (GetSubrectBlendMode()) {
+		case SubrectBlendMode::kHardCopy:
+			ImGui::TextWrapped("Sharp edge copy (CopySubresourceRegion).");
+			break;
+		case SubrectBlendMode::kFeather:
+			ImGui::TextWrapped("Smoothstep alpha ramp at edges.");
+			ImGui::SliderFloat("Feather Width", &settings.subrectFeatherWidth, 2.0f, 128.0f, "%.0f px");
+			break;
+		case SubrectBlendMode::kDither:
+			ImGui::TextWrapped("Noise-perturbed gradient in feather band.");
+			ImGui::SliderFloat("Dither Band", &settings.subrectFeatherWidth, 2.0f, 128.0f, "%.0f px");
+			ImGui::SliderFloat("Dither Strength", &settings.subrectDitherStrength, 0.0f, 2.0f, "%.2f");
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("0 = pure smooth, 1 = natural noise, 2 = aggressive dither.");
 			}
 			break;
 		}

--- a/src/Features/Upscaling/FoveatedRender.cpp
+++ b/src/Features/Upscaling/FoveatedRender.cpp
@@ -208,7 +208,7 @@ void FoveatedRender::DrawSettings()
 
 	ClampSettings();
 
-	Util::Text::WrappedInfo("Quality / Sharpness / DLSS Preset / Streamline log level are shared with the standard DLSS path above.");
+	Util::Text::WrappedInfo("Quality, Sharpness, and DLSS Preset are on the main Upscaling panel — changes there apply to foveated rendering too.");
 
 	// ── VR-only knobs ──
 	if (globals::game::isVR) {
@@ -216,29 +216,22 @@ void FoveatedRender::DrawSettings()
 		ImGui::Text("VR DLSS Mode");
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
-				"Default vs Faster: trade per-eye image quality for setup cost. Switch only when you\n"
-				"can see a difference in your scene — otherwise prefer Faster.\n"
+				"Default — highest quality. Each eye gets its own isolated copy of color/depth/motion\n"
+				"vectors so DLSS can't sample across the stereo midline. 5 copies per eye per frame.\n"
+				"All DLSS presets supported. Best for screenshots or when Faster shows edge artifacts.\n"
 				"\n"
-				"Default — use when: image quality matters more than the small overhead — cinematic\n"
-				"scenes, screenshot/recording, or if you notice ghosting/edge artifacts in Faster.\n"
-				"Each eye gets isolated per-eye intermediates for color/depth/MV/reactive/transparency\n"
-				"so DLSS can't sample across the SBS midline. Costs five per-eye copies per frame.\n"
-				"All DLSS presets (Default, J, K, L, M, F) supported.\n"
-				"\n"
-				"Faster — use when: you want the cheapest foveated path and aren't seeing artifacts —\n"
-				"fast-motion gameplay, exploration, anywhere small quality losses go unnoticed.\n"
-				"DLSS reads kMAIN directly via extent offsets, so bilinear sampling can touch 1-2\n"
-				"texels of the neighboring eye near the SBS midline. We snapshot kMAIN once and\n"
-				"clear the HMD hidden-area ring to prevent sky-blue bleed on fast head motion.\n"
-				"Presets J and K are unavailable — switching here auto-clamps preset to L.\n"
-				"\n"
-				"Extreme — experimental: both eyes merged into one strip texture, 1 DLSS evaluate.\n"
-				"Saves DLSS dispatch overhead but artifacts are likely. Not recommended for regular use.");
+				"Faster — lower overhead. DLSS reads directly from the frame buffer using a viewport\n"
+				"offset instead of isolating each eye. 1 snapshot + 2 mask clears per frame.\n"
+				"DLSS may sample 1-2 pixels from the neighboring eye near the stereo center — usually\n"
+				"invisible in motion. Presets J and K are incompatible and auto-clamp to L.");
 		}
 
-		static const char* dlssModes[] = { "Default", "Faster", "Extreme (not recommended)" };
+		static const char* dlssModes[] = { "Default", "Faster" };
 		uint prevMode = settings.dlssMode;
-		ImGui::SliderInt("DLSS Mode", reinterpret_cast<int*>(&settings.dlssMode), 0, 2, dlssModes[std::min(settings.dlssMode, 2u)]);
+		// Clamp to 1 in the slider — kExtreme (2) is reserved for future work.
+		uint sliderMode = std::min(settings.dlssMode, 1u);
+		if (ImGui::SliderInt("DLSS Mode", reinterpret_cast<int*>(&sliderMode), 0, 1, dlssModes[sliderMode]))
+			settings.dlssMode = sliderMode;
 		if (settings.dlssMode != prevMode) {
 			const uint prevPreset = globals::features::upscaling.settings.presetDLSS;
 			ClampPresetToMode();
@@ -249,117 +242,74 @@ void FoveatedRender::DrawSettings()
 		}
 		switch (GetDlssMode()) {
 		case DlssMode::kDefault:
-			ImGui::TextWrapped("Per-eye isolation: 2 resource sets, 2 DLSS evaluates.");
+			ImGui::TextWrapped("Per-eye isolation: 5 copies per frame, 2 DLSS evaluates. All presets.");
 			break;
 		case DlssMode::kFaster:
-			ImGui::TextWrapped("SBS viewport: 1 snapshot + 2 mask clears, 2 evaluates. Presets J/K unavailable.");
+			ImGui::TextWrapped("Viewport offset: 1 snapshot, 2 mask clears, 2 DLSS evaluates. Presets J/K unavailable.");
 			break;
-		case DlssMode::kExtreme:
-			ImGui::PushStyleColor(ImGuiCol_Text, Util::Colors::GetWarning());
-			ImGui::TextWrapped("Combined strip: 1 evaluate. Artifacts likely — not recommended.");
-			ImGui::PopStyleColor();
+		default:
 			break;
 		}
 
 		ImGui::Separator();
-		ImGui::Text("Background Stretch");
+		ImGui::Text("Periphery Rendering");
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
-				"How the cheap periphery is reconstructed to fill the area outside the DLSS subrect.\n"
-				"This is the cost-saving step — DLSS only runs on the subrect, the rest is filled by\n"
-				"this cheaper pass. Only affects pixels outside your selected region.");
+				"The area outside your selected subrect is filled cheaply rather than running DLSS.\n"
+				"These settings control how that cheap fill looks and whether it flickers.\n"
+				"\n"
+				"Stretch method: how pixels outside the subrect are reconstructed from the lower-res\n"
+				"render buffer. Does not affect the DLSS subrect region at all.\n"
+				"\n"
+				"Periphery AA: reduces temporal flicker in the stretched area using motion-compensated\n"
+				"history blending. Independent of the DLSS subrect.\n"
+				"\n"
+				"Edge Blend: controls how the DLSS subrect edge meets the stretched periphery.\n"
+				"Hard Copy leaves a sharp seam; Feather/Dither soften it. Only affects the boundary.");
 		}
-		ImGui::SliderInt("Stretch Mode", reinterpret_cast<int*>(&settings.stretchMode), 0, 2, stretchModes[settings.stretchMode]);
+
+		ImGui::SliderInt("Stretch", reinterpret_cast<int*>(&settings.stretchMode), 0, 2, stretchModes[settings.stretchMode]);
 		switch (GetStretchMode()) {
 		case StretchMode::kBilinear:
-			ImGui::TextWrapped("Bilinear: clean linear upscale. Looks like a soft DLSS-Performance result.");
-			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text(
-					"Use when: you want the periphery to look like a sensible low-quality reconstruction,\n"
-					"close to how DLSS-Performance would look. Default-ish choice.\n"
-					"\n"
-					"Visual artifact: typical bilinear softness — fine geometry in the periphery looks\n"
-					"slightly out of focus but not visibly stretched.");
-			}
+			ImGui::TextWrapped("Bilinear: smooth upscale of the render buffer. Looks soft but clean.");
 			break;
 		case StretchMode::kPoint:
-			ImGui::TextWrapped("Point (nearest-neighbor): cheapest. Visibly pixelated periphery.");
-			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text(
-					"Use when: you want the smallest possible cost in the periphery and don't mind\n"
-					"obvious pixelation outside your gaze region. Useful for benchmarking the upper\n"
-					"bound of foveated savings.\n"
-					"\n"
-					"Visual artifact: chunky pixel blocks in the periphery, very visible if you look\n"
-					"away from the subrect center.");
-			}
+			ImGui::TextWrapped("Point: cheapest, visibly pixelated. Good for benchmarking foveated savings.");
 			break;
 		case StretchMode::kGaussianBlur:
-			ImGui::TextWrapped("Gaussian blur: softens periphery further. Hides upscale artifacts behind blur.");
-			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text(
-					"Use when: you want the periphery to fall away into soft focus — closer to how\n"
-					"natural human peripheral vision feels. Good default for actual foveated use.\n"
-					"\n"
-					"Visual artifact: noticeable blur in the periphery. If your subrect is large this\n"
-					"is barely visible; if small, the blur is the dominant visual signal.");
-			}
-			ImGui::SliderFloat("Blur Radius", &settings.peripheryBlurRadius, 0.5f, 4.0f, "%.1f texels");
+			ImGui::TextWrapped("Gaussian: blurs the periphery further into soft focus. Good default for foveated use.");
+			ImGui::SliderFloat("Blur Radius", &settings.peripheryBlurRadius, 0.5f, 4.0f, "%.1f px");
 			break;
 		}
 
-		// ── Periphery AA ──
-		ImGui::Separator();
-		ImGui::Text("Periphery AA");
-		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text(
-				"Anti-flicker for the stretched periphery.\n"
-				"Temporal Smooth blends with motion-reprojected history to reduce shimmer.");
-		}
 		{
 			static const char* peripheryAAModes[] = { "None", "Temporal Smooth" };
-			ImGui::SliderInt("AA Mode", reinterpret_cast<int*>(&settings.peripheryAAMode), 0, 1, peripheryAAModes[settings.peripheryAAMode]);
+			ImGui::SliderInt("Periphery AA", reinterpret_cast<int*>(&settings.peripheryAAMode), 0, 1, peripheryAAModes[settings.peripheryAAMode]);
 		}
-		switch (GetPeripheryAAMode()) {
-		case PeripheryAAMode::kNone:
-			ImGui::TextWrapped("No periphery anti-aliasing.");
-			break;
-		case PeripheryAAMode::kTemporalSmooth:
-			ImGui::TextWrapped("Motion-compensated temporal accumulation.");
-			ImGui::SliderFloat("Temporal Alpha", &settings.peripheryTemporalAlpha, 0.05f, 0.5f, "%.2f");
+		if (GetPeripheryAAMode() == PeripheryAAMode::kTemporalSmooth) {
+			ImGui::TextWrapped("Blends the stretched periphery with motion-reprojected history to reduce flicker.");
+			ImGui::SliderFloat("Smoothing", &settings.peripheryTemporalAlpha, 0.05f, 0.5f, "%.2f");
 			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text("Current-frame blend weight. Lower = smoother (more history). Higher = more responsive.");
+				ImGui::Text("Lower = more temporal history (smoother but may ghost). Higher = more responsive.");
 			}
-			break;
 		}
 
-		// ── Subrect Blend ──
-		ImGui::Separator();
-		ImGui::Text("Subrect Blend");
-		if (auto _tt = Util::HoverTooltipWrapper()) {
-			ImGui::Text(
-				"How the DLSS subrect is composited back onto the stretched background.\n"
-				"Feather/Dither hide the seam at subrect edges.");
-		}
 		{
 			static const char* blendModes[] = { "Hard Copy", "Feather", "Dither" };
-			ImGui::SliderInt("Blend Mode", reinterpret_cast<int*>(&settings.subrectBlendMode), 0, 2, blendModes[std::min(settings.subrectBlendMode, 2u)]);
+			ImGui::SliderInt("Edge Blend", reinterpret_cast<int*>(&settings.subrectBlendMode), 0, 2, blendModes[std::min(settings.subrectBlendMode, 2u)]);
 		}
 		switch (GetSubrectBlendMode()) {
 		case SubrectBlendMode::kHardCopy:
-			ImGui::TextWrapped("Sharp edge copy (CopySubresourceRegion).");
+			ImGui::TextWrapped("Sharp seam at the subrect boundary. Lowest cost.");
 			break;
 		case SubrectBlendMode::kFeather:
-			ImGui::TextWrapped("Smoothstep alpha ramp at edges.");
+			ImGui::TextWrapped("Smoothstep fade over N pixels at the boundary. Hides the seam.");
 			ImGui::SliderFloat("Feather Width", &settings.subrectFeatherWidth, 2.0f, 128.0f, "%.0f px");
 			break;
 		case SubrectBlendMode::kDither:
-			ImGui::TextWrapped("Noise-perturbed gradient in feather band.");
-			ImGui::SliderFloat("Dither Band", &settings.subrectFeatherWidth, 2.0f, 128.0f, "%.0f px");
-			ImGui::SliderFloat("Dither Strength", &settings.subrectDitherStrength, 0.0f, 2.0f, "%.2f");
-			if (auto _tt = Util::HoverTooltipWrapper()) {
-				ImGui::Text("0 = pure smooth, 1 = natural noise, 2 = aggressive dither.");
-			}
+			ImGui::TextWrapped("Noise-dithered fade — more natural-looking than feather at large subrects.");
+			ImGui::SliderFloat("Band Width", &settings.subrectFeatherWidth, 2.0f, 128.0f, "%.0f px");
+			ImGui::SliderFloat("Noise Amount", &settings.subrectDitherStrength, 0.0f, 2.0f, "%.2f");
 			break;
 		}
 

--- a/src/Features/Upscaling/FoveatedRender.h
+++ b/src/Features/Upscaling/FoveatedRender.h
@@ -27,7 +27,6 @@ struct FoveatedRender
 	{
 		kDefault = 0,  // Per-eye isolation: 2 extra resource sets, 2 evaluates. Supports F/J/K/L/M.
 		kFaster = 1,   // SBS viewport: tell SL to read subrect from SBS directly, no extra resources, 2 evaluates. J/K incompatible, only L/M/F.
-		kExtreme = 2,  // Combined strip: both eyes' subrect merged into one long texture, 1 extra resource set, 1 evaluate. Supports F/J/K/L/M. (Not recommended)
 	};
 
 	// Subrect blend mode when writing DLSS output back over stretched background
@@ -70,9 +69,9 @@ struct FoveatedRender
 		uint stretchMode = (uint)StretchMode::kGaussianBlur;
 		float peripheryBlurRadius = 1.0f;
 		uint debugVisualize = 0;  // tint cheap-stretched periphery red; runtime toggle
-		uint peripheryAAMode = (uint)PeripheryAAMode::kTemporalSmooth;
+		uint peripheryAAMode = static_cast<uint>(PeripheryAAMode::kTemporalSmooth);
 		float peripheryTemporalAlpha = 0.16f;
-		uint subrectBlendMode = (uint)SubrectBlendMode::kHardCopy;
+		uint subrectBlendMode = static_cast<uint>(SubrectBlendMode::kHardCopy);
 		float subrectFeatherWidth = 64.0f;
 		float subrectDitherStrength = 1.0f;
 	};
@@ -110,10 +109,10 @@ struct FoveatedRender
 	/// (1=Quality .. 4=UltraPerformance). Delegates to the FFX SDK ratio table.
 	static float GetRenderScaleForQuality(uint qualityMode);
 
-	DlssMode GetDlssMode() const { return (DlssMode)std::min(settings.dlssMode, 2u); }
+	DlssMode GetDlssMode() const { return (DlssMode)std::min(settings.dlssMode, 1u); }
 	StretchMode GetStretchMode() const { return (StretchMode)std::min(settings.stretchMode, 2u); }
-	PeripheryAAMode GetPeripheryAAMode() const { return (PeripheryAAMode)std::min(settings.peripheryAAMode, 1u); }
-	SubrectBlendMode GetSubrectBlendMode() const { return (SubrectBlendMode)std::min(settings.subrectBlendMode, 2u); }
+	PeripheryAAMode GetPeripheryAAMode() const { return static_cast<PeripheryAAMode>(std::min(settings.peripheryAAMode, 1u)); }
+	SubrectBlendMode GetSubrectBlendMode() const { return static_cast<SubrectBlendMode>(std::min(settings.subrectBlendMode, 2u)); }
 
 	// Active getters: clamp + route shared fields through Upscaling::Settings.
 	uint GetActiveQualityMode() const;

--- a/src/Features/Upscaling/FoveatedRender.h
+++ b/src/Features/Upscaling/FoveatedRender.h
@@ -58,13 +58,13 @@ struct FoveatedRender
 	// the accessors below — do not duplicate them here. Sharpening on/off is
 	// controlled by the shared sharpnessDLSS slider (0 disables RCAS).
 	//
-	// Deferred to PR-3b: per-input DLSS hint toggles (MV dilation, reactive mask,
+	// Not yet implemented: per-input DLSS hint toggles (MV dilation, reactive mask,
 	// transparency mask). The original PR #2096 declared the Settings fields and
 	// UI sliders but never plumbed them to EncodeTexturesCS or to the EvaluateDLSS
-	// arg list, so they were no-ops there too. Bringing them back in PR-3b means
-	// shader permutations (per-toggle defines), conditional encode-pass skip when
-	// all are off, and per-toggle DLSS arg gating — ship the implementation and
-	// the UI together so the knobs don't lie.
+	// arg list, so they were no-ops there too. Implementing requires shader
+	// permutations (per-toggle defines), conditional encode-pass skip when all are
+	// off, and per-toggle DLSS arg gating — ship the implementation and the UI
+	// together so the knobs don't lie.
 	struct Settings
 	{
 		uint enabled = 0;  // opt-in: requires restart to take effect via LatchEnabled()

--- a/src/Features/Upscaling/FoveatedRender.h
+++ b/src/Features/Upscaling/FoveatedRender.h
@@ -72,7 +72,7 @@ struct FoveatedRender
 		uint debugVisualize = 0;  // tint cheap-stretched periphery red; runtime toggle
 		uint peripheryAAMode = (uint)PeripheryAAMode::kTemporalSmooth;
 		float peripheryTemporalAlpha = 0.16f;
-		uint subrectBlendMode = (uint)SubrectBlendMode::kDither;
+		uint subrectBlendMode = (uint)SubrectBlendMode::kHardCopy;
 		float subrectFeatherWidth = 64.0f;
 		float subrectDitherStrength = 1.0f;
 	};

--- a/src/Features/Upscaling/FoveatedRender.h
+++ b/src/Features/Upscaling/FoveatedRender.h
@@ -58,13 +58,11 @@ struct FoveatedRender
 	// the accessors below — do not duplicate them here. Sharpening on/off is
 	// controlled by the shared sharpnessDLSS slider (0 disables RCAS).
 	//
-	// Not yet implemented: per-input DLSS hint toggles (MV dilation, reactive mask,
-	// transparency mask). The original PR #2096 declared the Settings fields and
-	// UI sliders but never plumbed them to EncodeTexturesCS or to the EvaluateDLSS
-	// arg list, so they were no-ops there too. Implementing requires shader
-	// permutations (per-toggle defines), conditional encode-pass skip when all are
-	// off, and per-toggle DLSS arg gating — ship the implementation and the UI
-	// together so the knobs don't lie.
+	// Do not add UI sliders for MV-dilation / reactive-mask / transparency-mask
+	// toggles until the shader permutations are plumbed: EncodeTexturesCS needs
+	// per-toggle defines, the encode pass needs a conditional skip when all are
+	// off, and EvaluateDLSS needs per-toggle arg gating. Knobs without wiring
+	// are silent no-ops that mislead users.
 	struct Settings
 	{
 		uint enabled = 0;  // opt-in: requires restart to take effect via LatchEnabled()

--- a/src/Features/Upscaling/FoveatedRender.h
+++ b/src/Features/Upscaling/FoveatedRender.h
@@ -27,6 +27,22 @@ struct FoveatedRender
 	{
 		kDefault = 0,  // Per-eye isolation: 2 extra resource sets, 2 evaluates. Supports F/J/K/L/M.
 		kFaster = 1,   // SBS viewport: tell SL to read subrect from SBS directly, no extra resources, 2 evaluates. J/K incompatible, only L/M/F.
+		kExtreme = 2,  // Combined strip: both eyes' subrect merged into one long texture, 1 extra resource set, 1 evaluate. Supports F/J/K/L/M. (Not recommended)
+	};
+
+	// Subrect blend mode when writing DLSS output back over stretched background
+	enum class SubrectBlendMode : uint
+	{
+		kHardCopy = 0,  // CopySubresourceRegion (no blending — sharp edge)
+		kFeather = 1,   // smoothstep alpha ramp over N pixels
+		kDither = 2,    // Blue-noise binary threshold in feather band
+	};
+
+	// Periphery AA algorithm applied after background stretch
+	enum class PeripheryAAMode : uint
+	{
+		kNone = 0,            // No dedicated periphery AA
+		kTemporalSmooth = 1,  // Motion-compensated temporal accumulation (anti-flicker)
 	};
 
 	// Stretch algorithm for DRS → full-eye background (used by SubrectStretchCS shader)
@@ -54,7 +70,13 @@ struct FoveatedRender
 		uint enabled = 0;  // opt-in: requires restart to take effect via LatchEnabled()
 		uint dlssMode = (uint)DlssMode::kDefault;
 		uint stretchMode = (uint)StretchMode::kGaussianBlur;
+		float peripheryBlurRadius = 1.0f;
 		uint debugVisualize = 0;  // tint cheap-stretched periphery red; runtime toggle
+		uint peripheryAAMode = (uint)PeripheryAAMode::kTemporalSmooth;
+		float peripheryTemporalAlpha = 0.16f;
+		uint subrectBlendMode = (uint)SubrectBlendMode::kDither;
+		float subrectFeatherWidth = 64.0f;
+		float subrectDitherStrength = 1.0f;
 	};
 
 	Settings settings;
@@ -90,8 +112,10 @@ struct FoveatedRender
 	/// (1=Quality .. 4=UltraPerformance). Delegates to the FFX SDK ratio table.
 	static float GetRenderScaleForQuality(uint qualityMode);
 
-	DlssMode GetDlssMode() const { return (DlssMode)std::min(settings.dlssMode, 1u); }
+	DlssMode GetDlssMode() const { return (DlssMode)std::min(settings.dlssMode, 2u); }
 	StretchMode GetStretchMode() const { return (StretchMode)std::min(settings.stretchMode, 2u); }
+	PeripheryAAMode GetPeripheryAAMode() const { return (PeripheryAAMode)std::min(settings.peripheryAAMode, 1u); }
+	SubrectBlendMode GetSubrectBlendMode() const { return (SubrectBlendMode)std::min(settings.subrectBlendMode, 2u); }
 
 	// Active getters: clamp + route shared fields through Upscaling::Settings.
 	uint GetActiveQualityMode() const;

--- a/src/Features/Upscaling/FoveatedRender/Bridge.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Bridge.cpp
@@ -54,15 +54,22 @@ void FoveatedRenderImpl::Bridge::ComputeMvecScale(float& outX, float& outY)
 		return;
 
 	auto& enhancer = globals::features::upscaling.foveatedRender;
+	const auto mode = enhancer.GetDlssMode();
 	const auto& uv = enhancer.subrectController.GetUV();  // PR-1 stereo Subrect: GetUV() == left-eye in stereo mode
 	const bool isFullEye = (uv.w >= 0.999f && uv.h >= 0.999f);
 
 	if (isFullEye)
 		return;
 
-	// Default + Faster both use per-eye DLSS calls (not strip-merged), so
-	// motion vectors scale by 1/UV.w on x.
-	outX = (uv.w > 0.0f) ? (1.0f / uv.w) : 1.0f;
+	// Extreme mode merges both eyes into one strip of width 2*subOutW;
+	// motion vectors authored at full-eye resolution must shrink by 1/(2·w)
+	// on x to land in strip space. Default and Faster keep per-eye sets, so
+	// x-scale is 1/UV.w.
+	if (mode == FoveatedRender::DlssMode::kExtreme) {
+		outX = (uv.w > 0.0f) ? (1.0f / (2.0f * uv.w)) : 1.0f;
+	} else {
+		outX = (uv.w > 0.0f) ? (1.0f / uv.w) : 1.0f;
+	}
 	outY = (uv.h > 0.0f) ? (1.0f / uv.h) : 1.0f;
 }
 

--- a/src/Features/Upscaling/FoveatedRender/Bridge.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Bridge.cpp
@@ -12,31 +12,6 @@ bool FoveatedRenderImpl::Bridge::IsRouteActive()
 	return globals::features::upscaling.foveatedRender.IsActive();
 }
 
-// Bridge.h contract: when the route is inactive, getters return a neutral /
-// identity value so callers that forget to check IsRouteActive() don't
-// silently pick up FoveatedRender values.
-
-uint32_t FoveatedRenderImpl::Bridge::GetQualityMode()
-{
-	if (!IsRouteActive())
-		return 0u;
-	return globals::features::upscaling.foveatedRender.GetActiveQualityMode();
-}
-
-uint32_t FoveatedRenderImpl::Bridge::GetPresetDLSS()
-{
-	if (!IsRouteActive())
-		return 0u;
-	return globals::features::upscaling.foveatedRender.GetActivePresetDLSS();
-}
-
-float FoveatedRenderImpl::Bridge::GetSharpnessDLSS()
-{
-	if (!IsRouteActive())
-		return 0.0f;
-	return globals::features::upscaling.foveatedRender.GetActiveSharpnessDLSS();
-}
-
 void FoveatedRenderImpl::Bridge::BootSequence()
 {
 	auto& enhancer = globals::features::upscaling.foveatedRender;
@@ -54,33 +29,14 @@ void FoveatedRenderImpl::Bridge::ComputeMvecScale(float& outX, float& outY)
 		return;
 
 	auto& enhancer = globals::features::upscaling.foveatedRender;
-	const auto mode = enhancer.GetDlssMode();
 	const auto& uv = enhancer.subrectController.GetUV();  // PR-1 stereo Subrect: GetUV() == left-eye in stereo mode
 	const bool isFullEye = (uv.w >= 0.999f && uv.h >= 0.999f);
 
 	if (isFullEye)
 		return;
 
-	// Extreme mode merges both eyes into one strip of width 2*subOutW;
-	// motion vectors authored at full-eye resolution must shrink by 1/(2·w)
-	// on x to land in strip space. Default and Faster keep per-eye sets, so
-	// x-scale is 1/UV.w.
-	if (mode == FoveatedRender::DlssMode::kExtreme) {
-		outX = (uv.w > 0.0f) ? (1.0f / (2.0f * uv.w)) : 1.0f;
-	} else {
-		outX = (uv.w > 0.0f) ? (1.0f / uv.w) : 1.0f;
-	}
+	// Default + Faster both use per-eye DLSS calls (not strip-merged), so
+	// motion vectors scale by 1/UV.w on x.
+	outX = (uv.w > 0.0f) ? (1.0f / uv.w) : 1.0f;
 	outY = (uv.h > 0.0f) ? (1.0f / uv.h) : 1.0f;
-}
-
-float FoveatedRenderImpl::Bridge::GetRenderScaleForQuality(uint32_t qualityMode)
-{
-	return FoveatedRender::GetRenderScaleForQuality(qualityMode);
-}
-
-uint32_t FoveatedRenderImpl::Bridge::GetQualityModeAtBoot()
-{
-	if (!IsRouteActive())
-		return 0u;
-	return globals::features::upscaling.foveatedRender.GetQualityModeAtBoot();
 }

--- a/src/Features/Upscaling/FoveatedRender/Bridge.h
+++ b/src/Features/Upscaling/FoveatedRender/Bridge.h
@@ -32,6 +32,12 @@ namespace FoveatedRenderImpl::Bridge
 	// Returns {1,1} when route is inactive or subrect is full-eye.
 	void ComputeMvecScale(float& outX, float& outY);
 
+	// Set/cleared by ExecuteVRDlssCore to indicate that the foveated subrect
+	// execute path is actually running this frame. SetConstants checks this so
+	// mvecScale correction is not applied to the standard full-frame DLSS path
+	// (e.g. menus, frames where foveated is skipped).
+	inline bool foveatedEvaluating = false;
+
 	// Render-to-display scale for a quality mode index (1=Quality .. 4=UltraPerf).
 	// Delegates to the FFX SDK ratio table.
 	float GetRenderScaleForQuality(uint32_t qualityMode);

--- a/src/Features/Upscaling/FoveatedRender/Bridge.h
+++ b/src/Features/Upscaling/FoveatedRender/Bridge.h
@@ -3,14 +3,10 @@
 // FoveatedRenderImpl::Bridge — single point of contact between the FoveatedRender
 // subsystem and the rest of Community Shaders (Upscaling, Streamline).
 //
-// All "is FoveatedRender active?", "what settings should DLSS use?", and
-// "what happened at boot?" questions are answered here, so consumers never
-// need to #include FoveatedRender.h or poke globals::features::upscaling.foveatedRender
-// directly.
-//
-// IMPORTANT: when the FoveatedRender route is inactive every query returns a
-// neutral / identity value — callers must still check IsRouteActive() and
-// fall back to their own settings when it returns false.
+// Consumers read FoveatedRender settings directly from
+// globals::features::upscaling.foveatedRender; Bridge exposes only the
+// cross-cutting concerns that require route-aware logic (active check, boot
+// sequence, mvec scale, execute-frame flag).
 
 #include <cstdint>
 
@@ -18,11 +14,6 @@ namespace FoveatedRenderImpl::Bridge
 {
 	// True when VR + DLSS available + FoveatedRender enabled-at-boot.
 	bool IsRouteActive();
-
-	// Settings forwarding (live values from FoveatedRender GUI).
-	uint32_t GetQualityMode();
-	uint32_t GetPresetDLSS();
-	float GetSharpnessDLSS();
 
 	// Boot-time latches. Run once during BSShaderRenderTargets::Create.
 	// Latches enable + qualityMode so settings cannot drift mid-frame.
@@ -37,12 +28,4 @@ namespace FoveatedRenderImpl::Bridge
 	// mvecScale correction is not applied to the standard full-frame DLSS path
 	// (e.g. menus, frames where foveated is skipped).
 	inline bool foveatedEvaluating = false;
-
-	// Render-to-display scale for a quality mode index (1=Quality .. 4=UltraPerf).
-	// Delegates to the FFX SDK ratio table.
-	float GetRenderScaleForQuality(uint32_t qualityMode);
-
-	// Quality mode latched at boot (resource sizing decisions consult this so
-	// they don't shift mid-game when the user changes the live setting).
-	uint32_t GetQualityModeAtBoot();
 }

--- a/src/Features/Upscaling/FoveatedRender/Core.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Core.cpp
@@ -633,6 +633,15 @@ namespace FoveatedRenderImpl::Ops
 		return Core::vrTemporalHistory[writeIdx]->srv.get();
 	}
 
+	ID3D11ShaderResourceView* MaybeTemporalSmooth(const VRDlssParams& p)
+	{
+		if (globals::features::upscaling.foveatedRender.GetPeripheryAAMode() == FoveatedRender::PeripheryAAMode::kTemporalSmooth) {
+			EnsureTemporalResources(p.renderW, p.renderH, p.colorSrc, p.motionVectors);
+			return TemporalSmoothSBS(p.renderW, p.renderH);
+		}
+		return nullptr;
+	}
+
 	// ── Subrect Blend (feathered / dithered copy-back) ──
 
 	struct alignas(16) BlendCB

--- a/src/Features/Upscaling/FoveatedRender/Core.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Core.cpp
@@ -451,58 +451,6 @@ namespace FoveatedRenderImpl::Ops
 		Core::vrFasterOutH = subOutH;
 	}
 
-	void EnsureExtremeStripTextures(
-		uint32_t stripInW, uint32_t stripInH,
-		uint32_t stripOutW, uint32_t stripOutH,
-		ID3D11Resource* colorSrc, ID3D11Resource* mvecSrc,
-		ID3D11Resource* reactiveSrc, ID3D11Resource* transparencySrc)
-	{
-		bool needsRecreate = !Core::vrExtremeStripColorIn ||
-		                     Core::vrExtremeStripW != stripInW || Core::vrExtremeStripH != stripInH ||
-		                     Core::vrExtremeStripOutW != stripOutW || Core::vrExtremeStripOutH != stripOutH;
-		if (!needsRecreate) {
-			needsRecreate = (reactiveSrc && !Core::vrExtremeStripReactiveMask) ||
-			                (transparencySrc && !Core::vrExtremeStripTransparencyMask);
-		}
-		if (!needsRecreate)
-			return;
-
-		Core::vrExtremeStripColorIn = CreateTextureFromSource(colorSrc, stripInW, stripInH, false, true, true, "FoveatedRender::Strip_ColorIn");
-		Core::vrExtremeStripColorOut = CreateTextureFromSource(colorSrc, stripOutW, stripOutH, false, true, false, "FoveatedRender::Strip_ColorOut");
-
-		D3D11_TEXTURE2D_DESC depthDesc = {};
-		depthDesc.Width = stripInW;
-		depthDesc.Height = stripInH;
-		depthDesc.MipLevels = 1;
-		depthDesc.ArraySize = 1;
-		depthDesc.Format = DXGI_FORMAT_R32_TYPELESS;
-		depthDesc.SampleDesc.Count = 1;
-		depthDesc.Usage = D3D11_USAGE_DEFAULT;
-		depthDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
-		Core::vrExtremeStripDepth = eastl::make_unique<Texture2D>(depthDesc);
-		Util::SetResourceName(Core::vrExtremeStripDepth->resource.get(), "FoveatedRender::Strip_Depth");
-		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
-		srvDesc.Format = DXGI_FORMAT_R32_FLOAT;
-		srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
-		srvDesc.Texture2D.MipLevels = 1;
-		Core::vrExtremeStripDepth->CreateSRV(srvDesc);
-
-		Core::vrExtremeStripMotionVectors = CreateTextureFromSource(mvecSrc, stripInW, stripInH, false, true, false, "FoveatedRender::Strip_MVec");
-		if (reactiveSrc)
-			Core::vrExtremeStripReactiveMask = CreateTextureFromSource(reactiveSrc, stripInW, stripInH, false, true, false, "FoveatedRender::Strip_Reactive");
-		else
-			Core::vrExtremeStripReactiveMask.reset();
-		if (transparencySrc)
-			Core::vrExtremeStripTransparencyMask = CreateTextureFromSource(transparencySrc, stripInW, stripInH, false, true, false, "FoveatedRender::Strip_Transparency");
-		else
-			Core::vrExtremeStripTransparencyMask.reset();
-
-		Core::vrExtremeStripW = stripInW;
-		Core::vrExtremeStripH = stripInH;
-		Core::vrExtremeStripOutW = stripOutW;
-		Core::vrExtremeStripOutH = stripOutH;
-	}
-
 	// ── Periphery Temporal Smooth ──
 	// Ping-pong between two history buffers at render-res SBS.
 	// Blends current frame with motion-reprojected history to reduce flicker
@@ -558,8 +506,8 @@ namespace FoveatedRenderImpl::Ops
 
 		// Lazy-create CS resources
 		if (!Core::vrTemporalSmoothCS) {
-			Core::vrTemporalSmoothCS.attach((ID3D11ComputeShader*)Util::CompileShader(
-				L"Data/Shaders/Upscaling/FoveatedRender/PeripheryTemporalSmoothCS.hlsl", {}, "cs_5_0"));
+			Core::vrTemporalSmoothCS.attach(static_cast<ID3D11ComputeShader*>(Util::CompileShader(
+				L"Data/Shaders/Upscaling/FoveatedRender/PeripheryTemporalSmoothCS.hlsl", {}, "cs_5_0")));
 			Util::SetResourceName(Core::vrTemporalSmoothCS.get(), "FoveatedRender::TemporalSmoothCS");
 
 			D3D11_BUFFER_DESC cbDesc = {};
@@ -750,8 +698,8 @@ namespace FoveatedRenderImpl::Ops
 
 		// Lazy-create CS resources
 		if (!Core::vrSubrectBlendCS) {
-			Core::vrSubrectBlendCS.attach((ID3D11ComputeShader*)Util::CompileShader(
-				L"Data/Shaders/Upscaling/FoveatedRender/SubrectBlendCS.hlsl", {}, "cs_5_0"));
+			Core::vrSubrectBlendCS.attach(static_cast<ID3D11ComputeShader*>(Util::CompileShader(
+				L"Data/Shaders/Upscaling/FoveatedRender/SubrectBlendCS.hlsl", {}, "cs_5_0")));
 			Util::SetResourceName(Core::vrSubrectBlendCS.get(), "FoveatedRender::SubrectBlendCS");
 
 			D3D11_BUFFER_DESC cbDesc = {};
@@ -796,7 +744,7 @@ namespace FoveatedRenderImpl::Ops
 				logger::error("[FOVEATED] BlendSubrectToOutput Map(vrSubrectBlendCB) failed; skipping dispatch");
 				return;
 			}
-			BlendCB* cb = (BlendCB*)mapped.pData;
+			BlendCB* cb = reinterpret_cast<BlendCB*>(mapped.pData);
 			cb->DstOffsetX = dstOffsetX;
 			cb->DstOffsetY = dstOffsetY;
 			cb->SubWidth = subWidth;
@@ -885,14 +833,6 @@ namespace FoveatedRenderImpl
 			vrFasterColorOut[i].reset();
 		}
 		vrSubrectInW = vrSubrectInH = vrSubrectOutW = vrSubrectOutH = 0;
-
-		vrExtremeStripColorIn.reset();
-		vrExtremeStripColorOut.reset();
-		vrExtremeStripDepth.reset();
-		vrExtremeStripMotionVectors.reset();
-		vrExtremeStripReactiveMask.reset();
-		vrExtremeStripTransparencyMask.reset();
-		vrExtremeStripW = vrExtremeStripH = vrExtremeStripOutW = vrExtremeStripOutH = 0;
 
 		vrRenderSBS.reset();
 		vrRenderSBSW = vrRenderSBSH = 0;

--- a/src/Features/Upscaling/FoveatedRender/Core.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Core.cpp
@@ -473,8 +473,13 @@ namespace FoveatedRenderImpl::Ops
 		// Cache an SRV on the game's mvec resource (no copy needed)
 		if (Core::vrMvecSRVOwner != mvecSrc) {
 			Core::vrMvecSRV = nullptr;
+			winrt::com_ptr<ID3D11Texture2D> mvecTex;
+			if (FAILED(mvecSrc->QueryInterface(IID_PPV_ARGS(mvecTex.put())))) {
+				logger::error("[FOVEATED] EnsureTemporalResources: mvecSrc is not an ID3D11Texture2D");
+				return;
+			}
 			D3D11_TEXTURE2D_DESC desc;
-			static_cast<ID3D11Texture2D*>(mvecSrc)->GetDesc(&desc);
+			mvecTex->GetDesc(&desc);
 			D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
 			srvDesc.Format = desc.Format;
 			srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
@@ -714,6 +719,8 @@ namespace FoveatedRenderImpl::Ops
 			cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
 			if (FAILED(device->CreateBuffer(&cbDesc, nullptr, Core::vrSubrectBlendCB.put()))) {
 				logger::error("[FOVEATED] Failed to create SubrectBlend constant buffer");
+				// Drop the CS so the next frame retries the full init block.
+				Core::vrSubrectBlendCS = nullptr;
 				D3D11_BOX srcBox = { srcOffsetX, 0, 0, srcOffsetX + subWidth, subHeight, 1 };
 				context->CopySubresourceRegion(dst, 0, dstOffsetX, dstOffsetY, 0, dlssSrc, 0, &srcBox);
 				return;
@@ -727,8 +734,14 @@ namespace FoveatedRenderImpl::Ops
 		// Get or create cached SRV on the DLSS output
 		if (Core::vrBlendSrcSRVOwner != dlssSrc) {
 			Core::vrBlendSrcSRV = nullptr;
+			winrt::com_ptr<ID3D11Texture2D> dlssTex;
+			if (FAILED(dlssSrc->QueryInterface(IID_PPV_ARGS(dlssTex.put())))) {
+				D3D11_BOX srcBox = { srcOffsetX, 0, 0, srcOffsetX + subWidth, subHeight, 1 };
+				context->CopySubresourceRegion(dst, 0, dstOffsetX, dstOffsetY, 0, dlssSrc, 0, &srcBox);
+				return;
+			}
 			D3D11_TEXTURE2D_DESC desc;
-			static_cast<ID3D11Texture2D*>(dlssSrc)->GetDesc(&desc);
+			dlssTex->GetDesc(&desc);
 			D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
 			srvDesc.Format = desc.Format;
 			srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;

--- a/src/Features/Upscaling/FoveatedRender/Core.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Core.cpp
@@ -397,8 +397,7 @@ namespace FoveatedRenderImpl::Ops
 			cb.data[6] = srcEyeWidth;
 			cb.data[7] = srcEyeHeight;
 			cb.stretchMode = enhSettings.stretchMode;
-			// Fixed 1.0 blur radius for the GaussianBlur stretch path.
-			cb.blurRadius = 1.0f;
+			cb.blurRadius = enhSettings.peripheryBlurRadius;
 			cb.debugVisualize = enhSettings.debugVisualize;
 			std::memcpy(mapped.pData, &cb, sizeof(cb));
 			context->Unmap(Core::vrSubrectStretchCB.get(), 0);
@@ -452,6 +451,206 @@ namespace FoveatedRenderImpl::Ops
 		Core::vrFasterOutH = subOutH;
 	}
 
+	void EnsureExtremeStripTextures(
+		uint32_t stripInW, uint32_t stripInH,
+		uint32_t stripOutW, uint32_t stripOutH,
+		ID3D11Resource* colorSrc, ID3D11Resource* mvecSrc,
+		ID3D11Resource* reactiveSrc, ID3D11Resource* transparencySrc)
+	{
+		bool needsRecreate = !Core::vrExtremeStripColorIn ||
+		                     Core::vrExtremeStripW != stripInW || Core::vrExtremeStripH != stripInH ||
+		                     Core::vrExtremeStripOutW != stripOutW || Core::vrExtremeStripOutH != stripOutH;
+		if (!needsRecreate) {
+			needsRecreate = (reactiveSrc && !Core::vrExtremeStripReactiveMask) ||
+			                (transparencySrc && !Core::vrExtremeStripTransparencyMask);
+		}
+		if (!needsRecreate)
+			return;
+
+		Core::vrExtremeStripColorIn = CreateTextureFromSource(colorSrc, stripInW, stripInH, false, true, true, "FoveatedRender::Strip_ColorIn");
+		Core::vrExtremeStripColorOut = CreateTextureFromSource(colorSrc, stripOutW, stripOutH, false, true, false, "FoveatedRender::Strip_ColorOut");
+
+		D3D11_TEXTURE2D_DESC depthDesc = {};
+		depthDesc.Width = stripInW;
+		depthDesc.Height = stripInH;
+		depthDesc.MipLevels = 1;
+		depthDesc.ArraySize = 1;
+		depthDesc.Format = DXGI_FORMAT_R32_TYPELESS;
+		depthDesc.SampleDesc.Count = 1;
+		depthDesc.Usage = D3D11_USAGE_DEFAULT;
+		depthDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+		Core::vrExtremeStripDepth = eastl::make_unique<Texture2D>(depthDesc);
+		Util::SetResourceName(Core::vrExtremeStripDepth->resource.get(), "FoveatedRender::Strip_Depth");
+		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+		srvDesc.Format = DXGI_FORMAT_R32_FLOAT;
+		srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
+		Core::vrExtremeStripDepth->CreateSRV(srvDesc);
+
+		Core::vrExtremeStripMotionVectors = CreateTextureFromSource(mvecSrc, stripInW, stripInH, false, true, false, "FoveatedRender::Strip_MVec");
+		if (reactiveSrc)
+			Core::vrExtremeStripReactiveMask = CreateTextureFromSource(reactiveSrc, stripInW, stripInH, false, true, false, "FoveatedRender::Strip_Reactive");
+		else
+			Core::vrExtremeStripReactiveMask.reset();
+		if (transparencySrc)
+			Core::vrExtremeStripTransparencyMask = CreateTextureFromSource(transparencySrc, stripInW, stripInH, false, true, false, "FoveatedRender::Strip_Transparency");
+		else
+			Core::vrExtremeStripTransparencyMask.reset();
+
+		Core::vrExtremeStripW = stripInW;
+		Core::vrExtremeStripH = stripInH;
+		Core::vrExtremeStripOutW = stripOutW;
+		Core::vrExtremeStripOutH = stripOutH;
+	}
+
+	// ── Periphery Temporal Smooth ──
+	// Ping-pong between two history buffers at render-res SBS.
+	// Blends current frame with motion-reprojected history to reduce flicker
+	// in the stretched periphery region.
+	void EnsureTemporalResources(uint32_t renderW, uint32_t renderH, ID3D11Resource* colorSrc, ID3D11Resource* mvecSrc)
+	{
+		if (!Core::vrTemporalHistory[0] || Core::vrTemporalHistoryW != renderW || Core::vrTemporalHistoryH != renderH) {
+			for (int i = 0; i < 2; i++) {
+				Core::vrTemporalHistory[i] = CreateTextureFromSource(colorSrc, renderW, renderH, false, true, true,
+					i == 0 ? "FoveatedRender::TemporalHistA" : "FoveatedRender::TemporalHistB");
+			}
+			Core::vrTemporalHistoryW = renderW;
+			Core::vrTemporalHistoryH = renderH;
+			Core::vrTemporalHistoryValid = false;
+			Core::vrTemporalFrameIdx = 0;
+			Core::vrMvecSRV = nullptr;
+			Core::vrMvecSRVOwner = nullptr;
+		}
+
+		// Cache an SRV on the game's mvec resource (no copy needed)
+		if (Core::vrMvecSRVOwner != mvecSrc) {
+			Core::vrMvecSRV = nullptr;
+			D3D11_TEXTURE2D_DESC desc;
+			static_cast<ID3D11Texture2D*>(mvecSrc)->GetDesc(&desc);
+			D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+			srvDesc.Format = desc.Format;
+			srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+			srvDesc.Texture2D.MostDetailedMip = 0;
+			srvDesc.Texture2D.MipLevels = 1;
+			if (FAILED(globals::d3d::device->CreateShaderResourceView(mvecSrc, &srvDesc, Core::vrMvecSRV.put()))) {
+				logger::error("[FOVEATED] Failed to create SRV on mvec resource for temporal smooth");
+			}
+			Core::vrMvecSRVOwner = mvecSrc;
+		}
+	}
+
+	ID3D11ShaderResourceView* TemporalSmoothSBS(uint32_t renderW, uint32_t renderH)
+	{
+		auto context = globals::d3d::context;
+
+		uint32_t readIdx = Core::vrTemporalFrameIdx & 1;
+		uint32_t writeIdx = readIdx ^ 1;
+
+		if (!Core::vrTemporalHistoryValid) {
+			// First frame: copy snapshot as seed history
+			context->CopyResource(Core::vrTemporalHistory[writeIdx]->resource.get(), Core::vrRenderSBS->resource.get());
+			Core::vrTemporalHistoryValid = true;
+			Core::vrTemporalFrameIdx++;
+			return Core::vrTemporalHistory[writeIdx]->srv.get();
+		}
+
+		// Lazy-create CS resources
+		if (!Core::vrTemporalSmoothCS) {
+			Core::vrTemporalSmoothCS.attach((ID3D11ComputeShader*)Util::CompileShader(
+				L"Data/Shaders/Upscaling/FoveatedRender/PeripheryTemporalSmoothCS.hlsl", {}, "cs_5_0"));
+			Util::SetResourceName(Core::vrTemporalSmoothCS.get(), "FoveatedRender::TemporalSmoothCS");
+
+			D3D11_BUFFER_DESC cbDesc = {};
+			cbDesc.ByteWidth = 16;  // 2 uint + 1 float + 1 uint pad
+			cbDesc.Usage = D3D11_USAGE_DYNAMIC;
+			cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+			cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+			if (FAILED(globals::d3d::device->CreateBuffer(&cbDesc, nullptr, Core::vrTemporalSmoothCB.put()))) {
+				logger::error("[FOVEATED] Failed to create TemporalSmooth constant buffer");
+				return Core::vrRenderSBS->srv.get();
+			}
+			Util::SetResourceName(Core::vrTemporalSmoothCB.get(), "FoveatedRender::TemporalSmoothCB");
+
+			D3D11_SAMPLER_DESC sampDesc = {};
+			sampDesc.Filter = D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
+			sampDesc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+			sampDesc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+			sampDesc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+			if (FAILED(globals::d3d::device->CreateSamplerState(&sampDesc, Core::vrTemporalSmoothSampler.put()))) {
+				logger::error("[FOVEATED] Failed to create TemporalSmooth sampler");
+				return Core::vrRenderSBS->srv.get();
+			}
+			Util::SetResourceName(Core::vrTemporalSmoothSampler.get(), "FoveatedRender::TemporalSmoothSampler");
+		}
+
+		if (!Core::vrTemporalSmoothCS || !Core::vrTemporalSmoothCB || !Core::vrTemporalSmoothSampler)
+			return Core::vrRenderSBS->srv.get();
+
+		D3D11_MAPPED_SUBRESOURCE mapped{};
+		if (SUCCEEDED(context->Map(Core::vrTemporalSmoothCB.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
+			struct
+			{
+				uint32_t w;
+				uint32_t h;
+				float alpha;
+				uint32_t pad;
+			} cb;
+			cb.w = renderW;
+			cb.h = renderH;
+			cb.alpha = globals::features::upscaling.foveatedRender.settings.peripheryTemporalAlpha;
+			cb.pad = 0;
+			std::memcpy(mapped.pData, &cb, sizeof(cb));
+			context->Unmap(Core::vrTemporalSmoothCB.get(), 0);
+		}
+
+		context->CSSetShader(Core::vrTemporalSmoothCS.get(), nullptr, 0);
+		ID3D11Buffer* cbs[] = { Core::vrTemporalSmoothCB.get() };
+		context->CSSetConstantBuffers(0, 1, cbs);
+		ID3D11ShaderResourceView* srvs[] = {
+			Core::vrRenderSBS->srv.get(),
+			Core::vrTemporalHistory[readIdx]->srv.get(),
+			Core::vrMvecSRV.get()
+		};
+		context->CSSetShaderResources(0, 3, srvs);
+		ID3D11SamplerState* samplers[] = { Core::vrTemporalSmoothSampler.get() };
+		context->CSSetSamplers(0, 1, samplers);
+		ID3D11UnorderedAccessView* uavs[] = { Core::vrTemporalHistory[writeIdx]->uav.get() };
+		context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
+
+		context->Dispatch((renderW + 7) / 8, (renderH + 7) / 8, 1);
+
+		ID3D11ShaderResourceView* nullSRVs[3] = {};
+		ID3D11UnorderedAccessView* nullUAV[1] = {};
+		ID3D11Buffer* nullCB[1] = {};
+		ID3D11SamplerState* nullSampler[1] = {};
+		context->CSSetShaderResources(0, 3, nullSRVs);
+		context->CSSetUnorderedAccessViews(0, 1, nullUAV, nullptr);
+		context->CSSetConstantBuffers(0, 1, nullCB);
+		context->CSSetSamplers(0, 1, nullSampler);
+		context->CSSetShader(nullptr, nullptr, 0);
+
+		Core::vrTemporalFrameIdx++;
+		return Core::vrTemporalHistory[writeIdx]->srv.get();
+	}
+
+	// ── Subrect Blend (feathered / dithered copy-back) ──
+
+	struct alignas(16) BlendCB
+	{
+		uint32_t DstOffsetX;
+		uint32_t DstOffsetY;
+		uint32_t SubWidth;
+		uint32_t SubHeight;
+		uint32_t BlendMode;
+		float FeatherWidth;
+		uint32_t FrameIndex;
+		uint32_t SrcOffsetX;
+		float DitherStrength;
+		uint32_t _pad0, _pad1, _pad2;
+	};
+
+	static uint32_t s_blendFrameIdx = 0;
+
 	uint64_t ComputeSubrectUVHash(const Util::Subrect::UVRegion& leftUV,
 		const Util::Subrect::UVRegion& rightUV, uint32_t mode)
 	{
@@ -500,12 +699,104 @@ namespace FoveatedRenderImpl::Ops
 		}
 	}
 
-	void BlendSubrectToOutput(ID3D11Resource* dlssSrc, ID3D11Resource* dst,
+	void BlendSubrectToOutput(ID3D11Resource* dlssSrc, ID3D11Resource* dst, ID3D11UnorderedAccessView* dstUAV,
 		uint32_t dstOffsetX, uint32_t dstOffsetY, uint32_t subWidth, uint32_t subHeight, uint32_t srcOffsetX)
 	{
 		auto context = globals::d3d::context;
-		D3D11_BOX srcBox = { srcOffsetX, 0, 0, srcOffsetX + subWidth, subHeight, 1 };
-		context->CopySubresourceRegion(dst, 0, dstOffsetX, dstOffsetY, 0, dlssSrc, 0, &srcBox);
+		auto& foveated = globals::features::upscaling.foveatedRender;
+		auto blendMode = foveated.GetSubrectBlendMode();
+
+		// Fast path: hard copy (original behaviour)
+		if (blendMode == FoveatedRender::SubrectBlendMode::kHardCopy) {
+			D3D11_BOX srcBox = { srcOffsetX, 0, 0, srcOffsetX + subWidth, subHeight, 1 };
+			context->CopySubresourceRegion(dst, 0, dstOffsetX, dstOffsetY, 0, dlssSrc, 0, &srcBox);
+			return;
+		}
+
+		if (!dstUAV) {
+			// No UAV available — fall back to hard copy
+			D3D11_BOX srcBox = { srcOffsetX, 0, 0, srcOffsetX + subWidth, subHeight, 1 };
+			context->CopySubresourceRegion(dst, 0, dstOffsetX, dstOffsetY, 0, dlssSrc, 0, &srcBox);
+			return;
+		}
+
+		auto device = globals::d3d::device;
+
+		// Lazy-create CS resources
+		if (!Core::vrSubrectBlendCS) {
+			Core::vrSubrectBlendCS.attach((ID3D11ComputeShader*)Util::CompileShader(
+				L"Data/Shaders/Upscaling/FoveatedRender/SubrectBlendCS.hlsl", {}, "cs_5_0"));
+			Util::SetResourceName(Core::vrSubrectBlendCS.get(), "FoveatedRender::SubrectBlendCS");
+
+			D3D11_BUFFER_DESC cbDesc = {};
+			cbDesc.ByteWidth = sizeof(BlendCB);
+			cbDesc.Usage = D3D11_USAGE_DYNAMIC;
+			cbDesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
+			cbDesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
+			if (FAILED(device->CreateBuffer(&cbDesc, nullptr, Core::vrSubrectBlendCB.put()))) {
+				logger::error("[FOVEATED] Failed to create SubrectBlend constant buffer");
+				D3D11_BOX srcBox = { srcOffsetX, 0, 0, srcOffsetX + subWidth, subHeight, 1 };
+				context->CopySubresourceRegion(dst, 0, dstOffsetX, dstOffsetY, 0, dlssSrc, 0, &srcBox);
+				return;
+			}
+			Util::SetResourceName(Core::vrSubrectBlendCB.get(), "FoveatedRender::SubrectBlendCB");
+		}
+
+		if (!Core::vrSubrectBlendCS || !Core::vrSubrectBlendCB)
+			return;
+
+		// Get or create cached SRV on the DLSS output
+		if (Core::vrBlendSrcSRVOwner != dlssSrc) {
+			Core::vrBlendSrcSRV = nullptr;
+			D3D11_TEXTURE2D_DESC desc;
+			static_cast<ID3D11Texture2D*>(dlssSrc)->GetDesc(&desc);
+			D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+			srvDesc.Format = desc.Format;
+			srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+			srvDesc.Texture2D.MostDetailedMip = 0;
+			srvDesc.Texture2D.MipLevels = 1;
+			if (FAILED(device->CreateShaderResourceView(dlssSrc, &srvDesc, Core::vrBlendSrcSRV.put()))) {
+				D3D11_BOX srcBox = { srcOffsetX, 0, 0, srcOffsetX + subWidth, subHeight, 1 };
+				context->CopySubresourceRegion(dst, 0, dstOffsetX, dstOffsetY, 0, dlssSrc, 0, &srcBox);
+				return;
+			}
+			Core::vrBlendSrcSRVOwner = dlssSrc;
+		}
+
+		{
+			D3D11_MAPPED_SUBRESOURCE mapped;
+			context->Map(Core::vrSubrectBlendCB.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
+			BlendCB* cb = (BlendCB*)mapped.pData;
+			cb->DstOffsetX = dstOffsetX;
+			cb->DstOffsetY = dstOffsetY;
+			cb->SubWidth = subWidth;
+			cb->SubHeight = subHeight;
+			cb->BlendMode = (blendMode == FoveatedRender::SubrectBlendMode::kDither) ? 1 : 0;
+			cb->FeatherWidth = foveated.settings.subrectFeatherWidth;
+			cb->FrameIndex = s_blendFrameIdx++;
+			cb->SrcOffsetX = srcOffsetX;
+			cb->DitherStrength = foveated.settings.subrectDitherStrength;
+			cb->_pad0 = cb->_pad1 = cb->_pad2 = 0;
+			context->Unmap(Core::vrSubrectBlendCB.get(), 0);
+		}
+
+		context->CSSetShader(Core::vrSubrectBlendCS.get(), nullptr, 0);
+		ID3D11Buffer* cbs[] = { Core::vrSubrectBlendCB.get() };
+		context->CSSetConstantBuffers(0, 1, cbs);
+		ID3D11ShaderResourceView* srvs[] = { Core::vrBlendSrcSRV.get() };
+		context->CSSetShaderResources(0, 1, srvs);
+		ID3D11UnorderedAccessView* uavs[] = { dstUAV };
+		context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
+
+		context->Dispatch((subWidth + 7) / 8, (subHeight + 7) / 8, 1);
+
+		ID3D11ShaderResourceView* nullSRV[1] = {};
+		ID3D11UnorderedAccessView* nullUAV[1] = {};
+		ID3D11Buffer* nullCB[1] = {};
+		context->CSSetShaderResources(0, 1, nullSRV);
+		context->CSSetUnorderedAccessViews(0, 1, nullUAV, nullptr);
+		context->CSSetConstantBuffers(0, 1, nullCB);
+		context->CSSetShader(nullptr, nullptr, 0);
 	}
 
 }  // namespace FoveatedRenderImpl::Ops
@@ -559,15 +850,33 @@ namespace FoveatedRenderImpl
 			vrSubrectMotionVectors[i].reset();
 			vrSubrectReactiveMask[i].reset();
 			vrSubrectTransparencyMask[i].reset();
+
+			vrTemporalHistory[i].reset();
+			vrFasterColorOut[i].reset();
 		}
 		vrSubrectInW = vrSubrectInH = vrSubrectOutW = vrSubrectOutH = 0;
+
+		vrExtremeStripColorIn.reset();
+		vrExtremeStripColorOut.reset();
+		vrExtremeStripDepth.reset();
+		vrExtremeStripMotionVectors.reset();
+		vrExtremeStripReactiveMask.reset();
+		vrExtremeStripTransparencyMask.reset();
+		vrExtremeStripW = vrExtremeStripH = vrExtremeStripOutW = vrExtremeStripOutH = 0;
 
 		vrRenderSBS.reset();
 		vrRenderSBSW = vrRenderSBSH = 0;
 
-		vrFasterColorOut[0].reset();
-		vrFasterColorOut[1].reset();
 		vrFasterOutW = vrFasterOutH = 0;
+
+		vrMvecSRV = nullptr;
+		vrMvecSRVOwner = nullptr;
+		vrTemporalHistoryW = vrTemporalHistoryH = 0;
+		vrTemporalFrameIdx = 0;
+		vrTemporalHistoryValid = false;
+
+		vrBlendSrcSRV = nullptr;
+		vrBlendSrcSRVOwner = nullptr;
 
 		activeSubrectUVHash = 0;
 	}
@@ -577,5 +886,12 @@ namespace FoveatedRenderImpl
 		vrSubrectStretchCS = nullptr;
 		vrSubrectStretchCB = nullptr;
 		vrSubrectStretchSampler = nullptr;
+
+		vrTemporalSmoothCS = nullptr;
+		vrTemporalSmoothCB = nullptr;
+		vrTemporalSmoothSampler = nullptr;
+
+		vrSubrectBlendCS = nullptr;
+		vrSubrectBlendCB = nullptr;
 	}
 }

--- a/src/Features/Upscaling/FoveatedRender/Core.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Core.cpp
@@ -496,6 +496,9 @@ namespace FoveatedRenderImpl::Ops
 
 	ID3D11ShaderResourceView* TemporalSmoothSBS(uint32_t renderW, uint32_t renderH)
 	{
+		if (!Core::vrRenderSBS || !Core::vrRenderSBS->srv)
+			return nullptr;
+
 		auto context = globals::d3d::context;
 
 		uint32_t readIdx = Core::vrTemporalFrameIdx & 1;
@@ -633,8 +636,6 @@ namespace FoveatedRenderImpl::Ops
 		uint32_t _pad0, _pad1, _pad2;
 	};
 
-	static uint32_t s_blendFrameIdx = 0;
-
 	uint64_t ComputeSubrectUVHash(const Util::Subrect::UVRegion& leftUV,
 		const Util::Subrect::UVRegion& rightUV, uint32_t mode)
 	{
@@ -769,7 +770,7 @@ namespace FoveatedRenderImpl::Ops
 			cb->SubHeight = subHeight;
 			cb->BlendMode = (blendMode == FoveatedRender::SubrectBlendMode::kDither) ? 1 : 0;
 			cb->FeatherWidth = foveated.settings.subrectFeatherWidth;
-			cb->FrameIndex = s_blendFrameIdx++;
+			cb->FrameIndex = globals::state->frameCount;
 			cb->SrcOffsetX = srcOffsetX;
 			cb->DitherStrength = foveated.settings.subrectDitherStrength;
 			cb->_pad0 = cb->_pad1 = cb->_pad2 = 0;

--- a/src/Features/Upscaling/FoveatedRender/Core.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Core.cpp
@@ -587,6 +587,11 @@ namespace FoveatedRenderImpl::Ops
 	{
 		if (globals::features::upscaling.foveatedRender.GetPeripheryAAMode() == FoveatedRender::PeripheryAAMode::kTemporalSmooth) {
 			EnsureTemporalResources(p.renderW, p.renderH, p.colorSrc, p.motionVectors);
+			// Bail if the mvec SRV couldn't be created (EnsureTemporalResources logs
+			// the failure). TemporalSmoothSBS would otherwise dispatch the CS with a
+			// null SRV bound at t2, reading undefined data.
+			if (!Core::vrMvecSRV)
+				return nullptr;
 			return TemporalSmoothSBS(p.renderW, p.renderH);
 		}
 		return nullptr;

--- a/src/Features/Upscaling/FoveatedRender/Core.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Core.cpp
@@ -534,7 +534,9 @@ namespace FoveatedRenderImpl::Ops
 			srvDesc.Texture2D.MipLevels = 1;
 			if (FAILED(globals::d3d::device->CreateShaderResourceView(mvecSrc, &srvDesc, Core::vrMvecSRV.put()))) {
 				logger::error("[FOVEATED] Failed to create SRV on mvec resource for temporal smooth");
+				return;
 			}
+			Util::SetResourceName(Core::vrMvecSRV.get(), "FoveatedRender::MVecSRV");
 			Core::vrMvecSRVOwner = mvecSrc;
 		}
 	}
@@ -640,6 +642,21 @@ namespace FoveatedRenderImpl::Ops
 			return TemporalSmoothSBS(p.renderW, p.renderH);
 		}
 		return nullptr;
+	}
+
+	void ClearHMDMaskOnSnapshot(const VRDlssParams& p)
+	{
+		auto* depthSRV = globals::game::renderer->GetDepthStencilData()
+		                     .depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN]
+		                     .depthSRV;
+		if (!Core::vrRenderSBS || !Core::vrRenderSBS->uav || !depthSRV)
+			return;
+		auto& upscaling = globals::features::upscaling;
+		for (uint32_t i = 0; i < 2; ++i) {
+			const uint32_t eyeOffsetX = i * p.eyeWidthIn;
+			upscaling.ClearHMDMask(Core::vrRenderSBS->uav.get(), depthSRV,
+				p.eyeWidthIn, p.eyeHeightIn, eyeOffsetX, eyeOffsetX);
+		}
 	}
 
 	// ── Subrect Blend (feathered / dithered copy-back) ──
@@ -769,12 +786,16 @@ namespace FoveatedRenderImpl::Ops
 				context->CopySubresourceRegion(dst, 0, dstOffsetX, dstOffsetY, 0, dlssSrc, 0, &srcBox);
 				return;
 			}
+			Util::SetResourceName(Core::vrBlendSrcSRV.get(), "FoveatedRender::BlendSrcSRV");
 			Core::vrBlendSrcSRVOwner = dlssSrc;
 		}
 
 		{
 			D3D11_MAPPED_SUBRESOURCE mapped;
-			context->Map(Core::vrSubrectBlendCB.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped);
+			if (FAILED(context->Map(Core::vrSubrectBlendCB.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
+				logger::error("[FOVEATED] BlendSubrectToOutput Map(vrSubrectBlendCB) failed; skipping dispatch");
+				return;
+			}
 			BlendCB* cb = (BlendCB*)mapped.pData;
 			cb->DstOffsetX = dstOffsetX;
 			cb->DstOffsetY = dstOffsetY;

--- a/src/Features/Upscaling/FoveatedRender/Core.h
+++ b/src/Features/Upscaling/FoveatedRender/Core.h
@@ -4,7 +4,7 @@
 // FoveatedRenderImpl::Core — GPU resource pool & mode-dispatch entry point
 // ============================================================================
 //
-// Owns all per-mode intermediate textures (Default / Faster / Extreme),
+// Owns all per-mode intermediate textures (Default / Faster),
 // compute-shader objects (stretch, temporal smooth, subrect blend), and the
 // public entry points consumed by Upscaling.cpp.
 //

--- a/src/Features/Upscaling/FoveatedRender/Core.h
+++ b/src/Features/Upscaling/FoveatedRender/Core.h
@@ -70,16 +70,6 @@ namespace FoveatedRenderImpl
 		static inline eastl::unique_ptr<Texture2D> vrSubrectTransparencyMask[2];
 		static inline uint32_t vrSubrectInW = 0, vrSubrectInH = 0, vrSubrectOutW = 0, vrSubrectOutH = 0;
 
-		// Extreme mode: combined strip texture (both eyes' subrects side by side)
-		static inline eastl::unique_ptr<Texture2D> vrExtremeStripColorIn;
-		static inline eastl::unique_ptr<Texture2D> vrExtremeStripColorOut;
-		static inline eastl::unique_ptr<Texture2D> vrExtremeStripDepth;
-		static inline eastl::unique_ptr<Texture2D> vrExtremeStripMotionVectors;
-		static inline eastl::unique_ptr<Texture2D> vrExtremeStripReactiveMask;
-		static inline eastl::unique_ptr<Texture2D> vrExtremeStripTransparencyMask;
-		static inline uint32_t vrExtremeStripW = 0, vrExtremeStripH = 0;
-		static inline uint32_t vrExtremeStripOutW = 0, vrExtremeStripOutH = 0;
-
 		// Faster mode per-eye output textures (subOutW × subOutH)
 		static inline eastl::unique_ptr<Texture2D> vrFasterColorOut[2];
 		static inline uint32_t vrFasterOutW = 0, vrFasterOutH = 0;
@@ -118,6 +108,5 @@ namespace FoveatedRenderImpl
 	private:
 		static bool ExecuteDefaultMode(Streamline& streamline, const VRDlssParams& p);
 		static bool ExecuteFasterMode(Streamline& streamline, const VRDlssParams& p);
-		static bool ExecuteExtremeMode(Streamline& streamline, const VRDlssParams& p);
 	};
 }

--- a/src/Features/Upscaling/FoveatedRender/Core.h
+++ b/src/Features/Upscaling/FoveatedRender/Core.h
@@ -4,9 +4,9 @@
 // FoveatedRenderImpl::Core — GPU resource pool & mode-dispatch entry point
 // ============================================================================
 //
-// Owns all per-mode intermediate textures (Default / Faster), compute-shader
-// objects (subrect stretch), and the public entry points consumed by
-// Upscaling.cpp.
+// Owns all per-mode intermediate textures (Default / Faster / Extreme),
+// compute-shader objects (stretch, temporal smooth, subrect blend), and the
+// public entry points consumed by Upscaling.cpp.
 //
 // ============================================================================
 
@@ -70,6 +70,16 @@ namespace FoveatedRenderImpl
 		static inline eastl::unique_ptr<Texture2D> vrSubrectTransparencyMask[2];
 		static inline uint32_t vrSubrectInW = 0, vrSubrectInH = 0, vrSubrectOutW = 0, vrSubrectOutH = 0;
 
+		// Extreme mode: combined strip texture (both eyes' subrects side by side)
+		static inline eastl::unique_ptr<Texture2D> vrExtremeStripColorIn;
+		static inline eastl::unique_ptr<Texture2D> vrExtremeStripColorOut;
+		static inline eastl::unique_ptr<Texture2D> vrExtremeStripDepth;
+		static inline eastl::unique_ptr<Texture2D> vrExtremeStripMotionVectors;
+		static inline eastl::unique_ptr<Texture2D> vrExtremeStripReactiveMask;
+		static inline eastl::unique_ptr<Texture2D> vrExtremeStripTransparencyMask;
+		static inline uint32_t vrExtremeStripW = 0, vrExtremeStripH = 0;
+		static inline uint32_t vrExtremeStripOutW = 0, vrExtremeStripOutH = 0;
+
 		// Faster mode per-eye output textures (subOutW × subOutH)
 		static inline eastl::unique_ptr<Texture2D> vrFasterColorOut[2];
 		static inline uint32_t vrFasterOutW = 0, vrFasterOutH = 0;
@@ -83,11 +93,31 @@ namespace FoveatedRenderImpl
 		static inline winrt::com_ptr<ID3D11Buffer> vrSubrectStretchCB;
 		static inline winrt::com_ptr<ID3D11SamplerState> vrSubrectStretchSampler;
 
+		// Periphery temporal smooth (ping-pong history at render-res SBS)
+		static inline eastl::unique_ptr<Texture2D> vrTemporalHistory[2];   // SRV+UAV ping-pong
+		static inline winrt::com_ptr<ID3D11ShaderResourceView> vrMvecSRV;  // cached SRV on game's mvec resource
+		static inline ID3D11Resource* vrMvecSRVOwner = nullptr;            // track which resource the SRV was created from
+		static inline uint32_t vrTemporalHistoryW = 0, vrTemporalHistoryH = 0;
+		static inline uint32_t vrTemporalFrameIdx = 0;
+		static inline bool vrTemporalHistoryValid = false;
+
+		// Temporal smooth compute shader resources
+		static inline winrt::com_ptr<ID3D11ComputeShader> vrTemporalSmoothCS;
+		static inline winrt::com_ptr<ID3D11Buffer> vrTemporalSmoothCB;
+		static inline winrt::com_ptr<ID3D11SamplerState> vrTemporalSmoothSampler;
+
+		// Subrect blend compute shader resources (feather / dither copy-back)
+		static inline winrt::com_ptr<ID3D11ComputeShader> vrSubrectBlendCS;
+		static inline winrt::com_ptr<ID3D11Buffer> vrSubrectBlendCB;
+		static inline winrt::com_ptr<ID3D11ShaderResourceView> vrBlendSrcSRV;
+		static inline ID3D11Resource* vrBlendSrcSRVOwner = nullptr;
+
 		// Subrect UV hash for resource recreation detection
 		static inline uint64_t activeSubrectUVHash = 0;
 
 	private:
 		static bool ExecuteDefaultMode(Streamline& streamline, const VRDlssParams& p);
 		static bool ExecuteFasterMode(Streamline& streamline, const VRDlssParams& p);
+		static bool ExecuteExtremeMode(Streamline& streamline, const VRDlssParams& p);
 	};
 }

--- a/src/Features/Upscaling/FoveatedRender/Modes.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Modes.cpp
@@ -1,5 +1,5 @@
 // ============================================================================
-// Modes.cpp — Default / Faster DLSS execution strategies
+// Modes.cpp — Default / Faster / Extreme DLSS execution strategies
 // ============================================================================
 //
 // Each mode composes Ops primitives (snapshot, stretch, crop, blend…) in a
@@ -41,6 +41,8 @@ namespace FoveatedRenderImpl
 		switch (p.mode) {
 		case FoveatedRender::DlssMode::kFaster:
 			return ExecuteFasterMode(streamline, p);
+		case FoveatedRender::DlssMode::kExtreme:
+			return ExecuteExtremeMode(streamline, p);
 		default:
 			return ExecuteDefaultMode(streamline, p);
 		}
@@ -99,7 +101,15 @@ namespace FoveatedRenderImpl
 		// Snapshot + Stretch DRS → kMAIN (fill full-eye background)
 		SnapshotSBS(p.colorSrc, p.renderW, p.renderH);
 
-		StretchDRSBothEyes(p.colorDstUAV, p.eyeWidthOut, p.eyeHeightOut, p.eyeWidthIn, p.eyeHeightIn, p.renderW, p.renderH);
+		// Periphery temporal smooth: blend with reprojected history before stretch
+		// so the periphery gets temporal AA that DLSS doesn't cover for the cropped area.
+		ID3D11ShaderResourceView* stretchSrc = nullptr;
+		if (globals::features::upscaling.foveatedRender.GetPeripheryAAMode() == FoveatedRender::PeripheryAAMode::kTemporalSmooth) {
+			EnsureTemporalResources(p.renderW, p.renderH, p.colorSrc, p.motionVectors);
+			stretchSrc = TemporalSmoothSBS(p.renderW, p.renderH);
+		}
+
+		StretchDRSBothEyes(p.colorDstUAV, p.eyeWidthOut, p.eyeHeightOut, p.eyeWidthIn, p.eyeHeightIn, p.renderW, p.renderH, stretchSrc);
 
 		// Crop subrect per-eye from snapshot (not kMAIN which was overwritten by stretch)
 		auto context = globals::d3d::context;
@@ -145,7 +155,7 @@ namespace FoveatedRenderImpl
 			uint32_t dstCropX = (uint32_t)(uv.x * p.eyeWidthOut);
 			uint32_t dstCropY = (uint32_t)(uv.y * p.eyeHeightOut);
 			uint32_t dstX = (i == 1 ? p.eyeWidthOut : 0) + dstCropX;
-			BlendSubrectToOutput(Core::vrSubrectColorOut[i]->resource.get(), p.colorDst,
+			BlendSubrectToOutput(Core::vrSubrectColorOut[i]->resource.get(), p.colorDst, p.colorDstUAV,
 				dstX, dstCropY, subOutW, subOutH);
 		}
 
@@ -232,7 +242,13 @@ namespace FoveatedRenderImpl
 
 		// Step 3: Stretch DRS → kMAIN (subrect only) — snapshot reused from Step 2a.
 		if (!p.isFullEye) {
-			StretchDRSBothEyes(p.colorDstUAV, p.eyeWidthOut, p.eyeHeightOut, p.eyeWidthIn, p.eyeHeightIn, p.renderW, p.renderH);
+			// Periphery temporal smooth for the stretched periphery.
+			ID3D11ShaderResourceView* stretchSrc = nullptr;
+			if (globals::features::upscaling.foveatedRender.GetPeripheryAAMode() == FoveatedRender::PeripheryAAMode::kTemporalSmooth) {
+				EnsureTemporalResources(p.renderW, p.renderH, p.colorSrc, p.motionVectors);
+				stretchSrc = TemporalSmoothSBS(p.renderW, p.renderH);
+			}
+			StretchDRSBothEyes(p.colorDstUAV, p.eyeWidthOut, p.eyeHeightOut, p.eyeWidthIn, p.eyeHeightIn, p.renderW, p.renderH, stretchSrc);
 		}
 
 		// Step 4: Copy DLSS output back (with optional blend)
@@ -245,8 +261,96 @@ namespace FoveatedRenderImpl
 			uint32_t dstCropX = p.isFullEye ? 0 : (uint32_t)(uv.x * p.eyeWidthOut);
 			uint32_t dstCropY = p.isFullEye ? 0 : (uint32_t)(uv.y * p.eyeHeightOut);
 			uint32_t dstX = (i == 1 ? p.eyeWidthOut : 0) + dstCropX;
-			BlendSubrectToOutput(Core::vrFasterColorOut[i]->resource.get(), p.colorDst,
+			BlendSubrectToOutput(Core::vrFasterColorOut[i]->resource.get(), p.colorDst, p.colorDstUAV,
 				dstX, dstCropY, subOutW, subOutH);
+		}
+
+		return true;
+	}
+
+	// ── Extreme mode: combined strip, 1 resource set, 1 evaluate ──
+	// Both eyes' subrects merged horizontally into one long texture. Trades a
+	// pre-DLSS copy for a single Streamline evaluate (vs Default/Faster's two).
+
+	bool Core::ExecuteExtremeMode(Streamline& streamline, const VRDlssParams& p)
+	{
+		const Util::Subrect::UVRegion* eyeUVs[2] = { &p.leftUV, &p.rightUV };
+
+		// Strip allocation uses left-eye dims (auto-mirror constraint, same as
+		// Default/Faster). Per-eye loop uses real per-eye sizes.
+		uint32_t allocSubInW = p.isFullEye ? p.eyeWidthIn : std::max<uint32_t>(1, (uint32_t)(p.eyeWidthIn * p.leftUV.w));
+		uint32_t allocSubInH = p.isFullEye ? p.eyeHeightIn : std::max<uint32_t>(1, (uint32_t)(p.eyeHeightIn * p.leftUV.h));
+		uint32_t allocSubOutW = p.isFullEye ? p.eyeWidthOut : std::max<uint32_t>(1, (uint32_t)(p.eyeWidthOut * p.leftUV.w));
+		uint32_t allocSubOutH = p.isFullEye ? p.eyeHeightOut : std::max<uint32_t>(1, (uint32_t)(p.eyeHeightOut * p.leftUV.h));
+		uint32_t stripInW = allocSubInW * 2;
+		uint32_t stripOutW = allocSubOutW * 2;
+
+		EnsureExtremeStripTextures(stripInW, allocSubInH, stripOutW, allocSubOutH,
+			p.colorSrc, p.motionVectors, p.reactiveMask, p.transparencyMask);
+
+		auto context = globals::d3d::context;
+
+		// Snapshot + Stretch DRS → kMAIN if subrect (fills periphery).
+		if (!p.isFullEye) {
+			SnapshotSBS(p.colorSrc, p.renderW, p.renderH);
+
+			ID3D11ShaderResourceView* stretchSrc = nullptr;
+			if (globals::features::upscaling.foveatedRender.GetPeripheryAAMode() == FoveatedRender::PeripheryAAMode::kTemporalSmooth) {
+				EnsureTemporalResources(p.renderW, p.renderH, p.colorSrc, p.motionVectors);
+				stretchSrc = TemporalSmoothSBS(p.renderW, p.renderH);
+			}
+
+			StretchDRSBothEyes(p.colorDstUAV, p.eyeWidthOut, p.eyeHeightOut, p.eyeWidthIn, p.eyeHeightIn, p.renderW, p.renderH, stretchSrc);
+		}
+
+		// Copy both eyes' subrects into the strip. Color reads from the
+		// pre-stretch snapshot when available so we don't read kMAIN after stretch.
+		ID3D11Resource* colorReadSrc = (!p.isFullEye && Core::vrRenderSBS) ? Core::vrRenderSBS->resource.get() : p.colorSrc;
+		for (uint32_t i = 0; i < 2; ++i) {
+			const auto& uv = *eyeUVs[i];
+			// Per-eye sizing — same fix as Default/Faster (CodeRabbit Major @ original PR).
+			uint32_t subInW = p.isFullEye ? p.eyeWidthIn : std::max<uint32_t>(1, (uint32_t)(p.eyeWidthIn * uv.w));
+			uint32_t subInH = p.isFullEye ? p.eyeHeightIn : std::max<uint32_t>(1, (uint32_t)(p.eyeHeightIn * uv.h));
+
+			uint32_t cropX = p.isFullEye ? 0 : (uint32_t)(uv.x * p.eyeWidthIn);
+			uint32_t cropY = p.isFullEye ? 0 : (uint32_t)(uv.y * p.eyeHeightIn);
+			uint32_t sbsX = (i == 1 ? p.eyeWidthIn : 0) + cropX;
+			D3D11_BOX box = { sbsX, cropY, 0, sbsX + subInW, cropY + subInH, 1 };
+			uint32_t stripDstX = i * allocSubInW;
+
+			context->CopySubresourceRegion(Core::vrExtremeStripColorIn->resource.get(), 0, stripDstX, 0, 0, colorReadSrc, 0, &box);
+			context->CopySubresourceRegion(Core::vrExtremeStripDepth->resource.get(), 0, stripDstX, 0, 0, p.depthTexture, 0, &box);
+			context->CopySubresourceRegion(Core::vrExtremeStripMotionVectors->resource.get(), 0, stripDstX, 0, 0, p.motionVectors, 0, &box);
+			if (p.reactiveMask)
+				context->CopySubresourceRegion(Core::vrExtremeStripReactiveMask->resource.get(), 0, stripDstX, 0, 0, p.reactiveMask, 0, &box);
+			if (p.transparencyMask)
+				context->CopySubresourceRegion(Core::vrExtremeStripTransparencyMask->resource.get(), 0, stripDstX, 0, 0, p.transparencyMask, 0, &box);
+		}
+
+		// Single DLSS evaluate on the entire strip.
+		sl::Extent extentIn{ 0, 0, stripInW, allocSubInH };
+		sl::Extent extentOut{ 0, 0, stripOutW, allocSubOutH };
+		streamline.EvaluateDLSS(streamline.viewport, 0,
+			Core::vrExtremeStripColorIn->resource.get(), Core::vrExtremeStripColorOut->resource.get(),
+			Core::vrExtremeStripDepth->resource.get(), Core::vrExtremeStripMotionVectors->resource.get(),
+			p.reactiveMask ? Core::vrExtremeStripReactiveMask->resource.get() : nullptr,
+			p.transparencyMask ? Core::vrExtremeStripTransparencyMask->resource.get() : nullptr,
+			extentIn, extentOut, stripOutW);
+
+		// Write each eye's output back using srcOffsetX = i*allocSubOutW.
+		// SubrectBlendCS feather edge math uses tid.xy local coords (PR-3b shader fix)
+		// so the strip offset doesn't break the feather band.
+		for (uint32_t i = 0; i < 2; ++i) {
+			const auto& uv = *eyeUVs[i];
+			uint32_t subOutW = p.isFullEye ? p.eyeWidthOut : std::max<uint32_t>(1, (uint32_t)(p.eyeWidthOut * uv.w));
+			uint32_t subOutH = p.isFullEye ? p.eyeHeightOut : std::max<uint32_t>(1, (uint32_t)(p.eyeHeightOut * uv.h));
+
+			uint32_t dstCropX = p.isFullEye ? 0 : (uint32_t)(uv.x * p.eyeWidthOut);
+			uint32_t dstCropY = p.isFullEye ? 0 : (uint32_t)(uv.y * p.eyeHeightOut);
+			uint32_t dstX = (i == 1 ? p.eyeWidthOut : 0) + dstCropX;
+			uint32_t stripSrcX = i * allocSubOutW;
+			BlendSubrectToOutput(Core::vrExtremeStripColorOut->resource.get(), p.colorDst, p.colorDstUAV,
+				dstX, dstCropY, subOutW, subOutH, stripSrcX);
 		}
 
 		return true;

--- a/src/Features/Upscaling/FoveatedRender/Modes.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Modes.cpp
@@ -100,16 +100,7 @@ namespace FoveatedRenderImpl
 
 		// Snapshot + Stretch DRS → kMAIN (fill full-eye background)
 		SnapshotSBS(p.colorSrc, p.renderW, p.renderH);
-
-		// Periphery temporal smooth: blend with reprojected history before stretch
-		// so the periphery gets temporal AA that DLSS doesn't cover for the cropped area.
-		ID3D11ShaderResourceView* stretchSrc = nullptr;
-		if (globals::features::upscaling.foveatedRender.GetPeripheryAAMode() == FoveatedRender::PeripheryAAMode::kTemporalSmooth) {
-			EnsureTemporalResources(p.renderW, p.renderH, p.colorSrc, p.motionVectors);
-			stretchSrc = TemporalSmoothSBS(p.renderW, p.renderH);
-		}
-
-		StretchDRSBothEyes(p.colorDstUAV, p.eyeWidthOut, p.eyeHeightOut, p.eyeWidthIn, p.eyeHeightIn, p.renderW, p.renderH, stretchSrc);
+		StretchDRSBothEyes(p.colorDstUAV, p.eyeWidthOut, p.eyeHeightOut, p.eyeWidthIn, p.eyeHeightIn, p.renderW, p.renderH, MaybeTemporalSmooth(p));
 
 		// Crop subrect per-eye from snapshot (not kMAIN which was overwritten by stretch)
 		auto context = globals::d3d::context;
@@ -242,13 +233,7 @@ namespace FoveatedRenderImpl
 
 		// Step 3: Stretch DRS → kMAIN (subrect only) — snapshot reused from Step 2a.
 		if (!p.isFullEye) {
-			// Periphery temporal smooth for the stretched periphery.
-			ID3D11ShaderResourceView* stretchSrc = nullptr;
-			if (globals::features::upscaling.foveatedRender.GetPeripheryAAMode() == FoveatedRender::PeripheryAAMode::kTemporalSmooth) {
-				EnsureTemporalResources(p.renderW, p.renderH, p.colorSrc, p.motionVectors);
-				stretchSrc = TemporalSmoothSBS(p.renderW, p.renderH);
-			}
-			StretchDRSBothEyes(p.colorDstUAV, p.eyeWidthOut, p.eyeHeightOut, p.eyeWidthIn, p.eyeHeightIn, p.renderW, p.renderH, stretchSrc);
+			StretchDRSBothEyes(p.colorDstUAV, p.eyeWidthOut, p.eyeHeightOut, p.eyeWidthIn, p.eyeHeightIn, p.renderW, p.renderH, MaybeTemporalSmooth(p));
 		}
 
 		// Step 4: Copy DLSS output back (with optional blend)
@@ -294,13 +279,7 @@ namespace FoveatedRenderImpl
 		if (!p.isFullEye) {
 			SnapshotSBS(p.colorSrc, p.renderW, p.renderH);
 
-			ID3D11ShaderResourceView* stretchSrc = nullptr;
-			if (globals::features::upscaling.foveatedRender.GetPeripheryAAMode() == FoveatedRender::PeripheryAAMode::kTemporalSmooth) {
-				EnsureTemporalResources(p.renderW, p.renderH, p.colorSrc, p.motionVectors);
-				stretchSrc = TemporalSmoothSBS(p.renderW, p.renderH);
-			}
-
-			StretchDRSBothEyes(p.colorDstUAV, p.eyeWidthOut, p.eyeHeightOut, p.eyeWidthIn, p.eyeHeightIn, p.renderW, p.renderH, stretchSrc);
+			StretchDRSBothEyes(p.colorDstUAV, p.eyeWidthOut, p.eyeHeightOut, p.eyeWidthIn, p.eyeHeightIn, p.renderW, p.renderH, MaybeTemporalSmooth(p));
 		}
 
 		// Copy both eyes' subrects into the strip. Color reads from the
@@ -308,7 +287,8 @@ namespace FoveatedRenderImpl
 		ID3D11Resource* colorReadSrc = (!p.isFullEye && Core::vrRenderSBS) ? Core::vrRenderSBS->resource.get() : p.colorSrc;
 		for (uint32_t i = 0; i < 2; ++i) {
 			const auto& uv = *eyeUVs[i];
-			// Per-eye sizing — same fix as Default/Faster (CodeRabbit Major @ original PR).
+			// Per-eye sizing uses each eye's own UV; right-eye UV.w/h can differ
+			// from left-eye in asymmetric presets (e.g. Nasal Convergence).
 			uint32_t subInW = p.isFullEye ? p.eyeWidthIn : std::max<uint32_t>(1, (uint32_t)(p.eyeWidthIn * uv.w));
 			uint32_t subInH = p.isFullEye ? p.eyeHeightIn : std::max<uint32_t>(1, (uint32_t)(p.eyeHeightIn * uv.h));
 

--- a/src/Features/Upscaling/FoveatedRender/Modes.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Modes.cpp
@@ -275,16 +275,30 @@ namespace FoveatedRenderImpl
 
 		auto context = globals::d3d::context;
 
-		// Snapshot + Stretch DRS → kMAIN if subrect (fills periphery).
-		if (!p.isFullEye) {
-			SnapshotSBS(p.colorSrc, p.renderW, p.renderH);
+		// Snapshot + clear HMD mask on snapshot (same contract as Faster mode).
+		// The strip copy below reads from vrRenderSBS, so the mask must be cleared
+		// before the copy — otherwise sky-color bleeds into the subrect DLSS input.
+		SnapshotSBS(p.colorSrc, p.renderW, p.renderH);
+		auto* depthSRV = globals::game::renderer->GetDepthStencilData()
+		                     .depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN]
+		                     .depthSRV;
+		if (!p.isFullEye && Core::vrRenderSBS && Core::vrRenderSBS->uav && depthSRV) {
+			auto& upscaling = globals::features::upscaling;
+			for (uint32_t i = 0; i < 2; ++i) {
+				const uint32_t eyeOffsetX = i * p.eyeWidthIn;
+				upscaling.ClearHMDMask(Core::vrRenderSBS->uav.get(), depthSRV,
+					p.eyeWidthIn, p.eyeHeightIn, eyeOffsetX, eyeOffsetX);
+			}
+		}
 
+		// Stretch DRS → kMAIN if subrect (fills periphery).
+		if (!p.isFullEye) {
 			StretchDRSBothEyes(p.colorDstUAV, p.eyeWidthOut, p.eyeHeightOut, p.eyeWidthIn, p.eyeHeightIn, p.renderW, p.renderH, MaybeTemporalSmooth(p));
 		}
 
 		// Copy both eyes' subrects into the strip. Color reads from the
-		// pre-stretch snapshot when available so we don't read kMAIN after stretch.
-		ID3D11Resource* colorReadSrc = (!p.isFullEye && Core::vrRenderSBS) ? Core::vrRenderSBS->resource.get() : p.colorSrc;
+		// mask-cleared snapshot so we don't read kMAIN after stretch.
+		ID3D11Resource* colorReadSrc = (Core::vrRenderSBS) ? Core::vrRenderSBS->resource.get() : p.colorSrc;
 		for (uint32_t i = 0; i < 2; ++i) {
 			const auto& uv = *eyeUVs[i];
 			// Per-eye sizing uses each eye's own UV; right-eye UV.w/h can differ

--- a/src/Features/Upscaling/FoveatedRender/Modes.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Modes.cpp
@@ -338,8 +338,8 @@ namespace FoveatedRenderImpl
 			extentIn, extentOut, stripOutW);
 
 		// Write each eye's output back using srcOffsetX = i*allocSubOutW.
-		// SubrectBlendCS feather edge math uses tid.xy local coords (PR-3b shader fix)
-		// so the strip offset doesn't break the feather band.
+		// SubrectBlendCS feather edge math uses tid.xy local coords so the strip
+		// source offset (SrcOffsetX != 0) doesn't drive distR negative.
 		for (uint32_t i = 0; i < 2; ++i) {
 			const auto& uv = *eyeUVs[i];
 			uint32_t subOutW = p.isFullEye ? p.eyeWidthOut : std::max<uint32_t>(1, (uint32_t)(p.eyeWidthOut * uv.w));

--- a/src/Features/Upscaling/FoveatedRender/Modes.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Modes.cpp
@@ -106,23 +106,9 @@ namespace FoveatedRenderImpl
 		EnsureVRSubrectTextures(allocSubInW, allocSubInH, allocSubOutW, allocSubOutH,
 			p.colorSrc, p.motionVectors, p.reactiveMask, p.transparencyMask);
 
-		// Snapshot + clear HMD mask on snapshot before cropping. Without this,
-		// the HMD lens-ring sky color is cropped into vrSubrectColorIn and
-		// temporally accumulated by DLSS, bleeding color into the subrect edges.
+		// Snapshot + clear HMD hidden-area ring before cropping into subrect inputs.
 		SnapshotSBS(p.colorSrc, p.renderW, p.renderH);
-		{
-			auto* depthSRV = globals::game::renderer->GetDepthStencilData()
-			                     .depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN]
-			                     .depthSRV;
-			if (Core::vrRenderSBS && Core::vrRenderSBS->uav && depthSRV) {
-				auto& upscaling = globals::features::upscaling;
-				for (uint32_t i = 0; i < 2; ++i) {
-					const uint32_t eyeOffsetX = i * p.eyeWidthIn;
-					upscaling.ClearHMDMask(Core::vrRenderSBS->uav.get(), depthSRV,
-						p.eyeWidthIn, p.eyeHeightIn, eyeOffsetX, eyeOffsetX);
-				}
-			}
-		}
+		ClearHMDMaskOnSnapshot(p);
 		StretchDRSBothEyes(p.colorDstUAV, p.eyeWidthOut, p.eyeHeightOut, p.eyeWidthIn, p.eyeHeightIn, p.renderW, p.renderH, MaybeTemporalSmooth(p));
 
 		// Crop subrect per-eye from mask-cleared snapshot (not kMAIN which was overwritten by stretch)
@@ -209,23 +195,7 @@ namespace FoveatedRenderImpl
 		// the standard Streamline path (Streamline.cpp) and Default mode both
 		// pre-clear via per-eye intermediates.
 		SnapshotSBS(p.colorSrc, p.renderW, p.renderH);
-		auto& upscaling = globals::features::upscaling;
-		auto* depthSRV = globals::game::renderer->GetDepthStencilData()
-		                     .depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN]
-		                     .depthSRV;
-		if (Core::vrRenderSBS && Core::vrRenderSBS->uav && depthSRV) {
-			// Color target IS the SBS snapshot (not a per-eye buffer), so
-			// colorOffsetX must select the eye's half — same as depthOffsetX.
-			// ClearHMDMaskCS's default contract assumes the color target is
-			// per-eye (colorOffsetX = 0) and was written for Streamline's
-			// per-eye intermediates; here we're routing both eyes through one
-			// SBS texture so we override both offsets together.
-			for (uint32_t i = 0; i < 2; ++i) {
-				const uint32_t eyeOffsetX = i * p.eyeWidthIn;
-				upscaling.ClearHMDMask(Core::vrRenderSBS->uav.get(), depthSRV,
-					p.eyeWidthIn, p.eyeHeightIn, eyeOffsetX, eyeOffsetX);
-			}
-		}
+		ClearHMDMaskOnSnapshot(p);
 		ID3D11Resource* dlssColorSrc = (Core::vrRenderSBS ? Core::vrRenderSBS->resource.get() : p.colorSrc);
 
 		// Step 2b: DLSS reads from the mask-cleared SBS snapshot via extent offsets
@@ -298,21 +268,10 @@ namespace FoveatedRenderImpl
 
 		auto context = globals::d3d::context;
 
-		// Snapshot + clear HMD mask on snapshot (same contract as Faster mode).
-		// The strip copy below reads from vrRenderSBS, so the mask must be cleared
-		// before the copy — otherwise sky-color bleeds into the subrect DLSS input.
+		// Snapshot + clear HMD hidden-area ring before strip copy.
 		SnapshotSBS(p.colorSrc, p.renderW, p.renderH);
-		auto* depthSRV = globals::game::renderer->GetDepthStencilData()
-		                     .depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN]
-		                     .depthSRV;
-		if (!p.isFullEye && Core::vrRenderSBS && Core::vrRenderSBS->uav && depthSRV) {
-			auto& upscaling = globals::features::upscaling;
-			for (uint32_t i = 0; i < 2; ++i) {
-				const uint32_t eyeOffsetX = i * p.eyeWidthIn;
-				upscaling.ClearHMDMask(Core::vrRenderSBS->uav.get(), depthSRV,
-					p.eyeWidthIn, p.eyeHeightIn, eyeOffsetX, eyeOffsetX);
-			}
-		}
+		if (!p.isFullEye)
+			ClearHMDMaskOnSnapshot(p);
 
 		// Stretch DRS → kMAIN if subrect (fills periphery).
 		if (!p.isFullEye) {

--- a/src/Features/Upscaling/FoveatedRender/Modes.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Modes.cpp
@@ -7,6 +7,7 @@
 //
 // ============================================================================
 
+#include "Bridge.h"
 #include "Core.h"
 #include "Ops.h"
 #include "Params.h"
@@ -38,14 +39,21 @@ namespace FoveatedRenderImpl
 			Core::activeSubrectUVHash = uvHash;
 		}
 
+		Bridge::foveatedEvaluating = true;
+		bool result = false;
 		switch (p.mode) {
 		case FoveatedRender::DlssMode::kFaster:
-			return ExecuteFasterMode(streamline, p);
+			result = ExecuteFasterMode(streamline, p);
+			break;
 		case FoveatedRender::DlssMode::kExtreme:
-			return ExecuteExtremeMode(streamline, p);
+			result = ExecuteExtremeMode(streamline, p);
+			break;
 		default:
-			return ExecuteDefaultMode(streamline, p);
+			result = ExecuteDefaultMode(streamline, p);
+			break;
 		}
+		Bridge::foveatedEvaluating = false;
+		return result;
 	}
 
 	// ── Default mode: per-eye isolation, 2 resource sets, 2 evaluates ──
@@ -98,11 +106,26 @@ namespace FoveatedRenderImpl
 		EnsureVRSubrectTextures(allocSubInW, allocSubInH, allocSubOutW, allocSubOutH,
 			p.colorSrc, p.motionVectors, p.reactiveMask, p.transparencyMask);
 
-		// Snapshot + Stretch DRS → kMAIN (fill full-eye background)
+		// Snapshot + clear HMD mask on snapshot before cropping. Without this,
+		// the HMD lens-ring sky color is cropped into vrSubrectColorIn and
+		// temporally accumulated by DLSS, bleeding color into the subrect edges.
 		SnapshotSBS(p.colorSrc, p.renderW, p.renderH);
+		{
+			auto* depthSRV = globals::game::renderer->GetDepthStencilData()
+			                     .depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN]
+			                     .depthSRV;
+			if (Core::vrRenderSBS && Core::vrRenderSBS->uav && depthSRV) {
+				auto& upscaling = globals::features::upscaling;
+				for (uint32_t i = 0; i < 2; ++i) {
+					const uint32_t eyeOffsetX = i * p.eyeWidthIn;
+					upscaling.ClearHMDMask(Core::vrRenderSBS->uav.get(), depthSRV,
+						p.eyeWidthIn, p.eyeHeightIn, eyeOffsetX, eyeOffsetX);
+				}
+			}
+		}
 		StretchDRSBothEyes(p.colorDstUAV, p.eyeWidthOut, p.eyeHeightOut, p.eyeWidthIn, p.eyeHeightIn, p.renderW, p.renderH, MaybeTemporalSmooth(p));
 
-		// Crop subrect per-eye from snapshot (not kMAIN which was overwritten by stretch)
+		// Crop subrect per-eye from mask-cleared snapshot (not kMAIN which was overwritten by stretch)
 		auto context = globals::d3d::context;
 		for (uint32_t i = 0; i < 2; ++i) {
 			const auto& uv = *eyeUVs[i];

--- a/src/Features/Upscaling/FoveatedRender/Modes.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Modes.cpp
@@ -1,5 +1,5 @@
 // ============================================================================
-// Modes.cpp — Default / Faster / Extreme DLSS execution strategies
+// Modes.cpp — Default / Faster DLSS execution strategies
 // ============================================================================
 //
 // Each mode composes Ops primitives (snapshot, stretch, crop, blend…) in a

--- a/src/Features/Upscaling/FoveatedRender/Modes.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Modes.cpp
@@ -40,18 +40,9 @@ namespace FoveatedRenderImpl
 		}
 
 		Bridge::foveatedEvaluating = true;
-		bool result = false;
-		switch (p.mode) {
-		case FoveatedRender::DlssMode::kFaster:
-			result = ExecuteFasterMode(streamline, p);
-			break;
-		case FoveatedRender::DlssMode::kExtreme:
-			result = ExecuteExtremeMode(streamline, p);
-			break;
-		default:
-			result = ExecuteDefaultMode(streamline, p);
-			break;
-		}
+		bool result = (p.mode == FoveatedRender::DlssMode::kFaster) ?
+		                  ExecuteFasterMode(streamline, p) :
+		                  ExecuteDefaultMode(streamline, p);
 		Bridge::foveatedEvaluating = false;
 		return result;
 	}
@@ -246,89 +237,4 @@ namespace FoveatedRenderImpl
 		return true;
 	}
 
-	// ── Extreme mode: combined strip, 1 resource set, 1 evaluate ──
-	// Both eyes' subrects merged horizontally into one long texture. Trades a
-	// pre-DLSS copy for a single Streamline evaluate (vs Default/Faster's two).
-
-	bool Core::ExecuteExtremeMode(Streamline& streamline, const VRDlssParams& p)
-	{
-		const Util::Subrect::UVRegion* eyeUVs[2] = { &p.leftUV, &p.rightUV };
-
-		// Strip allocation uses left-eye dims (auto-mirror constraint, same as
-		// Default/Faster). Per-eye loop uses real per-eye sizes.
-		uint32_t allocSubInW = p.isFullEye ? p.eyeWidthIn : std::max<uint32_t>(1, (uint32_t)(p.eyeWidthIn * p.leftUV.w));
-		uint32_t allocSubInH = p.isFullEye ? p.eyeHeightIn : std::max<uint32_t>(1, (uint32_t)(p.eyeHeightIn * p.leftUV.h));
-		uint32_t allocSubOutW = p.isFullEye ? p.eyeWidthOut : std::max<uint32_t>(1, (uint32_t)(p.eyeWidthOut * p.leftUV.w));
-		uint32_t allocSubOutH = p.isFullEye ? p.eyeHeightOut : std::max<uint32_t>(1, (uint32_t)(p.eyeHeightOut * p.leftUV.h));
-		uint32_t stripInW = allocSubInW * 2;
-		uint32_t stripOutW = allocSubOutW * 2;
-
-		EnsureExtremeStripTextures(stripInW, allocSubInH, stripOutW, allocSubOutH,
-			p.colorSrc, p.motionVectors, p.reactiveMask, p.transparencyMask);
-
-		auto context = globals::d3d::context;
-
-		// Snapshot + clear HMD hidden-area ring before strip copy.
-		SnapshotSBS(p.colorSrc, p.renderW, p.renderH);
-		if (!p.isFullEye)
-			ClearHMDMaskOnSnapshot(p);
-
-		// Stretch DRS → kMAIN if subrect (fills periphery).
-		if (!p.isFullEye) {
-			StretchDRSBothEyes(p.colorDstUAV, p.eyeWidthOut, p.eyeHeightOut, p.eyeWidthIn, p.eyeHeightIn, p.renderW, p.renderH, MaybeTemporalSmooth(p));
-		}
-
-		// Copy both eyes' subrects into the strip. Color reads from the
-		// mask-cleared snapshot so we don't read kMAIN after stretch.
-		ID3D11Resource* colorReadSrc = (Core::vrRenderSBS) ? Core::vrRenderSBS->resource.get() : p.colorSrc;
-		for (uint32_t i = 0; i < 2; ++i) {
-			const auto& uv = *eyeUVs[i];
-			// Per-eye sizing uses each eye's own UV; right-eye UV.w/h can differ
-			// from left-eye in asymmetric presets (e.g. Nasal Convergence).
-			uint32_t subInW = p.isFullEye ? p.eyeWidthIn : std::max<uint32_t>(1, (uint32_t)(p.eyeWidthIn * uv.w));
-			uint32_t subInH = p.isFullEye ? p.eyeHeightIn : std::max<uint32_t>(1, (uint32_t)(p.eyeHeightIn * uv.h));
-
-			uint32_t cropX = p.isFullEye ? 0 : (uint32_t)(uv.x * p.eyeWidthIn);
-			uint32_t cropY = p.isFullEye ? 0 : (uint32_t)(uv.y * p.eyeHeightIn);
-			uint32_t sbsX = (i == 1 ? p.eyeWidthIn : 0) + cropX;
-			D3D11_BOX box = { sbsX, cropY, 0, sbsX + subInW, cropY + subInH, 1 };
-			uint32_t stripDstX = i * allocSubInW;
-
-			context->CopySubresourceRegion(Core::vrExtremeStripColorIn->resource.get(), 0, stripDstX, 0, 0, colorReadSrc, 0, &box);
-			context->CopySubresourceRegion(Core::vrExtremeStripDepth->resource.get(), 0, stripDstX, 0, 0, p.depthTexture, 0, &box);
-			context->CopySubresourceRegion(Core::vrExtremeStripMotionVectors->resource.get(), 0, stripDstX, 0, 0, p.motionVectors, 0, &box);
-			if (p.reactiveMask)
-				context->CopySubresourceRegion(Core::vrExtremeStripReactiveMask->resource.get(), 0, stripDstX, 0, 0, p.reactiveMask, 0, &box);
-			if (p.transparencyMask)
-				context->CopySubresourceRegion(Core::vrExtremeStripTransparencyMask->resource.get(), 0, stripDstX, 0, 0, p.transparencyMask, 0, &box);
-		}
-
-		// Single DLSS evaluate on the entire strip.
-		sl::Extent extentIn{ 0, 0, stripInW, allocSubInH };
-		sl::Extent extentOut{ 0, 0, stripOutW, allocSubOutH };
-		streamline.EvaluateDLSS(streamline.viewport, 0,
-			Core::vrExtremeStripColorIn->resource.get(), Core::vrExtremeStripColorOut->resource.get(),
-			Core::vrExtremeStripDepth->resource.get(), Core::vrExtremeStripMotionVectors->resource.get(),
-			p.reactiveMask ? Core::vrExtremeStripReactiveMask->resource.get() : nullptr,
-			p.transparencyMask ? Core::vrExtremeStripTransparencyMask->resource.get() : nullptr,
-			extentIn, extentOut, stripOutW);
-
-		// Write each eye's output back using srcOffsetX = i*allocSubOutW.
-		// SubrectBlendCS feather edge math uses tid.xy local coords so the strip
-		// source offset (SrcOffsetX != 0) doesn't drive distR negative.
-		for (uint32_t i = 0; i < 2; ++i) {
-			const auto& uv = *eyeUVs[i];
-			uint32_t subOutW = p.isFullEye ? p.eyeWidthOut : std::max<uint32_t>(1, (uint32_t)(p.eyeWidthOut * uv.w));
-			uint32_t subOutH = p.isFullEye ? p.eyeHeightOut : std::max<uint32_t>(1, (uint32_t)(p.eyeHeightOut * uv.h));
-
-			uint32_t dstCropX = p.isFullEye ? 0 : (uint32_t)(uv.x * p.eyeWidthOut);
-			uint32_t dstCropY = p.isFullEye ? 0 : (uint32_t)(uv.y * p.eyeHeightOut);
-			uint32_t dstX = (i == 1 ? p.eyeWidthOut : 0) + dstCropX;
-			uint32_t stripSrcX = i * allocSubOutW;
-			BlendSubrectToOutput(Core::vrExtremeStripColorOut->resource.get(), p.colorDst, p.colorDstUAV,
-				dstX, dstCropY, subOutW, subOutH, stripSrcX);
-		}
-
-		return true;
-	}
 }

--- a/src/Features/Upscaling/FoveatedRender/Ops.h
+++ b/src/Features/Upscaling/FoveatedRender/Ops.h
@@ -28,6 +28,9 @@ namespace FoveatedRenderImpl::Ops
 
 	void EnsureFasterOutputTextures(uint32_t subOutW, uint32_t subOutH, ID3D11Resource* colorSrc);
 
+	void EnsureExtremeStripTextures(uint32_t stripInW, uint32_t stripInH, uint32_t stripOutW, uint32_t stripOutH,
+		ID3D11Resource* colorSrc, ID3D11Resource* mvecSrc, ID3D11Resource* reactiveSrc, ID3D11Resource* transparencySrc);
+
 	void EnsureVRRenderSBS(uint32_t renderW, uint32_t renderH, ID3D11Resource* colorSrc);
 
 	// Copy full-eye slices from SBS textures into per-eye intermediates.
@@ -52,9 +55,18 @@ namespace FoveatedRenderImpl::Ops
 		uint32_t eyeWidthIn, uint32_t eyeHeightIn, uint32_t renderW, uint32_t renderH,
 		ID3D11ShaderResourceView* srcOverride = nullptr);
 
-	// Hard-copy a DLSS subrect output onto the destination at (offsetX, offsetY).
-	// No feather/dither — straight CopySubresourceRegion.
-	void BlendSubrectToOutput(ID3D11Resource* dlssSrc, ID3D11Resource* dst,
+	// Periphery temporal smooth: ensure ping-pong history textures and mvec SRV
+	// cache for the render-res SBS smoothing pass.
+	void EnsureTemporalResources(uint32_t renderW, uint32_t renderH, ID3D11Resource* colorSrc, ID3D11Resource* mvecSrc);
+
+	// Apply temporal smoothing on vrRenderSBS. Returns SRV of the smoothed result
+	// (pass as srcOverride to StretchDRSBothEyes). SnapshotSBS must be called first.
+	ID3D11ShaderResourceView* TemporalSmoothSBS(uint32_t renderW, uint32_t renderH);
+
+	// Blend a DLSS subrect output onto the destination at (offsetX, offsetY).
+	// kHardCopy fast-paths to CopySubresourceRegion; Feather/Dither dispatch
+	// SubrectBlendCS into dstUAV.
+	void BlendSubrectToOutput(ID3D11Resource* dlssSrc, ID3D11Resource* dst, ID3D11UnorderedAccessView* dstUAV,
 		uint32_t dstOffsetX, uint32_t dstOffsetY, uint32_t subWidth, uint32_t subHeight, uint32_t srcOffsetX = 0);
 
 	// Hash of per-eye UVs + mode for change detection (forces SL DLSS resource

--- a/src/Features/Upscaling/FoveatedRender/Ops.h
+++ b/src/Features/Upscaling/FoveatedRender/Ops.h
@@ -63,6 +63,11 @@ namespace FoveatedRenderImpl::Ops
 	// (pass as srcOverride to StretchDRSBothEyes). SnapshotSBS must be called first.
 	ID3D11ShaderResourceView* TemporalSmoothSBS(uint32_t renderW, uint32_t renderH);
 
+	// If PeripheryAAMode is kTemporalSmooth, ensures resources and returns the
+	// smoothed SRV; otherwise returns nullptr (StretchDRSBothEyes uses vrRenderSBS).
+	// SnapshotSBS must have been called on this frame before invoking this.
+	ID3D11ShaderResourceView* MaybeTemporalSmooth(const VRDlssParams& p);
+
 	// Blend a DLSS subrect output onto the destination at (offsetX, offsetY).
 	// kHardCopy fast-paths to CopySubresourceRegion; Feather/Dither dispatch
 	// SubrectBlendCS into dstUAV.

--- a/src/Features/Upscaling/FoveatedRender/Ops.h
+++ b/src/Features/Upscaling/FoveatedRender/Ops.h
@@ -28,9 +28,6 @@ namespace FoveatedRenderImpl::Ops
 
 	void EnsureFasterOutputTextures(uint32_t subOutW, uint32_t subOutH, ID3D11Resource* colorSrc);
 
-	void EnsureExtremeStripTextures(uint32_t stripInW, uint32_t stripInH, uint32_t stripOutW, uint32_t stripOutH,
-		ID3D11Resource* colorSrc, ID3D11Resource* mvecSrc, ID3D11Resource* reactiveSrc, ID3D11Resource* transparencySrc);
-
 	void EnsureVRRenderSBS(uint32_t renderW, uint32_t renderH, ID3D11Resource* colorSrc);
 
 	// Copy full-eye slices from SBS textures into per-eye intermediates.

--- a/src/Features/Upscaling/FoveatedRender/Ops.h
+++ b/src/Features/Upscaling/FoveatedRender/Ops.h
@@ -68,6 +68,11 @@ namespace FoveatedRenderImpl::Ops
 	// SnapshotSBS must have been called on this frame before invoking this.
 	ID3D11ShaderResourceView* MaybeTemporalSmooth(const VRDlssParams& p);
 
+	// Clear HMD hidden-area mask on both eye halves of vrRenderSBS.
+	// Must be called after SnapshotSBS. Prevents sky-blue temporal bleed into
+	// pixels the HMD lens never shows, which DLSS would otherwise accumulate.
+	void ClearHMDMaskOnSnapshot(const VRDlssParams& p);
+
 	// Blend a DLSS subrect output onto the destination at (offsetX, offsetY).
 	// kHardCopy fast-paths to CopySubresourceRegion; Feather/Dither dispatch
 	// SubrectBlendCS into dstUAV.

--- a/src/Features/Upscaling/Streamline.cpp
+++ b/src/Features/Upscaling/Streamline.cpp
@@ -379,11 +379,13 @@ bool Streamline::CheckFrameConstants(sl::ViewportHandle p_viewport, uint32_t eye
 	slConstants.jitterOffset = { -jitter.x, -jitter.y };
 	slConstants.reset = sl::Boolean::eFalse;
 
-	// Foveated subrect: motion vectors are authored at full-eye scale but DLSS
-	// processes a sub-region. Scale up so DLSS interprets them as subrect-local.
-	// Returns identity when foveated is inactive or subrect covers the full eye.
+	// Apply foveated mvec scale only when the subrect execute path is actually
+	// running this frame (flag set by ExecuteVRDlssCore). The standard full-frame
+	// DLSS path — including menus and frames where foveated is skipped — must
+	// keep mvecScale at identity or DLSS massively over-estimates motion.
 	float mvecX = 1.0f, mvecY = 1.0f;
-	FoveatedRenderImpl::Bridge::ComputeMvecScale(mvecX, mvecY);
+	if (FoveatedRenderImpl::Bridge::foveatedEvaluating)
+		FoveatedRenderImpl::Bridge::ComputeMvecScale(mvecX, mvecY);
 	slConstants.mvecScale = { mvecX, mvecY };
 	slConstants.motionVectors3D = sl::Boolean::eFalse;
 	slConstants.motionVectorsInvalidValue = FLT_MIN;

--- a/src/Features/Upscaling/Streamline.cpp
+++ b/src/Features/Upscaling/Streamline.cpp
@@ -11,6 +11,7 @@
 #include "../../Util.h"
 #include "../Upscaling.h"
 #include "DX12SwapChain.h"
+#include "FoveatedRender/Bridge.h"
 #include "PerfMode.h"
 
 namespace
@@ -378,7 +379,12 @@ bool Streamline::CheckFrameConstants(sl::ViewportHandle p_viewport, uint32_t eye
 	slConstants.jitterOffset = { -jitter.x, -jitter.y };
 	slConstants.reset = sl::Boolean::eFalse;
 
-	slConstants.mvecScale = { 1.0f, 1.0f };
+	// Foveated subrect: motion vectors are authored at full-eye scale but DLSS
+	// processes a sub-region. Scale up so DLSS interprets them as subrect-local.
+	// Returns identity when foveated is inactive or subrect covers the full eye.
+	float mvecX = 1.0f, mvecY = 1.0f;
+	FoveatedRenderImpl::Bridge::ComputeMvecScale(mvecX, mvecY);
+	slConstants.mvecScale = { mvecX, mvecY };
 	slConstants.motionVectors3D = sl::Boolean::eFalse;
 	slConstants.motionVectorsInvalidValue = FLT_MIN;
 	slConstants.orthographicProjection = sl::Boolean::eFalse;


### PR DESCRIPTION
## Summary

Ports the PR-3b deferred work onto the current `FoveatedRender` structure (renamed from `DlssEnhancer` in PR-3 / #44). Stacks on `dev` (PR-3 already merged).

### What's new

**Shaders**
- `SubrectBlendCS`: feather/dither-blend DLSS subrect back onto stretched periphery. Fixes bot-flagged edge-distance bug from original PR #2096 (SrcOffsetX in strip mode drove distR negative; fixed by using dispatch-local tid.xy).
- `PeripheryTemporalSmoothCS`: ping-pong motion-compensated history blend on the SBS render buffer; SBS eye-boundary clamp prevents cross-eye reprojection.

**Settings + UI**
- `SubrectBlendMode {kHardCopy, kFeather, kDither}`: controls how the DLSS subrect edge meets the stretched periphery.
- `PeripheryAAMode {kNone, kTemporalSmooth}`: temporal anti-flicker for the bulk of the stretched area.
- `peripheryBlurRadius`, `peripheryTemporalAlpha`, `subrectFeatherWidth`, `subrectDitherStrength` sliders.
- Mode tooltip rewritten. All three periphery controls consolidated under one "Periphery Rendering" section with a tooltip explaining which region each affects (periphery bulk vs. subrect boundary).

**Bug fixes**
- `ComputeMvecScale` was implemented but never called — `slConstants.mvecScale` was always `{1,1}`. DLSS received full-eye-scale motion vectors while processing a subrect → temporal accumulation drifted → subrect jitter. Fixed by wiring it into `Streamline::SetConstants`, gated on `Bridge::foveatedEvaluating` so menu/standard-path DLSS is unaffected.
- `ClearHMDMask` was missing from Default mode's subrect path and Extreme mode. HMD lens-ring sky-blue pixels were cropped into DLSS inputs and temporally accumulated → color bleed at subrect edges.
- Default blend mode changed from `kDither` (animated dither per frame → visible edge shimmer) to `kHardCopy` (matches PR-3 behavior).

**Dead code removed**
- `kExtreme`: `EvaluateDLSS` sets per-eye camera matrices via `CheckFrameConstants` — a single evaluate on a 2×-wide strip always uses left-eye matrices for both halves. Native stereo DLSS (not in current SL API) would be required. Removed enum value, function body, strip textures.
- Five dead Bridge getters (`GetQualityMode`, `GetPresetDLSS`, `GetSharpnessDLSS`, `GetQualityModeAtBoot`, `GetRenderScaleForQuality`) — consumers read directly from settings; zero external callsites.

**Not in this PR (documented in `FoveatedRender.h`)**
- DLSS encoder hint toggles (MV dilation, reactive mask, transparency mask): were no-ops in original PR #2096; require shader permutations + conditional encode-pass skip + per-toggle DLSS arg gating to be non-lying UI.

## Test plan
- [ ] VR + DLSS + Foveated enabled, Default mode: subrect renders at DLSS quality, periphery cheaply stretched. No HMD mask bleed. No subrect jitter.
- [ ] Faster mode: same quality result. No mask bleed. No edge shimmer (kHardCopy default).
- [ ] kFeather/kDither blend modes: smooth/dithered fade at subrect boundary. No per-frame shimmer on kFeather.
- [ ] Temporal Smooth enabled: reduced flicker in stretched periphery vs. None.
- [ ] Menus: no DLSS jitter (mvecScale correction gated on foveatedEvaluating flag).
- [ ] Non-VR / FSR: falls through cleanly, no regressions.
- [ ] CI: vs2026 build, Flatrim + VR shader validation, C++ unit tests, CodeQL.

Co-Authored-By: YtzyFvra <59631290+YtzyFvra@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added periphery temporal smoothing to reduce flicker in peripheral VR rendering.
  * Added subrect blending modes: hard copy, feathered blend, and dithered blend for smoother subrect writeback.
  * New VR settings: periphery blur, periphery AA mode, temporal smoothing strength, feather width, and dither strength.
* **Improvements**
  * Improved motion-vector handling and HMD-mask clearing to stabilize temporal results and avoid artifacts.
* **Fallbacks**
  * Fast-path and safe fallback keep behavior stable when blending resources are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/open-shaders/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->