### PR TITLE
refactor(slf): extract testable helpers

### DIFF
--- a/cmake/XSEPlugin.cmake
+++ b/cmake/XSEPlugin.cmake
@@ -65,6 +65,8 @@ if(CMAKE_GENERATOR MATCHES "Visual Studio")
 		"${PROJECT_NAME}"
 		PRIVATE
 		/MP
+		/bigobj # ShadowCasterManager.cpp (exprtk-heavy) exceeds the object-file
+		        # section limit under MSVC 14.50 without this (C1128).
 		/W4
 		/WX
 		/permissive-

--- a/cmake/XSEPlugin.cmake
+++ b/cmake/XSEPlugin.cmake
@@ -65,8 +65,6 @@ if(CMAKE_GENERATOR MATCHES "Visual Studio")
 		"${PROJECT_NAME}"
 		PRIVATE
 		/MP
-		/bigobj # ShadowCasterManager.cpp (exprtk-heavy) exceeds the object-file
-		        # section limit under MSVC 14.50 without this (C1128).
 		/W4
 		/WX
 		/permissive-

--- a/src/Features/InverseSquareLighting.cpp
+++ b/src/Features/InverseSquareLighting.cpp
@@ -1,5 +1,6 @@
 #include "InverseSquareLighting.h"
 #include "Features/InverseSquareLighting/Common.h"
+#include "Features/InverseSquareLighting/RadiusMath.h"
 #include "LightLimitFix.h"
 #include <numbers>
 
@@ -75,8 +76,8 @@ void InverseSquareLighting::ProcessLight(LightLimitFix::LightData& light, RE::BS
 		light.radius = CalculateRadius(intensity, ShadowCasterManager::IsShadowLightType(bsLight), runtimeData->cutoffOverride, runtimeData->size);
 		runtimeData->radius = light.radius;
 		light.invRadius = 1.f / light.radius;
-		light.fadeZone = 1.f / (light.radius * std::clamp(FadeZoneBase * light.invRadius, 0.f, 1.f));
-		light.sizeBias = ScaledUnitsSq * runtimeData->size * runtimeData->size * 0.5f;
+		light.fadeZone = 1.f / (light.radius * std::clamp(ISLMath::FadeZoneBase * light.invRadius, 0.f, 1.f));
+		light.sizeBias = ISLMath::ScaledUnitsSq * runtimeData->size * runtimeData->size * 0.5f;
 		// light.color *= intensity;
 		light.fade = intensity;
 	} else {
@@ -89,28 +90,12 @@ void InverseSquareLighting::ProcessLight(LightLimitFix::LightData& light, RE::BS
 
 float InverseSquareLighting::CalculateRadius(const float intensity, const bool shadowCaster, const float cutoffOverride, const float size)
 {
-	float cutoff = shadowCaster ? DefaultShadowCasterCutoff : DefaultCutoff;
-	cutoff = cutoffOverride == 1.f ? cutoff : cutoffOverride;
-	const float radius = std::sqrt(ScaledUnitsSq * ((2 * intensity - cutoff * size * size) / (2 * cutoff)));
-	// Clamp any degenerate result to 1.0 so callers never divide by a bad radius:
-	// a negative sqrt argument yields NaN, an exact-zero argument yields 0 (which
-	// would drive a 0/0 attenuation fade), and a zero cutoffOverride yields +inf
-	// (sqrt(+inf) is not NaN, so the old isnan-only check let it through).
-	return std::isfinite(radius) && radius > 0.f ? radius : 1.f;
-}
-
-inline float InverseSquareLighting::SmoothStep(const float edge0, const float edge1, const float x)
-{
-	const float t = std::clamp((x - edge0) / (edge1 - edge0), 0.0f, 1.0f);
-	return t * t * (3.0f - 2.0f * t);
+	return ISLMath::CalculateRadius(intensity, shadowCaster, cutoffOverride, size);
 }
 
 float InverseSquareLighting::GetAttenuation(const float distance, const float radius, const float size)
 {
-	const float attenuation = ScaledUnitsSq / (distance * distance + ScaledUnitsSq * size * size / 2);
-	const float fadeZone = std::clamp(FadeZoneBase / radius, 0.0f, 1.0f);
-	const float fade = SmoothStep(0, radius * fadeZone, radius - distance);
-	return attenuation * fade;
+	return ISLMath::GetAttenuation(distance, radius, size);
 }
 
 float InverseSquareLighting::BSLight_GetLuminance::thunk(RE::BSLight* bsLight, RE::NiPoint3* targetPosition, RE::NiLight* refLight)

--- a/src/Features/InverseSquareLighting.h
+++ b/src/Features/InverseSquareLighting.h
@@ -58,16 +58,8 @@ public:
 private:
 	LightEditor editor = LightEditor();
 
-	static constexpr float DefaultCutoff = 0.05f;
-	static constexpr float DefaultShadowCasterCutoff = 0.022f;
-
-	static constexpr float Scale = 0.8f;
-	static constexpr float MetresToUnits = 70.f;
-	static constexpr float MetresToUnitsSq = MetresToUnits * MetresToUnits;
-	static constexpr float ScaledUnitsSq = Scale * MetresToUnitsSq;
-	static constexpr float FadeZoneBase = 4.5f * Scale * MetresToUnits;
+	// Radius/attenuation constants and math live in InverseSquareLighting/RadiusMath.h
+	// (namespace ISLMath) so they can be unit-tested without the engine.
 
 	static void SetExtLightData(RE::NiLight* niLight, const RE::TESObjectLIGH* ligh);
-
-	static inline float SmoothStep(float edge0, float edge1, float x);
 };

--- a/src/Features/InverseSquareLighting.h
+++ b/src/Features/InverseSquareLighting.h
@@ -58,8 +58,7 @@ public:
 private:
 	LightEditor editor = LightEditor();
 
-	// Radius/attenuation constants and math live in InverseSquareLighting/RadiusMath.h
-	// (namespace ISLMath) so they can be unit-tested without the engine.
+	// Constants + math live in RadiusMath.h (ISLMath) for unit testing.
 
 	static void SetExtLightData(RE::NiLight* niLight, const RE::TESObjectLIGH* ligh);
 };

--- a/src/Features/InverseSquareLighting/RadiusMath.h
+++ b/src/Features/InverseSquareLighting/RadiusMath.h
@@ -3,11 +3,8 @@
 #include <algorithm>
 #include <cmath>
 
-// Pure inverse-square-lighting radius / attenuation math, extracted from
-// InverseSquareLighting so it can be unit-tested without the game/RE runtime.
-// All inputs and outputs are plain floats -- no engine types -- so this header
-// compiles standalone into the cpp_tests binary. InverseSquareLighting's static
-// methods delegate here.
+// Pure ISL radius/attenuation math, extracted so it can be unit-tested without
+// the game/RE runtime. InverseSquareLighting's static methods delegate here.
 namespace ISLMath
 {
 	inline constexpr float DefaultCutoff = 0.05f;

--- a/src/Features/InverseSquareLighting/RadiusMath.h
+++ b/src/Features/InverseSquareLighting/RadiusMath.h
@@ -23,14 +23,17 @@ namespace ISLMath
 	}
 
 	// Radius at which the inverse-square falloff reaches `cutoff`. A cutoffOverride
-	// of exactly 1.0 means "use the default"; anything else overrides it. NaN
-	// results (degenerate inputs) clamp to 1.0 so a light never gets a bad radius.
+	// of exactly 1.0 means "use the default"; anything else overrides it. Any
+	// degenerate result clamps to 1.0 so a light never gets a bad radius: a
+	// negative sqrt argument yields NaN, an exact-zero argument yields 0 (callers
+	// divide by radius, so 0 would drive a 0/0 SmoothStep), and a zero
+	// cutoffOverride yields +inf -- a finite-and-positive check guards all three.
 	inline float CalculateRadius(float intensity, bool shadowCaster, float cutoffOverride, float size)
 	{
 		float cutoff = shadowCaster ? DefaultShadowCasterCutoff : DefaultCutoff;
 		cutoff = cutoffOverride == 1.f ? cutoff : cutoffOverride;
 		const float radius = std::sqrt(ScaledUnitsSq * ((2 * intensity - cutoff * size * size) / (2 * cutoff)));
-		return std::isnan(radius) ? 1.f : radius;
+		return std::isfinite(radius) && radius > 0.0f ? radius : 1.0f;
 	}
 
 	inline float GetAttenuation(float distance, float radius, float size)

--- a/src/Features/InverseSquareLighting/RadiusMath.h
+++ b/src/Features/InverseSquareLighting/RadiusMath.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+
+// Pure inverse-square-lighting radius / attenuation math, extracted from
+// InverseSquareLighting so it can be unit-tested without the game/RE runtime.
+// All inputs and outputs are plain floats -- no engine types -- so this header
+// compiles standalone into the cpp_tests binary. InverseSquareLighting's static
+// methods delegate here.
+namespace ISLMath
+{
+	inline constexpr float DefaultCutoff = 0.05f;
+	inline constexpr float DefaultShadowCasterCutoff = 0.022f;
+
+	inline constexpr float Scale = 0.8f;
+	inline constexpr float MetresToUnits = 70.f;
+	inline constexpr float MetresToUnitsSq = MetresToUnits * MetresToUnits;
+	inline constexpr float ScaledUnitsSq = Scale * MetresToUnitsSq;
+	inline constexpr float FadeZoneBase = 4.5f * Scale * MetresToUnits;
+
+	inline float SmoothStep(float edge0, float edge1, float x)
+	{
+		const float t = std::clamp((x - edge0) / (edge1 - edge0), 0.0f, 1.0f);
+		return t * t * (3.0f - 2.0f * t);
+	}
+
+	// Radius at which the inverse-square falloff reaches `cutoff`. A cutoffOverride
+	// of exactly 1.0 means "use the default"; anything else overrides it. NaN
+	// results (degenerate inputs) clamp to 1.0 so a light never gets a bad radius.
+	inline float CalculateRadius(float intensity, bool shadowCaster, float cutoffOverride, float size)
+	{
+		float cutoff = shadowCaster ? DefaultShadowCasterCutoff : DefaultCutoff;
+		cutoff = cutoffOverride == 1.f ? cutoff : cutoffOverride;
+		const float radius = std::sqrt(ScaledUnitsSq * ((2 * intensity - cutoff * size * size) / (2 * cutoff)));
+		return std::isnan(radius) ? 1.f : radius;
+	}
+
+	inline float GetAttenuation(float distance, float radius, float size)
+	{
+		const float attenuation = ScaledUnitsSq / (distance * distance + ScaledUnitsSq * size * size / 2);
+		const float fadeZone = std::clamp(FadeZoneBase / radius, 0.0f, 1.0f);
+		const float fade = SmoothStep(0, radius * fadeZone, radius - distance);
+		return attenuation * fade;
+	}
+}

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -1,5 +1,6 @@
 #include "LightLimitFix.h"
 #include "Features/InverseSquareLighting/Common.h"
+#include "Features/LightLimitFix/SettingsSanitize.h"
 #include "Globals.h"
 #include "InverseSquareLighting.h"
 #include "LinearLighting.h"
@@ -380,7 +381,7 @@ LightLimitFix::PerFrame LightLimitFix::GetCommonBufferData()
 	// so reject non-finite values explicitly first; fall back to the lower
 	// bound on NaN/inf to produce degraded but stable behavior.
 	auto sanitizeFloat = [](float v, float lo, float hi) {
-		return std::isfinite(v) ? std::clamp(v, lo, hi) : lo;
+		return LightLimitFixSanitize::SanitizeFloat(v, lo, hi);
 	};
 
 	PerFrame perFrame{};

--- a/src/Features/LightLimitFix/SettingsSanitize.h
+++ b/src/Features/LightLimitFix/SettingsSanitize.h
@@ -12,6 +12,11 @@ namespace LightLimitFixSanitize
 	// value reach the GPU and cause divisions / infinite loops / corruption, so
 	// reject non-finite inputs explicitly and fall back to the lower bound for
 	// degraded-but-stable behavior.
+	//
+	// Precondition: lo and hi are finite with lo <= hi. Only the value is
+	// untrusted; the bounds are compile-time constants at every call site (the
+	// feature's fixed setting ranges), so they are not re-validated here -- a
+	// NaN lo would defeat the fallback and hi < lo is std::clamp UB.
 	inline float SanitizeFloat(float v, float lo, float hi)
 	{
 		return std::isfinite(v) ? std::clamp(v, lo, hi) : lo;

--- a/src/Features/LightLimitFix/SettingsSanitize.h
+++ b/src/Features/LightLimitFix/SettingsSanitize.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+
+// Pure settings-sanitization helper extracted from LightLimitFix so it can be
+// unit-tested without the game/RE runtime.
+namespace LightLimitFixSanitize
+{
+	// Clamp a user/config float to [lo, hi]. std::clamp passes NaN through
+	// unchanged (every NaN comparison is false), which would let a non-finite
+	// value reach the GPU and cause divisions / infinite loops / corruption, so
+	// reject non-finite inputs explicitly and fall back to the lower bound for
+	// degraded-but-stable behavior.
+	inline float SanitizeFloat(float v, float lo, float hi)
+	{
+		return std::isfinite(v) ? std::clamp(v, lo, hi) : lo;
+	}
+}

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -241,16 +241,7 @@ namespace ShadowCasterManager
 
 	static float ComputeFrameTimePercentile90()
 	{
-		// <= 0 (not just == 0): a negative count would drive a negative n into
-		// std::copy / std::nth_element below (out-of-bounds / UB).
-		if (s_ftCount <= 0)
-			return 16.67f;  // fallback: 60 fps target
-		const int n = std::min(s_ftCount, kFrameWindow);
-		float tmp[kFrameWindow];
-		std::copy(s_ftRing, s_ftRing + n, tmp);
-		const int idx = static_cast<int>(n * 0.9f);
-		std::nth_element(tmp, tmp + idx, tmp + n);
-		return tmp[idx];
+		return FrameTimePercentile90(s_ftRing, s_ftCount);
 	}
 
 	// Maximum ShadowLightCount the installed infrastructure supports.

--- a/src/Features/LightLimitFix/ShadowCasterManager.h
+++ b/src/Features/LightLimitFix/ShadowCasterManager.h
@@ -21,6 +21,8 @@
 #include "RE/B/BSShadowLight.h"
 #include "RE/S/ShadowSceneNode.h"
 
+#include "Features/LightLimitFix/ShadowCasterMath.h"
+
 struct ImVec4;
 
 namespace ShadowCasterManager
@@ -92,13 +94,8 @@ namespace ShadowCasterManager
 		std::uint32_t idx = 0;
 		while (idx < maxIdx) {
 			RE::BSShadowLight* light = accum[idx];
-			if (!light)
-				break;
 			const auto raw = reinterpret_cast<std::uintptr_t>(light);
-			// Reject the low 64 KiB too: the Windows x64 null-guard region is
-			// never a valid user mapping, so a near-null garbage value (e.g.
-			// 0x8) would otherwise pass and get dereferenced (AV/CTD).
-			if (raw < 0x10000ull || raw >= 0x0000800000000000ull || (raw & 0x7) != 0)
+			if (!IsPlausibleShadowLightPtr(raw))  // null / misaligned / non-canonical
 				break;
 			fn(light);
 			const std::uint32_t step = light->shadowMapCount;

--- a/src/Features/LightLimitFix/ShadowCasterMath.h
+++ b/src/Features/LightLimitFix/ShadowCasterMath.h
@@ -8,23 +8,28 @@
 namespace ShadowCasterManager
 {
 	// A shadow-light accumulator slot can hold heap garbage between our prepass
-	// and the engine's read. Treat a pointer as plausible only if it is
-	// non-null, inside the x64 user-mode canonical range, and 8-byte aligned
-	// (BSShadowLight is pointer-aligned). ForEachShadowLight stops iterating at
-	// the first implausible entry rather than dereferencing garbage.
+	// and the engine's read. Treat a pointer as plausible only if it is at or
+	// above the low 64 KiB (the Windows x64 null-guard region is never a valid
+	// user mapping, so a near-null garbage value like 0x8 must be rejected --
+	// dereferencing it is a guaranteed AV/CTD), inside the x64 user-mode
+	// canonical range, and 8-byte aligned (BSShadowLight is pointer-aligned).
+	// ForEachShadowLight stops iterating at the first implausible entry rather
+	// than dereferencing garbage.
 	inline bool IsPlausibleShadowLightPtr(std::uintptr_t raw) noexcept
 	{
-		return raw != 0 && raw < 0x0000800000000000ull && (raw & 0x7) == 0;
+		return raw >= 0x10000ull && raw < 0x0000800000000000ull && (raw & 0x7) == 0;
 	}
 
 	// 90th-percentile of the most-recent min(count, Window) frame-time samples
 	// in `ring`. Percentile is order-independent, so the first `n` entries are
 	// sampled directly (ring head/wraparound doesn't matter). Returns the 60fps
-	// fallback (16.67 ms) before any samples exist.
+	// fallback (16.67 ms) before any samples exist. A non-positive count (no
+	// samples, or a corrupt/negative value) takes the fallback -- a negative n
+	// would otherwise drive std::copy / std::nth_element out of bounds.
 	template <int Window>
 	inline float FrameTimePercentile90(const float (&ring)[Window], int count)
 	{
-		if (count == 0)
+		if (count <= 0)
 			return 16.67f;
 		const int n = std::min(count, Window);
 		float tmp[Window];

--- a/src/Features/LightLimitFix/ShadowCasterMath.h
+++ b/src/Features/LightLimitFix/ShadowCasterMath.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+// Pure helpers extracted from ShadowCasterManager so they can be unit-tested
+// without the game/RE runtime. No engine types in any signature.
+namespace ShadowCasterManager
+{
+	// A shadow-light accumulator slot can hold heap garbage between our prepass
+	// and the engine's read. Treat a pointer as plausible only if it is
+	// non-null, inside the x64 user-mode canonical range, and 8-byte aligned
+	// (BSShadowLight is pointer-aligned). ForEachShadowLight stops iterating at
+	// the first implausible entry rather than dereferencing garbage.
+	inline bool IsPlausibleShadowLightPtr(std::uintptr_t raw) noexcept
+	{
+		return raw != 0 && raw < 0x0000800000000000ull && (raw & 0x7) == 0;
+	}
+
+	// 90th-percentile of the most-recent min(count, Window) frame-time samples
+	// in `ring`. Percentile is order-independent, so the first `n` entries are
+	// sampled directly (ring head/wraparound doesn't matter). Returns the 60fps
+	// fallback (16.67 ms) before any samples exist.
+	template <int Window>
+	inline float FrameTimePercentile90(const float (&ring)[Window], int count)
+	{
+		if (count == 0)
+			return 16.67f;
+		const int n = std::min(count, Window);
+		float tmp[Window];
+		std::copy(ring, ring + n, tmp);
+		const int idx = static_cast<int>(n * 0.9f);
+		std::nth_element(tmp, tmp + idx, tmp + n);
+		return tmp[idx];
+	}
+}

--- a/src/Features/LightLimitFix/ShadowCasterMath.h
+++ b/src/Features/LightLimitFix/ShadowCasterMath.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 
 // Pure helpers extracted from ShadowCasterManager so they can be unit-tested
-// without the game/RE runtime. No engine types in any signature.
+// without the game/RE runtime.
 namespace ShadowCasterManager
 {
 	// A shadow-light accumulator slot can hold heap garbage between our prepass

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(cpp_tests
     test_sphericalharmonics.cpp
     test_input.cpp
     test_stringutils.cpp
+    test_isl_radiusmath.cpp
     # Compile the unit-under-test directly into the test binary so we don't
     # depend on the plugin DLL build (which pulls in FFX/Streamline/etc.).
     "${CMAKE_SOURCE_DIR}/src/Utils/Subrect.cpp"

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -50,6 +50,8 @@ add_executable(cpp_tests
     test_input.cpp
     test_stringutils.cpp
     test_isl_radiusmath.cpp
+    test_shadowcaster_math.cpp
+    test_llf_sanitize.cpp
     # Compile the unit-under-test directly into the test binary so we don't
     # depend on the plugin DLL build (which pulls in FFX/Streamline/etc.).
     "${CMAKE_SOURCE_DIR}/src/Utils/Subrect.cpp"

--- a/tests/cpp/test_isl_radiusmath.cpp
+++ b/tests/cpp/test_isl_radiusmath.cpp
@@ -37,10 +37,19 @@ TEST_CASE("cutoffOverride replaces the default regardless of shadow flag", "[isl
 	REQUIRE(ISLMath::CalculateRadius(1.0f, true, 0.05f, 0.0f) == Approx(280.0f));
 }
 
-TEST_CASE("CalculateRadius clamps a NaN (negative-sqrt) result to 1", "[isl]")
+TEST_CASE("CalculateRadius clamps degenerate results to 1", "[isl]")
 {
-	// intensity 0 with a large size makes the sqrt argument negative -> NaN -> 1.
+	// NaN: intensity 0 with a large size makes the sqrt argument negative.
 	REQUIRE(ISLMath::CalculateRadius(0.0f, false, 1.0f, 10.0f) == Approx(1.0f));
+	// Exact zero: 2*intensity == cutoff*size^2 (0.05 * 2^2 = 0.2, intensity 0.1)
+	// makes the sqrt argument 0. A 0 radius would drive a 0/0 SmoothStep downstream.
+	REQUIRE(ISLMath::CalculateRadius(0.1f, false, 1.0f, 2.0f) == Approx(1.0f));
+	// +inf: a zero cutoffOverride divides by 2*cutoff == 0. isnan() alone misses
+	// this (sqrt(+inf) is +inf, not NaN); the finite check catches it. The cutoff
+	// is read through a volatile so MSVC can't constant-fold the literal /0 into a
+	// compile-time C4723 -- at runtime the float divide yields +inf as intended.
+	volatile float zeroCutoff = 0.0f;
+	REQUIRE(ISLMath::CalculateRadius(1.0f, false, zeroCutoff, 0.0f) == Approx(1.0f));
 }
 
 TEST_CASE("GetAttenuation peaks at the source and vanishes past the radius", "[isl]")

--- a/tests/cpp/test_isl_radiusmath.cpp
+++ b/tests/cpp/test_isl_radiusmath.cpp
@@ -1,0 +1,64 @@
+// Unit tests for inverse-square-lighting radius/attenuation math
+// (src/Features/InverseSquareLighting/RadiusMath.h). Pure float math extracted
+// from InverseSquareLighting so it tests without the game/RE runtime.
+
+#include "Features/InverseSquareLighting/RadiusMath.h"
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+using Catch::Approx;
+
+TEST_CASE("SmoothStep is a clamped Hermite ramp", "[isl]")
+{
+	REQUIRE(ISLMath::SmoothStep(0.0f, 1.0f, 0.0f) == Approx(0.0f));
+	REQUIRE(ISLMath::SmoothStep(0.0f, 1.0f, 1.0f) == Approx(1.0f));
+	REQUIRE(ISLMath::SmoothStep(0.0f, 1.0f, 0.5f) == Approx(0.5f));  // t^2(3-2t) at 0.5
+	// Clamps outside [edge0, edge1].
+	REQUIRE(ISLMath::SmoothStep(0.0f, 1.0f, -1.0f) == Approx(0.0f));
+	REQUIRE(ISLMath::SmoothStep(0.0f, 1.0f, 2.0f) == Approx(1.0f));
+}
+
+TEST_CASE("CalculateRadius matches the closed form for default cutoff", "[isl]")
+{
+	// cutoffOverride == 1 -> default cutoff (0.05 for non-shadow); size 0.
+	// radius = sqrt(ScaledUnitsSq * (2*intensity / (2*0.05))) = sqrt(3920 * 20) = 280.
+	REQUIRE(ISLMath::CalculateRadius(1.0f, false, 1.0f, 0.0f) == Approx(280.0f));
+}
+
+TEST_CASE("Shadow casters get a larger radius (smaller cutoff)", "[isl]")
+{
+	const float normal = ISLMath::CalculateRadius(1.0f, false, 1.0f, 0.0f);
+	const float shadow = ISLMath::CalculateRadius(1.0f, true, 1.0f, 0.0f);
+	REQUIRE(shadow > normal);
+}
+
+TEST_CASE("cutoffOverride replaces the default regardless of shadow flag", "[isl]")
+{
+	// Override of 0.05 forces the non-shadow default value even for a shadow caster.
+	REQUIRE(ISLMath::CalculateRadius(1.0f, true, 0.05f, 0.0f) == Approx(280.0f));
+}
+
+TEST_CASE("CalculateRadius clamps a NaN (negative-sqrt) result to 1", "[isl]")
+{
+	// intensity 0 with a large size makes the sqrt argument negative -> NaN -> 1.
+	REQUIRE(ISLMath::CalculateRadius(0.0f, false, 1.0f, 10.0f) == Approx(1.0f));
+}
+
+TEST_CASE("GetAttenuation peaks at the source and vanishes past the radius", "[isl]")
+{
+	// distance 0, radius 280, size 1: attenuation = 3920/(0 + 3920/2) = 2.0;
+	// fade is 1 at the source.
+	REQUIRE(ISLMath::GetAttenuation(0.0f, 280.0f, 1.0f) == Approx(2.0f));
+	// Beyond the radius the SmoothStep fade clamps to zero.
+	REQUIRE(ISLMath::GetAttenuation(300.0f, 280.0f, 1.0f) == Approx(0.0f));
+}
+
+TEST_CASE("GetAttenuation decreases monotonically with distance in range", "[isl]")
+{
+	// 'near'/'far' are legacy Windows.h macros, so use distinct names.
+	const float attNear = ISLMath::GetAttenuation(10.0f, 280.0f, 1.0f);
+	const float attFar = ISLMath::GetAttenuation(150.0f, 280.0f, 1.0f);
+	REQUIRE(attNear > attFar);
+	REQUIRE(attFar > 0.0f);
+}

--- a/tests/cpp/test_isl_radiusmath.cpp
+++ b/tests/cpp/test_isl_radiusmath.cpp
@@ -1,6 +1,4 @@
-// Unit tests for inverse-square-lighting radius/attenuation math
-// (src/Features/InverseSquareLighting/RadiusMath.h). Pure float math extracted
-// from InverseSquareLighting so it tests without the game/RE runtime.
+// Unit tests for ISL radius/attenuation math (RadiusMath.h).
 
 #include "Features/InverseSquareLighting/RadiusMath.h"
 

--- a/tests/cpp/test_llf_sanitize.cpp
+++ b/tests/cpp/test_llf_sanitize.cpp
@@ -1,0 +1,31 @@
+// Unit tests for the LightLimitFix settings sanitizer
+// (src/Features/LightLimitFix/SettingsSanitize.h).
+
+#include "Features/LightLimitFix/SettingsSanitize.h"
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <limits>
+
+using Catch::Approx;
+using LightLimitFixSanitize::SanitizeFloat;
+
+TEST_CASE("SanitizeFloat clamps in-range, low, and high inputs", "[llf]")
+{
+	REQUIRE(SanitizeFloat(0.5f, 0.0f, 1.0f) == Approx(0.5f));
+	REQUIRE(SanitizeFloat(-1.0f, 0.0f, 1.0f) == Approx(0.0f));
+	REQUIRE(SanitizeFloat(2.0f, 0.0f, 1.0f) == Approx(1.0f));
+	REQUIRE(SanitizeFloat(64.0f, 64.0f, 4096.0f) == Approx(64.0f));   // exact lower bound
+	REQUIRE(SanitizeFloat(4096.0f, 64.0f, 4096.0f) == Approx(4096.0f));  // exact upper bound
+}
+
+TEST_CASE("SanitizeFloat falls back to the lower bound on non-finite input", "[llf]")
+{
+	const float nan = std::numeric_limits<float>::quiet_NaN();
+	const float inf = std::numeric_limits<float>::infinity();
+	REQUIRE(SanitizeFloat(nan, 0.5f, 8.0f) == Approx(0.5f));
+	REQUIRE(SanitizeFloat(inf, 0.5f, 8.0f) == Approx(0.5f));
+	REQUIRE(SanitizeFloat(-inf, 0.5f, 8.0f) == Approx(0.5f));
+}

--- a/tests/cpp/test_llf_sanitize.cpp
+++ b/tests/cpp/test_llf_sanitize.cpp
@@ -17,7 +17,7 @@ TEST_CASE("SanitizeFloat clamps in-range, low, and high inputs", "[llf]")
 	REQUIRE(SanitizeFloat(0.5f, 0.0f, 1.0f) == Approx(0.5f));
 	REQUIRE(SanitizeFloat(-1.0f, 0.0f, 1.0f) == Approx(0.0f));
 	REQUIRE(SanitizeFloat(2.0f, 0.0f, 1.0f) == Approx(1.0f));
-	REQUIRE(SanitizeFloat(64.0f, 64.0f, 4096.0f) == Approx(64.0f));   // exact lower bound
+	REQUIRE(SanitizeFloat(64.0f, 64.0f, 4096.0f) == Approx(64.0f));      // exact lower bound
 	REQUIRE(SanitizeFloat(4096.0f, 64.0f, 4096.0f) == Approx(4096.0f));  // exact upper bound
 }
 

--- a/tests/cpp/test_shadowcaster_math.cpp
+++ b/tests/cpp/test_shadowcaster_math.cpp
@@ -50,3 +50,11 @@ TEST_CASE("FrameTimePercentile90 honors count below the window size", "[scm]")
 	// n = 5, idx = int(5*0.9) = 4 -> the largest of {10..50} = 50.
 	REQUIRE(FrameTimePercentile90(ring, 5) == Approx(50.0f));
 }
+
+TEST_CASE("FrameTimePercentile90 clamps count above the window size", "[scm]")
+{
+	// count > Window: std::min clamps n to Window (10) so the copy stays in
+	// bounds; all slots are sampled. Pins the clamp against a regression.
+	float ring[10] = { 5, 2, 9, 1, 7, 3, 10, 4, 8, 6 };
+	REQUIRE(FrameTimePercentile90(ring, 99) == Approx(10.0f));
+}

--- a/tests/cpp/test_shadowcaster_math.cpp
+++ b/tests/cpp/test_shadowcaster_math.cpp
@@ -11,24 +11,29 @@ using Catch::Approx;
 using ShadowCasterManager::FrameTimePercentile90;
 using ShadowCasterManager::IsPlausibleShadowLightPtr;
 
-TEST_CASE("IsPlausibleShadowLightPtr rejects null, misaligned, and non-canonical", "[scm]")
+TEST_CASE("IsPlausibleShadowLightPtr rejects null, near-null, misaligned, and non-canonical", "[scm]")
 {
 	REQUIRE_FALSE(IsPlausibleShadowLightPtr(0));                      // null
-	REQUIRE(IsPlausibleShadowLightPtr(0x8));                          // aligned, in range
+	REQUIRE_FALSE(IsPlausibleShadowLightPtr(0x8));                    // near-null: below the 64 KiB floor
+	REQUIRE_FALSE(IsPlausibleShadowLightPtr(0xFFF8ull));              // aligned but still below the floor
+	REQUIRE(IsPlausibleShadowLightPtr(0x10000ull));                   // at the floor, aligned -> plausible
 	REQUIRE(IsPlausibleShadowLightPtr(0x00007FFFFFFFFFF8ull));        // top of user-mode range
 	REQUIRE_FALSE(IsPlausibleShadowLightPtr(0x0000800000000000ull));  // first non-canonical
 	REQUIRE_FALSE(IsPlausibleShadowLightPtr(0xFFFFF80000000000ull));  // kernel-space garbage
 
-	// Any non-8-byte alignment is rejected.
+	// Any non-8-byte alignment is rejected (use a base above the floor so the
+	// alignment check is what fails, not the minimum-address check).
 	for (std::uintptr_t off = 1; off < 8; ++off)
-		REQUIRE_FALSE(IsPlausibleShadowLightPtr(0x1000 + off));
-	REQUIRE(IsPlausibleShadowLightPtr(0x1000));
+		REQUIRE_FALSE(IsPlausibleShadowLightPtr(0x10000 + off));
 }
 
 TEST_CASE("FrameTimePercentile90 returns the 60fps fallback with no samples", "[scm]")
 {
 	float ring[8]{};
 	REQUIRE(FrameTimePercentile90(ring, 0) == Approx(16.67f));
+	// A negative count (corruption / future refactor) must not drive a negative
+	// n into std::copy / std::nth_element -- it takes the fallback too.
+	REQUIRE(FrameTimePercentile90(ring, -1) == Approx(16.67f));
 }
 
 TEST_CASE("FrameTimePercentile90 picks the P90 element", "[scm]")

--- a/tests/cpp/test_shadowcaster_math.cpp
+++ b/tests/cpp/test_shadowcaster_math.cpp
@@ -14,10 +14,10 @@ using ShadowCasterManager::IsPlausibleShadowLightPtr;
 TEST_CASE("IsPlausibleShadowLightPtr rejects null, misaligned, and non-canonical", "[scm]")
 {
 	REQUIRE_FALSE(IsPlausibleShadowLightPtr(0));                      // null
-	REQUIRE(IsPlausibleShadowLightPtr(0x8));                         // aligned, in range
-	REQUIRE(IsPlausibleShadowLightPtr(0x00007FFFFFFFFFF8ull));       // top of user-mode range
-	REQUIRE_FALSE(IsPlausibleShadowLightPtr(0x0000800000000000ull)); // first non-canonical
-	REQUIRE_FALSE(IsPlausibleShadowLightPtr(0xFFFFF80000000000ull)); // kernel-space garbage
+	REQUIRE(IsPlausibleShadowLightPtr(0x8));                          // aligned, in range
+	REQUIRE(IsPlausibleShadowLightPtr(0x00007FFFFFFFFFF8ull));        // top of user-mode range
+	REQUIRE_FALSE(IsPlausibleShadowLightPtr(0x0000800000000000ull));  // first non-canonical
+	REQUIRE_FALSE(IsPlausibleShadowLightPtr(0xFFFFF80000000000ull));  // kernel-space garbage
 
 	// Any non-8-byte alignment is rejected.
 	for (std::uintptr_t off = 1; off < 8; ++off)

--- a/tests/cpp/test_shadowcaster_math.cpp
+++ b/tests/cpp/test_shadowcaster_math.cpp
@@ -1,0 +1,47 @@
+// Unit tests for ShadowCasterManager pure helpers
+// (src/Features/LightLimitFix/ShadowCasterMath.h): the shadow-light pointer
+// plausibility check and the frame-time 90th-percentile.
+
+#include "Features/LightLimitFix/ShadowCasterMath.h"
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+using Catch::Approx;
+using ShadowCasterManager::FrameTimePercentile90;
+using ShadowCasterManager::IsPlausibleShadowLightPtr;
+
+TEST_CASE("IsPlausibleShadowLightPtr rejects null, misaligned, and non-canonical", "[scm]")
+{
+	REQUIRE_FALSE(IsPlausibleShadowLightPtr(0));                      // null
+	REQUIRE(IsPlausibleShadowLightPtr(0x8));                         // aligned, in range
+	REQUIRE(IsPlausibleShadowLightPtr(0x00007FFFFFFFFFF8ull));       // top of user-mode range
+	REQUIRE_FALSE(IsPlausibleShadowLightPtr(0x0000800000000000ull)); // first non-canonical
+	REQUIRE_FALSE(IsPlausibleShadowLightPtr(0xFFFFF80000000000ull)); // kernel-space garbage
+
+	// Any non-8-byte alignment is rejected.
+	for (std::uintptr_t off = 1; off < 8; ++off)
+		REQUIRE_FALSE(IsPlausibleShadowLightPtr(0x1000 + off));
+	REQUIRE(IsPlausibleShadowLightPtr(0x1000));
+}
+
+TEST_CASE("FrameTimePercentile90 returns the 60fps fallback with no samples", "[scm]")
+{
+	float ring[8]{};
+	REQUIRE(FrameTimePercentile90(ring, 0) == Approx(16.67f));
+}
+
+TEST_CASE("FrameTimePercentile90 picks the P90 element", "[scm]")
+{
+	// 10 samples 1..10: idx = int(10*0.9) = 9 -> the largest sorted element.
+	float ring[10] = { 5, 2, 9, 1, 7, 3, 10, 4, 8, 6 };
+	REQUIRE(FrameTimePercentile90(ring, 10) == Approx(10.0f));
+}
+
+TEST_CASE("FrameTimePercentile90 honors count below the window size", "[scm]")
+{
+	// Only the first 5 entries are valid; trailing slots must not be sampled.
+	float ring[10] = { 10, 20, 30, 40, 50, 999, 999, 999, 999, 999 };
+	// n = 5, idx = int(5*0.9) = 4 -> the largest of {10..50} = 50.
+	REQUIRE(FrameTimePercentile90(ring, 5) == Approx(50.0f));
+}


### PR DESCRIPTION
## Summary

**Phase 2 (Tier 2)** of the cpp-test expansion — pure logic lifted out of engine-coupled `.cpp`s into standalone, testable TUs. Production delegates to each extracted header (pure signatures, **no behavior change**). Stacked on #55; auto-retargets to `dev` when #55 merges.

## Extracted + tested units

| Unit | Header | Tests | Value |
|---|---|---|---|
| **ISL radius/attenuation** | `Features/InverseSquareLighting/RadiusMath.h` (`ISLMath`) | closed-form radius, shadow/override branches, NaN→1, attenuation peak/vanish/monotonic | physics correctness |
| **Shadow-pointer validator** | `Features/LightLimitFix/ShadowCasterMath.h` `IsPlausibleShadowLightPtr` | null/misaligned/non-canonical/kernel-space rejection | memory safety — the OOB-CTD guard |
| **Frame-time P90** | same header, `FrameTimePercentile90` | empty fallback, P90 element, count<window | scheduler budgeting |
| **LLF sanitize** | `Features/LightLimitFix/SettingsSanitize.h` `SanitizeFloat` | clamp, exact bounds, NaN/±inf→lo | GPU crash-guard |

`InverseSquareLighting`, `ShadowCasterManager` (validator + percentile), and `LightLimitFix::GetCommonBufferData` now delegate to these headers; call sites unchanged.

## Build note (no `/bigobj` needed)

`ShadowCasterManager.cpp` (exprtk-heavy) initially overflowed the COFF section limit under MSVC 14.50 (`C1128`) when the header change forced its recompile, so `/bigobj` was added as a stopgap. Extracting the math into headers shrank the translation unit back under the section limit, so `/bigobj` was **dropped** again — the two build commits net to zero and the plugin target is unchanged from `dev`. Verified by a clean local plugin build under MSVC 14.50 without `/bigobj`. (CI's VS2022 was never affected.)

## Validation

- cpp suite: **218 assertions / 61 cases**.
- Plugin (`CommunityShaders`) builds clean locally (MSVC 14.50) with all delegations — no `/bigobj` on the plugin target.

## Deferred (with reasons) — not in this PR

- **FormulaHelper** (exprtk): extractable but pulls the ~1.5 MB `exprtk` header into the `cpp_tests` binary, turning test builds from seconds → minutes. Needs a decision (separate opt-in slow-tests target vs accept the cost) → its own PR.
- **FileSystem**: deeper coupling than the `IEquals` issue suggested — `FileSystem.h` drags `Format.h` + `WinApi.h`, both referencing `REL::Version`. Needs `SanitizeFileName`/`DiffJson` lifted into a pure TU.
- **A/B `mean`/`median`**: trivial near-duplicates of the already-tested `PerfUtils::Mean/Median` — negligible marginal value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal lighting and shadow math into testable modules and centralized validation utilities for improved maintainability.

* **Bug Fixes**
  * Improved robustness of light value sanitization (non-finite values now reliably fallback) and more reliable shadow-light/frametime handling.

* **Tests**
  * Added comprehensive unit tests covering lighting math, shadow-pointer/frametime helpers, and sanitizer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
