### PR TITLE
fix(slf): VR accumulator OOB heap write

### DIFF
--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -337,8 +337,12 @@ namespace ShadowCasterManager
 		int extra = needed - have;
 		if (extra > 0) {
 			ctx.Rdi += extra;
-			// SE only: RDX is a second counter in the same loop.
-			if (!REL::Module::IsVR() && REL::Module::GetRuntime() != REL::Module::Runtime::AE)
+			// SE/VR latch EDX from EDI inside the patched 5 bytes (before the
+			// stub captures CONTEXT), so BSTArray::resize runs with the un-
+			// bumped count while the fill loop runs with the bumped one --
+			// OOB heap write scaling with ShadowLightCount. AE inlines the
+			// resize and re-reads EDI after the stub, so RDX is dead here.
+			if (!REL::Module::IsAE())
 				ctx.Rdx += extra;
 		}
 	}
@@ -3611,8 +3615,9 @@ namespace ShadowCasterManager
 				const auto opcode = *reinterpret_cast<const std::uint8_t*>(site);
 				const auto rel32 = *reinterpret_cast<const std::int32_t*>(site + 1);
 				if (opcode != kCallOpcode || rel32 != kExpectedRel32) {
-					logger::warn("[SCM] VR shadow-mask site drift: expected E8 rel32=0x{:X} at RenderShadowmasks+0x{:X}, "
-								 "found 0x{:02X} rel32=0x{:X}. Clamping ShadowLightCount to 4 (vanilla) to avoid OOB CTD.",
+					logger::warn(
+						"[SCM] VR shadow-mask site drift: expected E8 rel32=0x{:X} at RenderShadowmasks+0x{:X}, "
+						"found 0x{:02X} rel32=0x{:X}. Clamping ShadowLightCount to 4 (vanilla) to avoid OOB CTD.",
 						kExpectedRel32, kCallOffset, opcode, rel32);
 					s_installedShadowLightCount = 4;
 				} else {


### PR DESCRIPTION
## Summary

`Hook_AccumulatedLightsArray` bumped `RDI` (fill-loop count) but not `RDX` (BSTArray resize count) on VR, producing an OOB heap write proportional to `ShadowLightCount`. Symptom: random later crashes in the Papyrus VM string heap with `RDI = 0x83485708245C8948` — byte-reversed, those are the prologue bytes (`48 89 5C 24 08 57 48 83`) of the inlined `BSTArray::resize` callee, indicating a tbbmalloc freelist next-pointer was stomped and a later allocation returned code memory.

## Mechanism

The hook installs with `includeSize=+5`, so the original 5 bytes run **before** the CONTEXT-capture stub. On SE and VR the patched 5 bytes are:

```
LEA EDI,[RBP+0x8]   ; 3 bytes -- count+8
MOV EDX,EDI         ; 2 bytes -- EDX latched to un-bumped count
```

After the stub, `EDI` is bumped but `EDX` is not. Downstream `BSTArray::resize` then allocates the original 10-slot buffer while the fill loop writes `(ShadowLightCount + ConvertedShadowSlots + 1) * 2` entries. Higher counts crash earlier — matches user reports.

AE inlines the resize and re-derives `EDX` from `EDI` **after** the stub, so its `RDX` at the hook point is a dead caller-saved value and must not be touched. SE was already bumping `RDX` correctly. The original gate (`!IsVR && !IsAE`) inverted the VR case — it should have been `!IsAE`.

## Verification

Confirmed at the patch site in all three runtimes via Ghidra static disasm:

| Runtime | Patched 5 bytes | EDX source for resize | RDX bump |
|---|---|---|---|
| SE  | `LEA EDI / MOV EDX,EDI` | inside patch (pre-stub) | needed (was present) |
| AE  | `LEA EDI / TEST EDI,EDI` | inlined resize re-reads EDI post-stub | not needed (correctly absent) |
| VR  | `LEA EDI / MOV EDX,EDI` | inside patch (pre-stub) | **needed (was missing — bug)** |

## Test plan

- [ ] Build `ALL` preset, verify SE behavior unchanged at default shadow counts
- [ ] VR + high `ShadowLightCount` (16+): play 15+ minutes loading interiors/exteriors, no Papyrus VM heap crash
- [ ] RenderDoc once on VR: confirm `kSHADOWMAPS` slices populate correctly at high count

🤖 Generated with [Claude Code](https://claude.com/claude-code)