### PR TITLE
chore: drop issue/PR refs from code comments

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2508,10 +2508,10 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	// EndSplitDistances.y instead of returning fully-lit.
 	float4 shadowColor = (Permutation::PixelShaderDescriptor & Permutation::LightingFlags::DefShadow) ? TexShadowMaskSampler.Load(int3(input.Position.xy, 0)) : 1.0;
 
-	// Mirrors #2319 for VOLUMETRIC_SHADOWS: use HasDirectionalShadows() (= !IsInterior() ||
-	// InteriorSun::IsActive) instead of the bare !InInterior gate, so Interior Sun cells
-	// reach the LLF cascade + engine-mask sampling path. Without this, interior scenes
-	// with active Interior Sun render with zero directional contribution and no sun shadow.
+	// Use HasDirectionalShadows() (= !IsInterior() || InteriorSun::IsActive) instead of
+	// the bare !InInterior gate, so Interior Sun cells reach the LLF cascade + engine-mask
+	// sampling path. Without this, interior scenes with active Interior Sun render with
+	// zero directional contribution and no sun shadow.
 	if (inWorld && !inReflection && ShadowSampling::HasDirectionalShadows()) {
 #	if !defined(LOD)
 		// On non-deferred passes, use the cheaper VSM shadows if available

--- a/package/Shaders/Particle.hlsl
+++ b/package/Shaders/Particle.hlsl
@@ -308,8 +308,8 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float3 dirLightColor = SharedData::DirLightColor.xyz;
 
-	// Mirrors #2319 / Lighting.hlsl: HasDirectionalShadows() admits Interior Sun cells
-	// to the directional shadow sampling path.
+	// HasDirectionalShadows() admits Interior Sun cells to the directional shadow
+	// sampling path (matching Lighting.hlsl).
 	if (ShadowSampling::HasDirectionalShadows()) {
 		// Use the cheaper VSM shadows if available
 #	if defined(VOLUMETRIC_SHADOWS)

--- a/src/Features/InverseSquareLighting.cpp
+++ b/src/Features/InverseSquareLighting.cpp
@@ -68,7 +68,7 @@ void InverseSquareLighting::ProcessLight(LightLimitFix::LightData& light, RE::BS
 		const float intensity = runtimeData->fade * 4;
 		// Use the type-based helper rather than the virtual IsShadowLight():
 		// SCM's Hook_IsShadowLight reports false for shadow lights converted
-		// to normal-light overflow handling (issue #2121 #3). If we followed
+		// to normal-light overflow handling. If we followed
 		// that hook here the cutoff would flip from DefaultShadowCasterCutoff
 		// (0.022) to DefaultCutoff (0.05) when a light is converted, shrinking
 		// its effective radius by ~33% and visibly reducing its lit area.

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -730,7 +730,7 @@ void LightLimitFix::UpdateLights()
 	//
 	// Without this, ConvertExcessToNormal lights have no entry in the cluster
 	// lightsData[] and never render — the user-visible "converted lights are
-	// invisible" symptom of issue #2121 #3.
+	// invisible" symptom.
 	ShadowCasterManager::ForEachConvertedLight([&](RE::BSShadowLight* light) {
 		auto* asBs = static_cast<RE::BSLight*>(light);
 		if (shadowLightPtrs.count(asBs))

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -3081,7 +3081,7 @@ namespace ShadowCasterManager
 			lights[added++] = l;
 		}
 
-		// Step 4: Inject converted shadow lights (s_normalConvert, issue #2121 #3)
+		// Step 4: Inject converted shadow lights (s_normalConvert)
 		// into the per-surface lights array. These lights have frustrumCull == 0xFF
 		// (parabolic shadow-caster marker) and are skipped by Step 3, while Steps
 		// 1/2 don't include them either (ReturnShadowmaps cleared shadowLightsAccum).

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -600,7 +600,7 @@ void Upscaling::LoadSettings(json& o_json)
 	// outer settings deserialize. FoveatedRender::ClampSettings touches sibling
 	// presetDLSS (cross-feature compat), so re-run it after `settings = o_json`
 	// below — otherwise the JSON re-assign overwrites the clamp and an
-	// incompatible preset slips through. (Copilot on PR #44.)
+	// incompatible preset slips through.
 	if (o_json.contains("foveatedRender")) {
 		foveatedRender.LoadSettings(o_json["foveatedRender"]);
 		o_json.erase("foveatedRender");
@@ -629,7 +629,6 @@ void Upscaling::LoadSettings(json& o_json)
 	// re-assign above has overwritten anything it set during its own
 	// LoadSettings (which fired before this block ran). Idempotent — no-op
 	// if FoveatedRender is inactive or the preset is already compatible.
-	// (Copilot on PR #44.)
 	foveatedRender.ClampSettings();
 	const float originalReflexFPSLimit = settings.reflexFPSLimit;
 	if (!std::isfinite(settings.reflexFPSLimit)) {

--- a/src/Features/Upscaling/FoveatedRender.cpp
+++ b/src/Features/Upscaling/FoveatedRender.cpp
@@ -68,7 +68,7 @@ void FoveatedRender::LoadSettings(const json& o_json)
 	settings = o_json;
 	// Util::Subrect::Controller::LoadSettings takes `const json&` (Subrect.h:68)
 	// so no const_cast is needed — keeping it would imply mutation that never
-	// happens. (Copilot + CodeRabbit on PR #44.)
+	// happens.
 	subrectController.LoadSettings(o_json);
 	ClampSettings();
 }

--- a/src/Features/Upscaling/FoveatedRender/Core.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Core.cpp
@@ -32,7 +32,6 @@ namespace FoveatedRenderImpl::Ops
 
 		// QueryInterface for ID3D11Texture2D rather than blind static_cast — a
 		// non-texture resource passed here would crash GetDesc otherwise.
-		// (CodeRabbit on PR #44.)
 		winrt::com_ptr<ID3D11Texture2D> srcTex;
 		if (FAILED(src->QueryInterface(IID_PPV_ARGS(srcTex.put())))) {
 			logger::error("[FOVEATED] CreateTextureFromSource src is not an ID3D11Texture2D ({})", name ? name : "<unnamed>");
@@ -107,7 +106,6 @@ namespace FoveatedRenderImpl::Ops
 		// DLSS then samples stale masks. Drop the intermediate so subsequent
 		// frames don't read it. Independent of the recreate path: shrinking is
 		// cheap and the next non-null source will trigger recreate above.
-		// (Copilot on PR #44.)
 		if (!reactiveSrc && Core::vrIntermediateReactiveMask[0]) {
 			Core::vrIntermediateReactiveMask[0].reset();
 			Core::vrIntermediateReactiveMask[1].reset();
@@ -368,8 +366,7 @@ namespace FoveatedRenderImpl::Ops
 		// Guard against a null destination UAV — CSSetUnorderedAccessViews +
 		// Dispatch with nullptr would either no-op silently or assert in
 		// debug builds. Returning lets the route's `routeHandled=false` path
-		// fall back to standard DLSS so users still see output. (CodeRabbit
-		// on PR #44.)
+		// fall back to standard DLSS so users still see output.
 		if (!kMainUAV) {
 			logger::error("[FOVEATED] StretchDRSToFullEye called with null kMainUAV");
 			return;
@@ -380,7 +377,7 @@ namespace FoveatedRenderImpl::Ops
 		// dispatch. CSSetConstantBuffers + Dispatch would then run the
 		// shader against stale geometry/scale parameters, producing wrong
 		// pixels rather than no pixels. Early-return preserves the prior
-		// frame's output. (CodeRabbit on PR #44.)
+		// frame's output.
 		if (FAILED(context->Map(Core::vrSubrectStretchCB.get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped))) {
 			logger::error("[FOVEATED] StretchDRSToFullEye Map(vrSubrectStretchCB) failed; skipping dispatch");
 			return;

--- a/src/Features/Upscaling/FoveatedRender/Modes.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Modes.cpp
@@ -54,7 +54,7 @@ namespace FoveatedRenderImpl
 		// Subrect path needs colorDstUAV (StretchDRSBothEyes writes through it).
 		// Full-eye path doesn't touch it. Return false on the subrect path so
 		// the router falls back to standard DLSS rather than hitting the null
-		// guard inside StretchDRSToFullEye every frame. (CodeRabbit on PR #44.)
+		// guard inside StretchDRSToFullEye every frame.
 		if (!p.isFullEye && !p.colorDstUAV) {
 			logger::error("[FOVEATED] ExecuteDefaultMode subrect path missing colorDstUAV — falling back");
 			return false;

--- a/src/Features/Upscaling/FoveatedRender/Preprocess.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Preprocess.cpp
@@ -43,7 +43,7 @@ namespace FoveatedRenderImpl
 
 		// motionVectorCopyTexture is dereferenced unconditionally in the UAV
 		// array below when method == kDLSS. The above resource check did not
-		// cover it. Fail closed rather than null-deref. (CodeRabbit on PR #44.)
+		// cover it. Fail closed rather than null-deref.
 		if (upscaleMethod == Upscaling::UpscaleMethod::kDLSS && !upscaling.motionVectorCopyTexture) {
 			logger::error("[FOVEATED] Missing motionVectorCopyTexture for DLSS preprocess");
 			return false;


### PR DESCRIPTION
## Summary

Code-comment style cleanup: removes issue/PR-number references and bot-review attributions from comments, per the repo standard that comments explain the *why* self-contained — "what changed" (issue/PR numbers, which review surfaced a fix) belongs in the PR/commit, not the source, since the reader only sees the present file.

## Removed

- **Upstream issue `#2121 #3`** refs — `LightLimitFix.cpp`, `LightLimitFix/ShadowCasterManager.cpp`, `InverseSquareLighting.cpp`
- **Upstream PR `#2319`** ("Mirrors #2319…") — `Lighting.hlsl`, `Particle.hlsl`
- **`(CodeRabbit/Copilot on PR #44.)`** review attributions — `Upscaling.cpp`, `Upscaling/FoveatedRender.cpp`, `FoveatedRender/Core.cpp` (×4), `Modes.cpp`, `Preprocess.cpp`

In every case the surrounding technical rationale is preserved verbatim — only the reference/attribution is dropped.

## Kept deliberately

- `Valve issue #110` (`VR/InSceneOverlay.cpp`) — an **external** OpenVR bug tracker reference that documents the rationale for a workaround; load-bearing, not internal noise.
- `step #10` (`PerfMode.cpp`) — a render-pipeline step index, not an issue number.

## Scope

Comment-only — every changed line is a comment (15 insertions / 19 deletions, 10 files). No functional or shader-compilation impact. Note: `Particle.hlsl` and `ShadowCasterManager.cpp` are also touched by #51/#53 in adjacent regions, so a trivial rebase may be needed depending on merge order.