### PR TITLE
ci: rolling dev prerelease + publish action

### DIFF
--- a/.github/actions/publish-release/action.yaml
+++ b/.github/actions/publish-release/action.yaml
@@ -1,0 +1,106 @@
+name: "Publish Release"
+description: "Download the dist artifact and create-or-update a GitHub release via ncipollo. Shared by pr-checks, release-dev, and release-build so the ncipollo pin and the allowUpdates/replaces/removeArtifacts invariants live in one place."
+
+inputs:
+    token:
+        description: >
+            Token for the release API. Pass GITHUB_TOKEN (not a PAT) for
+            prereleases that must NOT re-trigger release-build.yaml's
+            `release: created` — releases created with GITHUB_TOKEN do not
+            trigger other workflows.
+        required: true
+    tag:
+        description: "Release tag."
+        required: true
+    name:
+        description: "Release display name."
+        required: true
+    commit:
+        description: "Commit the tag should point at (ncipollo `commit`). Empty == ncipollo default."
+        required: false
+        default: ""
+    artifacts:
+        description: "Glob of artifact files to attach."
+        required: false
+        default: "${{ github.workspace }}/dist/*.7z"
+    body:
+        description: "Inline release body (markdown). Used only when body-file is empty."
+        required: false
+        default: ""
+    body-file:
+        description: "Path to a release-body file. When set, `body` is ignored."
+        required: false
+        default: ""
+    prerelease:
+        description: "Mark as a prerelease."
+        required: false
+        default: "false"
+    draft:
+        description: "Create as a draft."
+        required: false
+        default: "false"
+    omit-draft-during-update:
+        description: "ncipollo omitDraftDuringUpdate — keep an already-published release published on update."
+        required: false
+        default: "false"
+    generate-release-notes:
+        description: "Let GitHub auto-generate release notes."
+        required: false
+        default: "false"
+    download-artifact:
+        description: "Download the workflow artifact into ./dist first. Set false if the caller already downloaded it."
+        required: false
+        default: "true"
+    artifact-name:
+        description: "Workflow artifact to download when download-artifact is true."
+        required: false
+        default: "dist-artifacts"
+
+runs:
+    using: "composite"
+    steps:
+        - name: Download dist artifact
+          if: inputs.download-artifact == 'true'
+          uses: actions/download-artifact@v7
+          with:
+              name: ${{ inputs.artifact-name }}
+              path: dist/
+
+        # Two gated invocations so `body` and `bodyFile` are NEVER passed
+        # together: ncipollo does not reliably defer an empty `body` to
+        # `bodyFile`, so passing both could blank a file-based caller's body.
+        - name: Create or update release (body file)
+          if: inputs.body-file != ''
+          uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
+          with:
+              token: ${{ inputs.token }}
+              tag: ${{ inputs.tag }}
+              commit: ${{ inputs.commit }}
+              name: ${{ inputs.name }}
+              artifacts: ${{ inputs.artifacts }}
+              bodyFile: ${{ inputs.body-file }}
+              prerelease: ${{ inputs.prerelease }}
+              draft: ${{ inputs.draft }}
+              omitDraftDuringUpdate: ${{ inputs.omit-draft-during-update }}
+              generateReleaseNotes: ${{ inputs.generate-release-notes }}
+              allowUpdates: true
+              replacesArtifacts: true
+              removeArtifacts: true
+
+        - name: Create or update release (inline / generated body)
+          if: inputs.body-file == ''
+          uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
+          with:
+              token: ${{ inputs.token }}
+              tag: ${{ inputs.tag }}
+              commit: ${{ inputs.commit }}
+              name: ${{ inputs.name }}
+              artifacts: ${{ inputs.artifacts }}
+              body: ${{ inputs.body }}
+              prerelease: ${{ inputs.prerelease }}
+              draft: ${{ inputs.draft }}
+              omitDraftDuringUpdate: ${{ inputs.omit-draft-during-update }}
+              generateReleaseNotes: ${{ inputs.generate-release-notes }}
+              allowUpdates: true
+              replacesArtifacts: true
+              removeArtifacts: true

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -136,8 +136,9 @@ jobs:
             shader-tests-should-build: ${{ needs.check-changes.outputs.shader-tests-should-build || 'true' }}
             cpp-tests-should-build: ${{ needs.check-changes.outputs.cpp-tests-should-build || 'true' }}
 
-    # Security: this job uses GITHUB_TOKEN with write permissions but does NOT execute
-    # fork code — it only downloads pre-built artifacts from the build job above.
+    # Security: this job has GITHUB_TOKEN write permissions but executes no fork
+    # code. It sparse-checks-out the BASE branch (trusted) for the
+    # publish-release composite and downloads the build job's pre-built artifacts.
     prerelease:
         name: Post Prerelease from PR
         needs: [build]
@@ -149,6 +150,14 @@ jobs:
             contents: write
             pull-requests: write
         steps:
+            # Sparse-checkout only the composite action. Under
+            # pull_request_target the default ref is the BASE branch, so this
+            # introduces no fork code into this write-token job.
+            - name: Check out composite action
+              uses: actions/checkout@v6
+              with:
+                  sparse-checkout: .github/actions
+
             - name: Download dist artifacts
               uses: actions/download-artifact@v7
               with:
@@ -193,29 +202,27 @@ jobs:
 
             - name: Upload prerelease (custom notes)
               if: steps.gen_notes.outputs.notes_generated == 'true'
-              uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
+              uses: ./.github/actions/publish-release
               with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
                   name: "Open Shaders ${{ needs.build.outputs.version }} PR #${{ github.event.pull_request.number }}"
                   tag: v${{ needs.build.outputs.version }}-pr${{ github.event.pull_request.number }}
-                  prerelease: true
+                  prerelease: "true"
                   artifacts: "${{ github.workspace }}/dist/CommunityShaders_AIO-*.7z"
-                  bodyFile: release-notes.md
-                  allowUpdates: true
-                  replacesArtifacts: true
-                  removeArtifacts: true
+                  body-file: release-notes.md
+                  download-artifact: "false"
 
             - name: Upload prerelease (auto-generated notes)
               if: steps.gen_notes.outputs.notes_generated != 'true'
-              uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
+              uses: ./.github/actions/publish-release
               with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
                   name: "Open Shaders ${{ needs.build.outputs.version }} PR #${{ github.event.pull_request.number }}"
                   tag: v${{ needs.build.outputs.version }}-pr${{ github.event.pull_request.number }}
-                  prerelease: true
+                  prerelease: "true"
                   artifacts: "${{ github.workspace }}/dist/CommunityShaders_AIO-*.7z"
-                  generateReleaseNotes: true
-                  allowUpdates: true
-                  replacesArtifacts: true
-                  removeArtifacts: true
+                  generate-release-notes: "true"
+                  download-artifact: "false"
 
             - name: Comment on PR
               if: success()

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -87,6 +87,15 @@ jobs:
         permissions:
             contents: write
         steps:
+            # Sparse-checkout the composite action FIRST: actions/checkout's
+            # default clean would wipe the artifacts downloaded below if it ran
+            # after them. Only .github/actions is fetched; gh still resolves the
+            # repo via GH_REPO in the notes step.
+            - name: Check out composite action
+              uses: actions/checkout@v6
+              with:
+                  sparse-checkout: .github/actions
+
             - name: Ensure ref is a tag
               if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
               shell: bash
@@ -112,17 +121,13 @@ jobs:
             - name: Generate combined release notes
               id: combined_notes
               shell: bash
-              # GH_TOKEN is required for `gh release view` — without it the
-              # call silently failed and the `||` fallback wrote an empty
-              # file, which then clobbered the existing release body when
-              # ncipollo updated it (this happened on v1.5.1).
-              #
-              # GH_REPO is required because this job downloads artifacts but
-              # never runs actions/checkout. Without it `gh` falls back to
-              # `git remote` to infer the repo and dies with "fatal: not a
-              # git repository" — which then mismatches the `release not
-              # found` fallback grep and aborts the whole step (this
-              # happened on v1.5.2: run 25871339509).
+              # GH_TOKEN: required for `gh release view`; without it the `||`
+              # fallback wrote an empty file that clobbered the release body on
+              # update (v1.5.1).
+              # GH_REPO: pinned so `gh` never infers the repo from git remotes.
+              # The checkout above is sparse (actions-only), so don't rely on its
+              # remote config -- inference once died "fatal: not a git repository"
+              # and aborted the step (v1.5.2 run 25871339509).
               env:
                   GH_TOKEN: ${{ github.token }}
                   GH_REPO: ${{ github.repository }}
@@ -172,19 +177,16 @@ jobs:
                   echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
 
             - name: Create or Update Release
-              id: create_release
-              uses: ncipollo/release-action@v1
+              uses: ./.github/actions/publish-release
               with:
+                  token: ${{ github.token }}
                   name: "Open Shaders ${{ steps.combined_notes.outputs.release_tag }}"
-                  draft: true
-                  omitDraftDuringUpdate: true
                   tag: ${{ steps.combined_notes.outputs.release_tag }}
+                  draft: "true"
+                  omit-draft-during-update: "true"
                   artifacts: "${{ github.workspace }}/dist/*.7z"
-                  bodyFile: ${{ steps.combined_notes.outputs.body_file }}
-                  generateReleaseNotes: false
-                  replacesArtifacts: true
-                  removeArtifacts: true
-                  allowUpdates: true
+                  body-file: ${{ steps.combined_notes.outputs.body_file }}
+                  download-artifact: "false"
 
     nexus-dry-run:
         # Chained from `release` to avoid the artifact-attachment race a

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -1,0 +1,138 @@
+name: "Release: Dev Rolling Prerelease"
+
+# Builds dev-HEAD and refreshes one rolling `dev-latest` prerelease so the
+# post-merge integration state is always testable without manually cutting an
+# RC -- per-PR builds validate the PR branch, not the squash-merge result, and
+# RCs are manual (release-semantic). Trigger/step rationale is inline below.
+
+on:
+    push:
+        branches: [dev]
+        # Skip docs-only / non-buildable pushes: the rolling release still
+        # reflects the latest *binary* state from the prior build.
+        paths:
+            - "**.cpp"
+            - "**.h"
+            - "**.hpp"
+            - "**.c"
+            - "**.hlsl"
+            - "**.hlsli"
+            - "**.ini"
+            - "src/**"
+            - "include/**"
+            - "features/**"
+            - "package/Shaders/**"
+            - "tests/**"
+            - "CMakeLists.txt"
+            - "CMakePresets.json"
+            - "vcpkg.json"
+            - "vcpkg-configuration.json"
+            - ".gitmodules"
+            - "extern/**"
+            - "cmake/**"
+            - ".github/workflows/release-dev.yaml"
+            - ".github/workflows/_shared-build.yaml"
+            - ".github/actions/**"
+            - ".github/configs/**"
+    schedule:
+        # Nightly floor: the push path is a reset-debounce (below), so a fast
+        # push cadence could starve it -- this guarantees >=1 build/day and
+        # self-skips quiet days. 06:00 UTC clears maint-cleanup (02:00) and
+        # maint-upstream-sync (Mon 08:00).
+        - cron: "0 6 * * *"
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+# Newest-wins: a new push cancels any in-flight run. Safe as one group (vs
+# auto-rebase's split jobs) because publishing is idempotent (ncipollo
+# allowUpdates), so a cancelled publish just re-runs.
+concurrency:
+    group: release-dev
+    cancel-in-progress: true
+
+jobs:
+    debounce:
+        name: Debounce / nightly-floor gate
+        runs-on: ubuntu-latest
+        outputs:
+            should-build: ${{ steps.gate.outputs.should-build }}
+        steps:
+            - name: Decide whether to build
+              id: gate
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  set -euo pipefail
+                  if [ "${{ github.event_name }}" != "schedule" ]; then
+                    echo "should-build=true" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+                  # Nightly floor: only rebuild if dev actually moved, so quiet
+                  # days don't burn a runner re-publishing an identical build.
+                  since=$(date -u -d '25 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+                  count=$(gh api "repos/${{ github.repository }}/commits?sha=dev&since=${since}" --jq 'length' 2>/dev/null || echo 0)
+                  if [ "${count:-0}" -gt 0 ]; then
+                    echo "Nightly floor: ${count} dev commit(s) since ${since} — building."
+                    echo "should-build=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "Nightly floor: no dev commits since ${since} — skipping."
+                    echo "should-build=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Coalesce a burst of merges
+              # 30 min reset-debounce: folds a merge storm into one build and
+              # matches auto-rebase's cadence. The nightly cron is the floor.
+              if: github.event_name == 'push'
+              run: sleep 1800
+
+    build:
+        name: Build dev-HEAD
+        needs: debounce
+        if: needs.debounce.outputs.should-build == 'true'
+        # Trusted (own-repo) build — full suite is the dev integration gate.
+        # Build github.sha for every event: the pushed commit on push, dev tip
+        # on the nightly cron (dev is the default branch), or the dispatched
+        # ref. The body + dev-latest tag reference the same SHA, so testers are
+        # always pointed at the exact commit that was built.
+        uses: ./.github/workflows/_shared-build.yaml
+        with:
+            ref: ${{ github.sha }}
+            repository: ${{ github.repository }}
+            run-cpp: true
+            run-shader-validation: true
+            run-shader-tests: true
+            run-cpp-tests: true
+
+    prerelease:
+        name: Publish rolling dev-latest prerelease
+        needs: build
+        if: needs.build.outputs.cpp-built == 'true'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            # Local composite actions need the repo in the workspace.
+            - name: Check out composite action
+              uses: actions/checkout@v6
+              with:
+                  sparse-checkout: .github/actions
+
+            - name: Refresh dev-latest prerelease
+              uses: ./.github/actions/publish-release
+              with:
+                  # GITHUB_TOKEN (not a PAT) so this can't trigger release-build.
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  # Non-semver tag: dodges maint-cleanup and the dev branch name.
+                  tag: dev-latest
+                  # Point the rolling tag at the built commit (matches the body).
+                  commit: ${{ github.sha }}
+                  name: "Open Shaders (dev) — latest build ${{ needs.build.outputs.version }}"
+                  prerelease: "true"
+                  artifacts: "${{ github.workspace }}/dist/CommunityShaders_AIO-*.7z"
+                  body: |
+                      Rolling build of `dev` at commit ${{ github.sha }}.
+
+                      ⚠️ Unstable integration build for testing — not a release.
+                      For stable builds see the latest non-prerelease.


### PR DESCRIPTION
## What

Adds an automatic **rolling `dev-latest` prerelease** so the post-merge dev-HEAD integration state is always testable without manually cutting an RC, and consolidates the duplicated release-publish logic into a shared composite action.

### `release-dev.yaml` (new)
- Triggers: push to `dev` (30-min reset-debounce, newest-wins via `cancel-in-progress`), a **nightly cron floor** (06:00 UTC, self-skips when `dev` hasn't moved in 25h), and `workflow_dispatch`.
- Builds dev-HEAD through the existing `_shared-build.yaml` (full suite: cpp + shader validation + shader tests + cpp tests) and refreshes one `dev-latest` GitHub prerelease with the AIO attached.
- Published with `GITHUB_TOKEN` so it can't loop into `release-build.yaml`'s `release: created`; the non-semver `dev-latest` tag dodges `maint-cleanup-releases` and never collides with the `dev` branch name.

### `.github/actions/publish-release` (new composite)
- Extracts the shared "download dist + ncipollo (`allowUpdates`/`replacesArtifacts`/`removeArtifacts`)" pattern.
- All **4** call sites now route through it: `release-dev` (×1), `pr-checks` (×2), `release-build` (×1). ncipollo is now pinned in exactly one place (`release-build` also moves from unpinned `@v1` → SHA-pinned via the composite).

## Notes
- Consuming jobs sparse-checkout `.github/actions` (local actions need the repo in the workspace). Under `pull_request_target` the default ref is the **base** branch — no fork code enters the write-token job. In `release-build` the checkout is placed first so `actions/checkout`'s default clean can't wipe the downloaded artifacts.
- The `pr-checks`/`release-build` edits resolve from the base branch, so they take effect only **after** this merges to `dev` and aren't exercised by this PR's own checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release publishing and artifact handling for more reliable uploads and updates.
* **New Features**
  * Automated rolling dev prereleases: scheduled and push-triggered builds now publish refreshed dev-latest prereleases with attached build artifacts for earlier access to in-progress changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/open-shaders/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->