### PR TITLE
refactor(slf): shared directional-shadow helper

### DIFF
--- a/package/Shaders/Common/DirectionalShadow.hlsli
+++ b/package/Shaders/Common/DirectionalShadow.hlsli
@@ -1,0 +1,27 @@
+#ifndef __DIRECTIONAL_SHADOW_DEPENDENCY_HLSL__
+#define __DIRECTIONAL_SHADOW_DEPENDENCY_HLSL__
+
+#include "Common/Math.hlsli"
+
+namespace DirectionalShadow
+{
+	// Single owner of the directional-shadow routing decision, so new consumers
+	// can't read the stale engine mask under SLF. Under LIGHT_LIMIT_FIX the engine
+	// mask is a no-op, so sample LLF cascades directly (fully lit past range);
+	// otherwise return the engine mask as-is. Also owns the PCF noise-rotation so
+	// callers skip the sincos boilerplate. Lighting.hlsl deliberately bypasses this
+	// (feeds the mask into LLF as the past-cascade fallback). Needs LightLimitFix.hlsli first.
+	float GetSceneDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise, float a_engineMaskShadow)
+	{
+#if defined(LIGHT_LIMIT_FIX)
+		float2 rotation;
+		sincos(Math::TAU * a_screenNoise, rotation.y, rotation.x);
+		float2x2 rotationMatrix = float2x2(rotation.x, rotation.y, -rotation.y, rotation.x);
+		return LightLimitFix::GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex);
+#else
+		return a_engineMaskShadow;
+#endif
+	}
+}
+
+#endif  // __DIRECTIONAL_SHADOW_DEPENDENCY_HLSL__

--- a/package/Shaders/Particle.hlsl
+++ b/package/Shaders/Particle.hlsl
@@ -251,6 +251,8 @@ cbuffer PerGeometry : register(b2)
 #		include "InverseSquareLighting/InverseSquareLighting.hlsli"
 #	endif
 
+#	include "Common/DirectionalShadow.hlsli"
+
 PS_OUTPUT main(PS_INPUT input)
 {
 	PS_OUTPUT psout;
@@ -297,9 +299,6 @@ PS_OUTPUT main(PS_INPUT input)
 	positionWS.xyz = positionWS.xyz / positionWS.w;
 
 	float screenNoise = Random::InterleavedGradientNoise(input.Position.xy, SharedData::FrameCount);
-	float2 rotation;
-	sincos(Math::TAU * screenNoise, rotation.y, rotation.x);
-	float2x2 rotationMatrix = float2x2(rotation.x, rotation.y, -rotation.y, rotation.x);
 
 	float3 worldPositionWS = positionWS.xyz + FrameBuffer::CameraPosAdjust[eyeIndex].xyz;
 
@@ -311,11 +310,12 @@ PS_OUTPUT main(PS_INPUT input)
 	// HasDirectionalShadows() admits Interior Sun cells to the directional shadow
 	// sampling path (matching Lighting.hlsl).
 	if (ShadowSampling::HasDirectionalShadows()) {
-		// Use the cheaper VSM shadows if available
+		// Use the cheaper VSM shadows if available; otherwise route through the
+		// shared SLF-vs-vanilla helper (LLF cascades under SLF, else lit).
 #	if defined(VOLUMETRIC_SHADOWS)
 		dirSoftShadow = VolumetricShadows::GetVSMShadow2D(positionWS.xyz, worldPositionWS, eyeIndex, dirDetailedShadow);
-#	elif defined(LIGHT_LIMIT_FIX)
-		dirDetailedShadow = LightLimitFix::GetDirectionalShadow(positionWS.xyz, worldPositionWS, rotationMatrix, eyeIndex);
+#	else
+		dirDetailedShadow = DirectionalShadow::GetSceneDirectionalShadow(positionWS.xyz, worldPositionWS, eyeIndex, screenNoise, 1.0);
 #	endif
 	}
 

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -434,6 +434,8 @@ cbuffer AlphaTestRefCB : register(b11)
 #		include "InverseSquareLighting/InverseSquareLighting.hlsli"
 #	endif
 
+#	include "Common/DirectionalShadow.hlsli"
+
 #	define SampColorSampler SampBaseSampler
 
 #	if defined(DYNAMIC_CUBEMAPS)
@@ -607,19 +609,8 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	// HasDirectionalShadows() admits Interior Sun cells; mirrors the
 	// same swap in Lighting.hlsl / Particle.hlsl.
 	if (ShadowSampling::HasDirectionalShadows()) {
-#			if defined(LIGHT_LIMIT_FIX)
-		// SLF suppresses the engine's screen-space shadow-mask pass, so
-		// shadowColor.x is no longer a valid directional shadow signal under
-		// LIGHT_LIMIT_FIX. Sample LLF's cascades directly, matching
-		// Lighting.hlsl / Particle.hlsl.
-		float2 rotation;
-		sincos(Math::TAU * screenNoise, rotation.y, rotation.x);
-		float2x2 rotationMatrix = float2x2(rotation.x, rotation.y, -rotation.y, rotation.x);
 		float3 worldPositionWS = input.WorldPosition.xyz + FrameBuffer::CameraPosAdjust[eyeIndex].xyz;
-		dirDetailedShadow *= LightLimitFix::GetDirectionalShadow(input.WorldPosition.xyz, worldPositionWS, rotationMatrix, eyeIndex);
-#			else
-		dirDetailedShadow *= shadowColor.x;
-#			endif
+		dirDetailedShadow *= DirectionalShadow::GetSceneDirectionalShadow(input.WorldPosition.xyz, worldPositionWS, eyeIndex, screenNoise, shadowColor.x);
 	}
 
 #			if defined(SCREEN_SPACE_SHADOWS)
@@ -866,19 +857,8 @@ PS_OUTPUT main(PS_INPUT input)
 	// HasDirectionalShadows() admits Interior Sun cells; mirrors the
 	// same swap in Lighting.hlsl / Particle.hlsl.
 	if (ShadowSampling::HasDirectionalShadows()) {
-#			if defined(LIGHT_LIMIT_FIX)
-		// SLF suppresses the engine's screen-space shadow-mask pass, so
-		// shadowColor.x is no longer a valid directional shadow signal under
-		// LIGHT_LIMIT_FIX. Sample LLF's cascades directly, matching
-		// Lighting.hlsl / Particle.hlsl.
-		float2 rotation;
-		sincos(Math::TAU * screenNoise, rotation.y, rotation.x);
-		float2x2 rotationMatrix = float2x2(rotation.x, rotation.y, -rotation.y, rotation.x);
 		float3 worldPositionWS = input.WorldPosition.xyz + FrameBuffer::CameraPosAdjust[eyeIndex].xyz;
-		dirDetailedShadow = LightLimitFix::GetDirectionalShadow(input.WorldPosition.xyz, worldPositionWS, rotationMatrix, eyeIndex);
-#			else
-		dirDetailedShadow = shadowColor.x;
-#			endif
+		dirDetailedShadow = DirectionalShadow::GetSceneDirectionalShadow(input.WorldPosition.xyz, worldPositionWS, eyeIndex, screenNoise, shadowColor.x);
 	}
 
 #			if defined(SCREEN_SPACE_SHADOWS)


### PR DESCRIPTION
## Summary

Follow-up to #51. Centralizes the SLF-vs-vanilla directional-shadow routing decision so a new geometry shader can't silently read the (SLF-stale) engine shadow mask — the root cause of the #48 class of bug, where `RunGrass.hlsl` was missed when SLF moved directional shadow off the mask.

> **Stacked on #51** (`fix/slf-grass-directional-shadow`). Review/merge #51 first; GitHub will auto-retarget this to `dev`.

## Change

New `package/Shaders/Common/DirectionalShadow.hlsli`:

```hlsl
DirectionalShadow::GetSceneDirectionalShadow(worldPos, worldPosWS, rotationMatrix, eyeIndex, engineMaskShadow)
```

- Under `LIGHT_LIMIT_FIX`: sample LLF's cascades (lit past the cascade range — the engine mask is suppressed/stale under SLF).
- Otherwise: return the engine mask value.

Included right after the `ShadowSampling -> LightLimitFix` block in each consumer so `LightLimitFix::GetDirectionalShadow` is in scope under SLF; in non-SLF builds the helper just returns the fallback.

## Conversions

- **RunGrass.hlsl** (both `main()` variants): collapses the per-site `#if LIGHT_LIMIT_FIX / #else` into one call with `shadowColor.x` as the fallback.
- **Particle.hlsl**: VSM stays exclusive; the non-VSM branch routes through the helper with a `1.0` fallback.
- **Lighting.hlsl**: intentionally left as a direct `LightLimitFix::GetDirectionalShadow` call — its deferred path feeds the engine mask into LLF as the past-cascade fallback (valid on the non-SLF path), so folding it into the 1.0-fallback helper would change its behavior. A note in the header records this.

## No behavior change

Pure refactor — reproduces each converted site's current behavior. Full shader suite: **2926/2926 variants, 0 errors, 0 new warnings**.