### PR TITLE
fix(VR): enable GetLuminanceAtPoint in SLF

### DIFF
--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -3681,9 +3681,8 @@ namespace ShadowCasterManager
 			const uint8_t jmp = 0xEB;
 			REL::safe_write(uid.address() + off2, &jmp, 1);
 		}
-		// Per-light check (ID 99725/106362): not yet confirmed in VR address library,
-		// so guard VR until addresses are found.
-		if (!REL::Module::IsVR()) {
+		// Per-light check inside ShadowSceneNode::GetLuminanceAtPoint (ID 99725/106362).
+		{
 			static REL::RelocationID uid(99725, 106362);
 			uintptr_t off = REL::Relocate(0x648 - 0x560, 0xB49 - 0xA60, 0x648 - 0x560);
 			if (!SKSE::stl::install_context_hook(uid.address() + off, 5, Hook_CheckLightLevelPlayer))


### PR DESCRIPTION
## Summary

Removes the `if (!REL::Module::IsVR())` guard around the `ShadowSceneNode::GetLuminanceAtPoint` per-light hook (ID 99725/106362) in `ShadowCasterManager.cpp`, making it install on VR. This is the second half of SLF's stealth-detection fix (the first, `GetLightLevel`/38900, already ran on VR) — without it, VR's player light-level / sneak detection isn't filtered to SLF's chosen shadow lights.

## Why it's now safe on VR

The hook was previously VR-gated because ID 99725 was missing from the VR Address Library. That entry now exists (`id 99725 → 0x1412f9c10`), and the hook site was verified in Ghidra:

- VR `0x1412f9c10 + 0xE8` = `41 85 F6 74 16` (`TEST R14D,ESI` + `JZ`, 5 bytes) — **byte-identical to SE** at `0x1412bc190 + 0xE8`.
- Surrounding instructions align; the function differs SE↔VR only in struct field offsets, which the hook never touches.
- Offset selector `REL::Relocate(0x648-0x560, 0xB49-0xA60, 0x648-0x560)` already pins VR = `0xE8`.

## Prerequisite

Requires the VR Address Library runtime binary to include ID 99725 (added to `vr_address_tools` `database.csv`; must be regenerated into the shipped `.bin`). The plugin resolves it via `REL::RelocationID(99725, 106362)`.

## Test plan

- [ ] VR: confirm no CTD on load (hook installs; `[SCM] Failed to install Hook_CheckLightLevelPlayer` absent from log)
- [ ] VR: sneak/light-level detection tracks SLF's selected shadow lights (parity with SE/AE)
- [ ] SE/AE: unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stealth detection mechanics to behave consistently across VR and standard gameplay modes, ensuring a uniform experience for all players.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/open-shaders/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->