### PR TITLE
refactor(llf): align cluster light cap

### DIFF
--- a/features/Light Limit Fix/Shaders/LightLimitFix/ClusterCullingCS.hlsl
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/ClusterCullingCS.hlsl
@@ -18,8 +18,6 @@ RWStructuredBuffer<uint> lightIndexCounter : register(u0);
 RWStructuredBuffer<uint> lightIndexList : register(u1);
 RWStructuredBuffer<LightGrid> lightGrid : register(u2);
 
-groupshared Light sharedLights[GROUP_SIZE];
-
 bool LightIntersectsCluster(float3 position, float radiusSquared, ClusterAABB cluster)
 {
 	float3 closest = max(cluster.minPoint.xyz, min(position, cluster.maxPoint.xyz));
@@ -42,14 +40,10 @@ bool LightIntersectsCluster(float3 position, float radiusSquared, ClusterAABB cl
 
 	ClusterAABB cluster = clusters[clusterIndex];
 
-	if (groupIndex < LightCount) {
-		uint lightIndex = groupIndex;
-		Light light = lights[lightIndex];
-		sharedLights[groupIndex] = light;
-	}
-
-	GroupMemoryBarrierWithGroupSync();
-
+	// Threads read the global lights buffer directly (cached); with no
+	// inter-thread sharing there is nothing to synchronize, so no barriers. Dead
+	// groupshared staging was removed here -- do not re-add: Light[GROUP_SIZE] is
+	// 96 KB, over the 32 KB LDS limit, so a live read would not compile.
 	for (uint i = 0; i < LightCount; i++) {
 		Light light = lights[i];
 
@@ -73,8 +67,6 @@ bool LightIntersectsCluster(float3 position, float radiusSquared, ClusterAABB cl
 				break;
 		}
 	}
-
-	GroupMemoryBarrierWithGroupSync();
 
 	uint offset = 0;
 	InterlockedAdd(lightIndexCounter[0], visibleLightCount, offset);

--- a/features/Light Limit Fix/Shaders/LightLimitFix/Common.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/Common.hlsli
@@ -5,7 +5,10 @@
 #define NUMTHREAD_Y 16
 #define NUMTHREAD_Z 4
 #define GROUP_SIZE (NUMTHREAD_X * NUMTHREAD_Y * NUMTHREAD_Z)
-#define MAX_CLUSTER_LIGHTS 256
+// Per-cluster light cap. MUST match LightLimitFix::CLUSTER_MAX_LIGHTS: the C++
+// side sizes the global lightIndexList pool as clusterCount * that value, so a
+// larger cap here can overrun the pool.
+#define MAX_CLUSTER_LIGHTS 128
 
 namespace LightFlags
 {

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -12,6 +12,9 @@ struct LightLimitFix : OverlayFeature
 {
 private:
 	static constexpr uint32_t MAX_LIGHTS = 1024;
+	// Per-cluster visible-light cap; sizes the global lightIndexList pool as
+	// clusterCount * CLUSTER_MAX_LIGHTS. MUST match MAX_CLUSTER_LIGHTS in the
+	// shader-side Common.hlsli or the cull pass can overrun the pool.
 	static constexpr uint32_t CLUSTER_MAX_LIGHTS = 128;
 
 public:


### PR DESCRIPTION
## Summary

Two related cleanups to the LightLimitFix clustered light-culling pass (`ClusterCullingCS.hlsl`), both confirmed by standalone `fxc cs_5_0` compiles (flat + VR) and before/after DXBC disassembly diff. **No observable behavior change in any realistic scene** — this is consistency hardening + dead-code removal, hence `refactor`.

### 1. Align the per-cluster light cap with the index-pool size

`MAX_CLUSTER_LIGHTS` in the shader was **256** while the C++ side allocates the global `lightIndexList` pool as `clusterCount * CLUSTER_MAX_LIGHTS` = **128 per cluster** (`LightLimitFix.h`). The two constants are meant to represent the same quantity, so the shader cap is set to 128 and both sides now cross-reference each other in comments.

In principle a 256 cap could let the summed per-cluster counts overrun the pool (D3D11 silently discards out-of-bounds `RWStructuredBuffer` writes), but in practice this is unreachable: the pool is global and filled via a shared atomic, and the overwhelming majority of clusters hold zero lights, so the average per-cluster count stays far below 128 even in dense scenes. The change is therefore a correctness/consistency hardening, not a user-visible fix. It also halves the per-thread `visibleLightIndices[]` indexable-temp array.

### 2. Remove dead `groupshared` staging (zero codegen change)

The `groupshared Light sharedLights[GROUP_SIZE]` copy and its two `GroupMemoryBarrierWithGroupSync()` calls were vestigial:

- **Never read, in any commit on any branch.** `git log --all -G` for a read of `sharedLights` returns nothing. The inner cull loop has read the global `lights` buffer directly since the first LLF commit (`4118e7f7d`) — a name collision on the original pezcode port: the shared array was renamed `sharedLights` while the global SRV kept the name `lights`, so `lights[i]` always resolved to global memory. PR #697 later removed the batching `while` loop, collapsing the staging into obvious single-element dead code.
- **Could never have worked here.** `Light[GROUP_SIZE]` = 1024 × 96 B = **96 KB**, 3× over the **32 KB** `cs_5_0`/DX11 groupshared limit. A live read would be a hard compile error, so the shader only ever compiled *because* the staging was dead and `fxc` stripped it.
- **Removal is byte-identical in codegen.** The prior shader's DXBC already had zero `dcl_tgsm` and zero `sync_*`. The only DXBC delta in this PR is the `256 → 128` cap from change 1.

## Risk

Low. Change 2 is provably codegen-neutral; change 1 only tightens a cap the allocation already assumed.

## Notes

A larger occupancy optimization for this shader (eliminating the per-thread index array via a two-pass count/write — `fxc` confirms it removes the X4714 occupancy warning) is being evaluated separately with an in-game Tracy A/B; it is intentionally **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
