### PR TITLE
fix(slf): grass directional shadow + effect-mesh shadow lights

### DIFF
--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -799,9 +799,9 @@ PS_OUTPUT main(PS_INPUT input)
 		// Effect meshes are alpha-blended and lack reliable occluder depth
 		// at their visible surface, so sampling LLF's shadow atlas with the
 		// effect's world position produces incorrect dark imprints from
-		// nearby shadow-casting bulbs (see #47). Matches pre-SLF behaviour:
-		// shadow-flagged lights still contribute lighting through other
-		// passes but skip the effect-mesh contribution entirely.
+		// nearby shadow-casting bulbs. Shadow-flagged lights still contribute
+		// lighting through the other passes; only the effect-mesh shadow
+		// attenuation is skipped here.
 		if (light.lightFlags & LightLimitFix::LightFlags::Shadow)
 			continue;
 

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -796,6 +796,15 @@ PS_OUTPUT main(PS_INPUT input)
 				continue;
 		}
 
+		// Effect meshes are alpha-blended and lack reliable occluder depth
+		// at their visible surface, so sampling LLF's shadow atlas with the
+		// effect's world position produces incorrect dark imprints from
+		// nearby shadow-casting bulbs (see #47). Matches pre-SLF behaviour:
+		// shadow-flagged lights still contribute lighting through other
+		// passes but skip the effect-mesh contribution entirely.
+		if (light.lightFlags & LightLimitFix::LightFlags::Shadow)
+			continue;
+
 		float3 lightDirection = light.positionWS[eyeIndex].xyz - input.WorldPosition.xyz;
 		float lightDist = length(lightDirection);
 
@@ -810,15 +819,8 @@ PS_OUTPUT main(PS_INPUT input)
 		float intensityMultiplier = 1 - intensityFactor * intensityFactor;
 #			endif
 
-		float shadowMul = 1.0;
-		if (inWorld && (light.lightFlags & LightLimitFix::LightFlags::Shadow)) {
-			bool shadowCoverage = false;
-			float3 worldPositionWS = input.WorldPosition.xyz + FrameBuffer::CameraPosAdjust[eyeIndex].xyz;
-			shadowMul = LightLimitFix::GetShadowLightShadow(light.shadowMapIndex, worldPositionWS, rotationMatrix, shadowCoverage);
-		}
-
 		const bool isPointLightLinear = light.lightFlags & LightLimitFix::LightFlags::Linear;
-		float3 lightColor = Color::PointLight(light.color.xyz, isPointLightLinear) * intensityMultiplier * 0.5 * light.fade * Color::EffectLightingMult() * shadowMul;
+		float3 lightColor = Color::PointLight(light.color.xyz, isPointLightLinear) * intensityMultiplier * 0.5 * light.fade * Color::EffectLightingMult();
 		propertyColor += lightColor;
 	}
 

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -606,8 +606,21 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	// HasDirectionalShadows() admits Interior Sun cells; mirrors the
 	// same swap in Lighting.hlsl / Particle.hlsl.
-	if (ShadowSampling::HasDirectionalShadows())
+	if (ShadowSampling::HasDirectionalShadows()) {
+#			if defined(LIGHT_LIMIT_FIX)
+		// SLF suppresses the engine's screen-space shadow-mask pass, so
+		// shadowColor.x is no longer a valid directional shadow signal under
+		// LIGHT_LIMIT_FIX. Sample LLF's cascades directly, matching
+		// Lighting.hlsl / Particle.hlsl.
+		float2 rotation;
+		sincos(Math::TAU * screenNoise, rotation.y, rotation.x);
+		float2x2 rotationMatrix = float2x2(rotation.x, rotation.y, -rotation.y, rotation.x);
+		float3 worldPositionWS = input.WorldPosition.xyz + FrameBuffer::CameraPosAdjust[eyeIndex].xyz;
+		dirDetailedShadow *= LightLimitFix::GetDirectionalShadow(input.WorldPosition.xyz, worldPositionWS, rotationMatrix, eyeIndex);
+#			else
 		dirDetailedShadow *= shadowColor.x;
+#			endif
+	}
 
 #			if defined(SCREEN_SPACE_SHADOWS)
 	if (ShadowSampling::HasDirectionalShadows() && dirLightAngle >= 0.0)
@@ -852,8 +865,21 @@ PS_OUTPUT main(PS_INPUT input)
 
 	// HasDirectionalShadows() admits Interior Sun cells; mirrors the
 	// same swap in Lighting.hlsl / Particle.hlsl.
-	if (ShadowSampling::HasDirectionalShadows())
+	if (ShadowSampling::HasDirectionalShadows()) {
+#			if defined(LIGHT_LIMIT_FIX)
+		// SLF suppresses the engine's screen-space shadow-mask pass, so
+		// shadowColor.x is no longer a valid directional shadow signal under
+		// LIGHT_LIMIT_FIX. Sample LLF's cascades directly, matching
+		// Lighting.hlsl / Particle.hlsl.
+		float2 rotation;
+		sincos(Math::TAU * screenNoise, rotation.y, rotation.x);
+		float2x2 rotationMatrix = float2x2(rotation.x, rotation.y, -rotation.y, rotation.x);
+		float3 worldPositionWS = input.WorldPosition.xyz + FrameBuffer::CameraPosAdjust[eyeIndex].xyz;
+		dirDetailedShadow = LightLimitFix::GetDirectionalShadow(input.WorldPosition.xyz, worldPositionWS, rotationMatrix, eyeIndex);
+#			else
 		dirDetailedShadow = shadowColor.x;
+#			endif
+	}
 
 #			if defined(SCREEN_SPACE_SHADOWS)
 	if (ShadowSampling::HasDirectionalShadows())

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -577,11 +577,9 @@ namespace ShadowCasterManager
 		// shadowColor.x is consulted only as a fallback past the cascade
 		// range and during the !LIGHT_LIMIT_FIX vanilla path. Dropping the
 		// mask therefore loses no functionality LLF provides -- but every
-		// shader that previously read shadowColor.x for directional shadow
-		// MUST be migrated to GetDirectionalShadow under LIGHT_LIMIT_FIX,
-		// or it will sample the stale/cleared mask and decouple from sun
-		// shadows (issue #48 was RunGrass.hlsl being missed in the
-		// original SLF merge).
+		// shader that reads shadowColor.x for directional shadow MUST route
+		// through GetDirectionalShadow under LIGHT_LIMIT_FIX, or it samples
+		// the stale/cleared mask and decouples from the sun shadow.
 		//
 		// Critically, unlike the previous Hook_DisableColorMask, we do NOT
 		// call ReturnShadowmaps. That side-effect cleared shadowmap-

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -569,13 +569,19 @@ namespace ShadowCasterManager
 		//
 		// Under LIGHT_LIMIT_FIX (this fork's shipping configuration) the
 		// screen-space mask is not on the sun-shadow consumer path:
-		//   - Lighting.hlsl:2515 uses LightLimitFix::GetDirectionalShadow,
-		//     which samples DirectionalShadowCascades (t99) directly.
+		//   - Lighting.hlsl, Particle.hlsl, and RunGrass.hlsl all sample
+		//     LightLimitFix::GetDirectionalShadow, which reads
+		//     DirectionalShadowCascades (t99) directly.
 		//   - The cluster loop uses LightLimitFix::GetShadowLightShadow,
 		//     which samples kSHADOWMAPS slices directly.
 		// shadowColor.x is consulted only as a fallback past the cascade
 		// range and during the !LIGHT_LIMIT_FIX vanilla path. Dropping the
-		// mask therefore loses no functionality LLF provides.
+		// mask therefore loses no functionality LLF provides -- but every
+		// shader that previously read shadowColor.x for directional shadow
+		// MUST be migrated to GetDirectionalShadow under LIGHT_LIMIT_FIX,
+		// or it will sample the stale/cleared mask and decouple from sun
+		// shadows (issue #48 was RunGrass.hlsl being missed in the
+		// original SLF merge).
 		//
 		// Critically, unlike the previous Hook_DisableColorMask, we do NOT
 		// call ReturnShadowmaps. That side-effect cleared shadowmap-


### PR DESCRIPTION
## Summary

Two regressions from the SLF merge (#35) where shader-side updates were missed:

### #48 — Complex grass lighting inverted

`RunGrass.hlsl` still reads `shadowColor.x` from `TexShadowMaskSampler` for directional shadow, but SLF made `Hook_RenderShadowLightsWithUtilityShader::thunk` a no-op that suppresses the engine's screen-space shadow-mask pass under `LIGHT_LIMIT_FIX`. With no producer, the mask channel is stale/cleared and grass directional lighting decouples from the sun. `Lighting.hlsl` and `Particle.hlsl` were updated to sample LLF's cascades directly via `LightLimitFix::GetDirectionalShadow`; `RunGrass.hlsl` was missed.

Both grass `main()` variants (TRUE_PBR and non-PBR) now call `GetDirectionalShadow` when `LIGHT_LIMIT_FIX` is defined, otherwise keep `shadowColor.x` for vanilla / non-SLF builds.

### #47 — Shadows cast onto effect meshes in interiors

The SLF merge replaced a pre-existing `continue` on `LightFlags::Shadow` in `Effect.hlsl` with a world-space `LightLimitFix::GetShadowLightShadow` sample. Effect meshes are alpha-blended billboards without a meaningful occluder at their visible surface, so the atlas lookup using the effect's `worldPositionWS` returns incorrect dark imprints from nearby shadow-casting bulbs.

Restored the pre-merge skip: shadow-flagged lights still contribute via `Lighting.hlsl` on opaque geometry, but never apply (correct or incorrect) shadow attenuation to effect meshes -- matches CS v1.5.2.

## SLF-disabled robustness

- Grass: gated on compile-time `LIGHT_LIMIT_FIX`. `GetDirectionalShadow` reads `DirectionalShadowCascades` which `Deferred::CopyShadowLightData` uploads regardless of runtime SCM enable; correct under both SCM states.
- Effect: `continue` is unconditional in both branches; matches CS v1.5.2 either way.

Closes #48
Refs #47

## Test plan

- [x] @Laminin64 (#48): confirm complex grass shading no longer inverts on the scene from the issue screenshots
- [x] @Laminin64 (#47): confirm shadow caster bulbs no longer paint shadows onto interior effect meshes
- [x] SE/AE/VR at default `ShadowLightCount`
- [x] Exterior + Interior Sun cell: sun shadow visible on grass in both
- [x] Non-PBR and TRUE_PBR grass mods
- [x] Toggle SCM off at runtime: grass + effects render correctly
- [x] Hlslkit targeted compile on RunGrass.hlsl and Effect.hlsl

🤖 Generated with [Claude Code](https://claude.com/claude-code)