### PR TITLE
refactor(llf): unify particle stem extraction

### DIFF
--- a/src/Features/LightLimitFix/Particle.cpp
+++ b/src/Features/LightLimitFix/Particle.cpp
@@ -6,31 +6,15 @@
 #include "Globals.h"
 #include "Shadercache.h"
 #include "Util.h"
+#include "Utils/StringUtils.h"
 
 #include <algorithm>
-#include <cctype>
 #include <cmath>
 #include <limits>
 
 namespace
 {
 	constexpr uint MAX_LIGHTS = 1024;
-
-	char ToLowerAscii(char a_char)
-	{
-		return static_cast<char>(std::tolower(static_cast<unsigned char>(a_char)));
-	}
-
-	bool EndsWithDdsInsensitive(std::string_view a_filename)
-	{
-		if (a_filename.size() < 4)
-			return false;
-		const std::string_view ext = a_filename.substr(a_filename.size() - 4);
-		return ToLowerAscii(ext[0]) == '.' &&
-		       ToLowerAscii(ext[1]) == 'd' &&
-		       ToLowerAscii(ext[2]) == 'd' &&
-		       ToLowerAscii(ext[3]) == 's';
-	}
 
 	bool IsNearWhiteTint(const RE::NiColorA& a_color)
 	{
@@ -200,28 +184,6 @@ namespace
 		       std::max(a_tint.blue, 0.0f);
 	}
 
-	std::string ExtractTextureStem(std::string_view a_path)
-	{
-		if (a_path.empty())
-			return {};
-
-		auto lastSeparatorPos = a_path.find_last_of("\\/");
-		std::string_view filename = (lastSeparatorPos == std::string::npos) ? a_path : a_path.substr(lastSeparatorPos + 1);
-		if (filename.empty() || !EndsWithDdsInsensitive(filename))
-			return {};
-
-		filename.remove_suffix(4);  // Remove ".dds"
-		if (filename.empty())
-			return {};
-
-		std::string textureName{};
-		textureName.reserve(filename.size());
-		for (char c : filename)
-			textureName.push_back(ToLowerAscii(c));
-
-		return textureName;
-	}
-
 	struct VertexColor
 	{
 		std::uint8_t data[4];
@@ -254,8 +216,7 @@ namespace
 			}
 		}
 #if defined(_MSC_VER)
-		__except (1)
-		{
+		__except (1) {
 			return false;
 		}
 #endif
@@ -350,12 +311,12 @@ LightLimitFix::ParticleLightReference LightLimitFix::GetParticleLightConfigs(RE:
 	if (material->sourceTexturePath.empty())
 		return {};
 
-	std::string textureName = ExtractTextureStem(material->sourceTexturePath.c_str());
-	if (textureName.empty())
+	auto textureName = Util::GetLowercaseStem(material->sourceTexturePath.c_str(), ".dds");
+	if (!textureName)
 		return cacheInvalidReference(node);
 
 	auto& configs = particleLights.particleLightConfigs;
-	auto it = configs.find(textureName);
+	auto it = configs.find(*textureName);
 	if (it == configs.end())
 		return cacheInvalidReference(node);
 
@@ -365,10 +326,10 @@ LightLimitFix::ParticleLightReference LightLimitFix::GetParticleLightConfigs(RE:
 	if (!material->greyscaleTexturePath.empty()) {
 		// Gradients are an optional override: a missing entry falls back to the base
 		// config rather than disabling the particle light entirely.
-		const std::string gradientName = ExtractTextureStem(material->greyscaleTexturePath.c_str());
-		if (!gradientName.empty()) {
+		const auto gradientName = Util::GetLowercaseStem(material->greyscaleTexturePath.c_str(), ".dds");
+		if (gradientName) {
 			auto& gradientConfigs = particleLights.particleLightGradientConfigs;
-			if (auto itGradient = gradientConfigs.find(gradientName); itGradient != gradientConfigs.end()) {
+			if (auto itGradient = gradientConfigs.find(*gradientName); itGradient != gradientConfigs.end()) {
 				hasGradientConfig = true;
 				gradientConfig = itGradient->second;
 			}

--- a/src/Features/LightLimitFix/ParticleLights.cpp
+++ b/src/Features/LightLimitFix/ParticleLights.cpp
@@ -1,10 +1,10 @@
 #include "Features/LightLimitFix/ParticleLights.h"
 
+#include "Utils/StringUtils.h"
+
 #include <algorithm>
-#include <cctype>
 #include <cmath>
 #include <exception>
-#include <optional>
 
 namespace
 {
@@ -16,26 +16,6 @@ namespace
 		if (!std::isfinite(f))
 			return a_default;
 		return std::clamp(f, a_min, a_max);
-	}
-
-	std::optional<std::string> ExtractIniStem(const std::string& path)
-	{
-		auto lastSeparatorPos = path.find_last_of("\\/");
-		if (lastSeparatorPos == std::string::npos) {
-			logger::error("[LLF] Path incomplete");
-			return std::nullopt;
-		}
-
-		std::string filename = path.substr(lastSeparatorPos + 1);
-		if (filename.size() < 4) {
-			logger::error("[LLF] Path too short");
-			return std::nullopt;
-		}
-
-		filename.erase(filename.length() - 4);  // Remove ".ini"
-		std::transform(filename.begin(), filename.end(), filename.begin(),
-			[](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-		return filename;
 	}
 }
 
@@ -77,7 +57,7 @@ void ParticleLights::GetConfigs()
 				data.colorMult.blue = SanitizeIniFloat(ini.GetDoubleValue("Light", "ColorMultBlue", 1.0), 0.0f, 16.0f, 1.0f);
 				data.radiusMult = SanitizeIniFloat(ini.GetDoubleValue("Light", "RadiusMult", 1.0), 0.0f, 16.0f, 1.0f);
 
-				const auto filename = ExtractIniStem(path);
+				const auto filename = Util::GetLowercaseStem(path, ".ini");
 				if (!filename) {
 					continue;
 				}
@@ -151,7 +131,7 @@ void ParticleLights::GetConfigs()
 				continue;
 			}
 
-			const auto filename = ExtractIniStem(path);
+			const auto filename = Util::GetLowercaseStem(path, ".ini");
 			if (!filename) {
 				continue;
 			}

--- a/src/Utils/StringUtils.h
+++ b/src/Utils/StringUtils.h
@@ -1,0 +1,64 @@
+// Self-contained string/path helpers.
+//
+// Header-only and dependency-free (no PCH, RE, or SKSE) so the pure logic can be
+// unit-tested directly in tests/cpp. Heavier string formatting lives in Format.h.
+
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace Util
+{
+	/**
+	 * @brief Lowercases the ASCII letters in @p a_str, returning a new string.
+	 *
+	 * The C++ standard library has no whole-string lowercase, so this wraps the
+	 * canonical std::tolower idiom. Locale-independent for ASCII; suitable for
+	 * case-insensitive matching of asset paths.
+	 *
+	 * @param a_str Input text.
+	 * @return A lowercased copy of @p a_str.
+	 */
+	inline std::string ToLowerAscii(std::string_view a_str)
+	{
+		std::string result;
+		result.reserve(a_str.size());
+		for (char c : a_str)
+			result.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+		return result;
+	}
+
+	/**
+	 * @brief Extracts the lowercased filename stem from a path, requiring a given extension.
+	 *
+	 * Uses std::filesystem to split the path (matching the extension+stem idiom used
+	 * elsewhere in the codebase, e.g. TerrainShadows / FeatureIssues), verifies the
+	 * extension case-insensitively, then lowercases the stem. Used to match asset
+	 * filenames (e.g. a `.dds` texture or `.ini` config) against keyed lookup tables.
+	 *
+	 * @param a_path Path to a file, absolute or relative.
+	 * @param a_extension Required extension including the leading dot, e.g. ".dds" or ".ini".
+	 * @return The lowercased stem, or std::nullopt when the extension doesn't match or
+	 *         the stem is empty. Note std::filesystem treats a leading-dot-only name
+	 *         (e.g. ".dds") as a stem with no extension, so those are rejected here too.
+	 */
+	inline std::optional<std::string> GetLowercaseStem(const std::filesystem::path& a_path, std::string_view a_extension)
+	{
+		const std::string extension = a_path.extension().string();
+		if (extension.size() != a_extension.size() ||
+			!std::equal(extension.begin(), extension.end(), a_extension.begin(),
+				[](unsigned char x, unsigned char y) { return std::tolower(x) == std::tolower(y); }))
+			return std::nullopt;
+
+		const std::string stem = a_path.stem().string();
+		if (stem.empty())
+			return std::nullopt;
+
+		return ToLowerAscii(stem);
+	}
+}

--- a/src/Utils/StringUtils.h
+++ b/src/Utils/StringUtils.h
@@ -41,21 +41,30 @@ namespace Util
 	 * extension case-insensitively, then lowercases the stem. Used to match asset
 	 * filenames (e.g. a `.dds` texture or `.ini` config) against keyed lookup tables.
 	 *
-	 * @param a_path Path to a file, absolute or relative.
+	 * @param a_path Path to a file, absolute or relative. Both `\` and `/` separators
+	 *               are accepted on every platform.
 	 * @param a_extension Required extension including the leading dot, e.g. ".dds" or ".ini".
 	 * @return The lowercased stem, or std::nullopt when the extension doesn't match or
 	 *         the stem is empty. Note std::filesystem treats a leading-dot-only name
 	 *         (e.g. ".dds") as a stem with no extension, so those are rejected here too.
 	 */
-	inline std::optional<std::string> GetLowercaseStem(const std::filesystem::path& a_path, std::string_view a_extension)
+	inline std::optional<std::string> GetLowercaseStem(std::string_view a_path, std::string_view a_extension)
 	{
-		const std::string extension = a_path.extension().string();
+		// Normalize `\` to `/` before parsing: game asset paths use backslashes, but
+		// std::filesystem only treats them as separators on Windows. This keeps the
+		// helper separator-agnostic on every platform (matching the hand-rolled code
+		// it replaced) so the unit tests aren't Windows-only.
+		std::string normalized(a_path);
+		std::replace(normalized.begin(), normalized.end(), '\\', '/');
+		const std::filesystem::path path = normalized;
+
+		const std::string extension = path.extension().string();
 		if (extension.size() != a_extension.size() ||
 			!std::equal(extension.begin(), extension.end(), a_extension.begin(),
 				[](unsigned char x, unsigned char y) { return std::tolower(x) == std::tolower(y); }))
 			return std::nullopt;
 
-		const std::string stem = a_path.stem().string();
+		const std::string stem = path.stem().string();
 		if (stem.empty())
 			return std::nullopt;
 

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(cpp_tests
     test_restartsettings.cpp
     test_sphericalharmonics.cpp
     test_input.cpp
+    test_stringutils.cpp
     # Compile the unit-under-test directly into the test binary so we don't
     # depend on the plugin DLL build (which pulls in FFX/Streamline/etc.).
     "${CMAKE_SOURCE_DIR}/src/Utils/Subrect.cpp"

--- a/tests/cpp/test_stringutils.cpp
+++ b/tests/cpp/test_stringutils.cpp
@@ -1,0 +1,44 @@
+// Unit tests for Util string/path helpers (src/Utils/StringUtils.h).
+//
+// Header-only, pure logic. No game/D3D/ImGui dependency.
+
+#include "Utils/StringUtils.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("ToLowerAscii folds only ASCII letters", "[stringutils]")
+{
+	REQUIRE(Util::ToLowerAscii("MixedCASE") == "mixedcase");
+	REQUIRE(Util::ToLowerAscii("already_lower-123") == "already_lower-123");
+	REQUIRE(Util::ToLowerAscii("") == "");
+	// Non-letters (digits, punctuation) pass through unchanged.
+	REQUIRE(Util::ToLowerAscii("MX_LightGlow01.DDS") == "mx_lightglow01.dds");
+}
+
+TEST_CASE("GetLowercaseStem strips directory, extension, and lowercases", "[stringutils]")
+{
+	REQUIRE(Util::GetLowercaseStem("Data\\ParticleLights\\CandleGlow01.dds", ".dds") == "candleglow01");
+	REQUIRE(Util::GetLowercaseStem("Data/ParticleLights/CandleGlow01.dds", ".dds") == "candleglow01");
+	// Bare filename with no directory component.
+	REQUIRE(Util::GetLowercaseStem("MX_LightGlow01.dds", ".dds") == "mx_lightglow01");
+}
+
+TEST_CASE("GetLowercaseStem matches the extension case-insensitively", "[stringutils]")
+{
+	REQUIRE(Util::GetLowercaseStem("foo.DDS", ".dds") == "foo");
+	REQUIRE(Util::GetLowercaseStem("foo.DdS", ".dds") == "foo");
+	REQUIRE(Util::GetLowercaseStem("bar.INI", ".ini") == "bar");
+}
+
+TEST_CASE("GetLowercaseStem rejects mismatched or degenerate paths", "[stringutils]")
+{
+	// Wrong extension.
+	REQUIRE(Util::GetLowercaseStem("foo.ini", ".dds") == std::nullopt);
+	// Empty path.
+	REQUIRE(Util::GetLowercaseStem("", ".dds") == std::nullopt);
+	// Extension-only filename leaves an empty stem.
+	REQUIRE(Util::GetLowercaseStem(".dds", ".dds") == std::nullopt);
+	REQUIRE(Util::GetLowercaseStem("Data\\Lights\\.dds", ".dds") == std::nullopt);
+	// No extension at all.
+	REQUIRE(Util::GetLowercaseStem("foo", ".dds") == std::nullopt);
+}


### PR DESCRIPTION
## What

`Particle.cpp` and `ParticleLights.cpp` each carried a near-duplicate
filename-stem extractor — `ExtractTextureStem` (`.dds`) and
`ExtractIniStem` (`.ini`) — plus their own ad-hoc ASCII lowercasing.
This unifies them into a single `Util::GetLowercaseStem(path, ext)` in a
new header-only `src/Utils/StringUtils.h`.

## Why this shape

- **Leans on the wheel.** The helper splits paths with
  `std::filesystem::path::stem()/extension()` — the same idiom already
  used elsewhere in the repo (`TerrainShadows.cpp`, `FeatureIssues.cpp`)
  — instead of hand-rolling `find_last_of` + suffix scanning. It then
  gates the extension case-insensitively and lowercases the stem.
- **Only wraps what std lacks.** C++ has no whole-string lowercase or
  case-insensitive string compare, so those two small primitives stay
  inline (`ToLowerAscii`). Maintained alternatives exist
  (`pystring::lower`, `Util::IEquals`) but pulling them in would re-break
  standalone testability — neither is linked into `cpp_tests`, and
  `IEquals` lives in the PCH-heavy `Format.cpp`.
- **Dependency-free header** (no PCH/RE/SKSE) so the pure logic is
  unit-testable directly in `tests/cpp`.

## Tests

Adds `tests/cpp/test_stringutils.cpp` (Catch2): directory stripping
(`\` and `/`), case-insensitive extension matching, and the
empty/mismatched/dotfile cases the old per-file copies guarded
inconsistently. Full C++ suite: **47 cases / 176 assertions pass**.

## Behavior

No change for valid particle-light packs — configs always arrive as
well-formed `Data\ParticleLights\*.ini` / `*.dds` paths.
`std::filesystem`'s dotfile rule additionally rejects extension-only
names (`.dds`), which the two old copies handled inconsistently.

## Note

The diff includes one incidental one-line brace normalization in
`TryGetMaxAlphaVertexColor` (`__except (1) {`) — a pre-existing Allman
inconsistency the mandatory `clang-format` pre-commit hook corrects when
the file is touched. It is not a logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate string processing utilities into a centralized module for improved code maintainability and consistency.

* **Tests**
  * Added comprehensive unit tests for string utility functions to ensure reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/open-shaders/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->