### PR TITLE
feat(mcp): shader recompile observability

### DIFF
--- a/src/Features/RemoteControl.cpp
+++ b/src/Features/RemoteControl.cpp
@@ -540,7 +540,7 @@ void RemoteControl::RegisterInspectTool()
 							  "monotonically increases each render tick; use as a "
 							  "ground truth for verifying that deferred operations "
 							  "(see `console`) have had time to run.\n"
-							  "  shadercache — { compiling, completedTasks, "
+							  "  shadercache — { plugin, compiling, completedTasks, "
 							  "totalTasks, failedTasks, currentFailedCount, "
 							  "frame_count }. Poll completedTasks against a "
 							  "pre-deploy snapshot to confirm a hot-reloaded "

--- a/src/Features/RemoteControl.cpp
+++ b/src/Features/RemoteControl.cpp
@@ -12,6 +12,7 @@
 #include "Features/RenderDoc.h"
 #include "Features/ScreenshotFeature.h"
 #include "Globals.h"
+#include "ShaderCompileStatus.h"
 #include "State.h"
 
 #include <imgui.h>
@@ -449,6 +450,34 @@ static mcp::json EngineStateBlob()
 	});
 }
 
+// Helper used by inspect(kind="shadercache"): runtime shader (re)compile
+// status, built entirely from existing thread-safe ShaderCache accessors (no
+// added state). Hot-reloading an .hlsl clears its variants and requeues them,
+// so completedTasks advances once the recompile lands — poll it against a
+// pre-deploy snapshot to know the new shader is live. A rising failedTasks /
+// currentFailedCount means a (re)compile failed (otherwise invisible).
+static mcp::json ShaderCacheBlob()
+{
+	const uint frames = globals::state ? globals::state->frameCountAtomic.load(std::memory_order_relaxed) : 0u;
+	const SIE::ShaderCompileStatus s = SIE::GetShaderCompileStatus();
+	if (!s.valid) {
+		return mcp::json({
+			{ "plugin", "CommunityShaders" },
+			{ "frame_count", frames },
+			{ "error", "shaderCache unavailable" },
+		});
+	}
+	return mcp::json({
+		{ "plugin", "CommunityShaders" },
+		{ "frame_count", frames },
+		{ "compiling", s.compiling },
+		{ "completedTasks", s.completedTasks },
+		{ "totalTasks", s.totalTasks },
+		{ "failedTasks", s.failedTasks },
+		{ "currentFailedCount", s.currentFailedCount },
+	});
+}
+
 // Helper used by feature(action="list") to build one entry per feature.
 static mcp::json FeatureEntry(Feature* f)
 {
@@ -510,11 +539,17 @@ void RemoteControl::RegisterInspectTool()
 							  "  state — { plugin, frame_count, vr }. Frame counter "
 							  "monotonically increases each render tick; use as a "
 							  "ground truth for verifying that deferred operations "
-							  "(see `console`) have had time to run.\n\n"
+							  "(see `console`) have had time to run.\n"
+							  "  shadercache — { compiling, completedTasks, "
+							  "totalTasks, failedTasks, currentFailedCount, "
+							  "frame_count }. Poll completedTasks against a "
+							  "pre-deploy snapshot to confirm a hot-reloaded "
+							  "shader finished recompiling; a rising failedTasks "
+							  "/ currentFailedCount means a compile failed.\n\n"
 							  "For feature reads (enumerate / settings), use the "
 							  "`feature` tool with action='list' or 'get'.")
 	                      .with_string_param("kind",
-							  "Currently 'state'. New kinds will be added here "
+							  "'state' or 'shadercache'. New kinds will be added here "
 							  "rather than as new tools.")
 	                      .build();
 	server->register_tool(tool,
@@ -527,9 +562,12 @@ void RemoteControl::RegisterInspectTool()
 			if (kind == "state") {
 				return TextResult(EngineStateBlob().dump());
 			}
+			if (kind == "shadercache") {
+				return TextResult(ShaderCacheBlob().dump());
+			}
 			return ErrorResult("unknown kind",
 				{ { "kind", kind },
-					{ "supported", mcp::json::array({ "state" }) } });
+					{ "supported", mcp::json::array({ "state", "shadercache" }) } });
 		});
 }
 

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -23,14 +23,19 @@ namespace SIE
 		auto* cache = globals::shaderCache;
 		if (!cache)
 			return {};
-		return ShaderCompileStatus{
-			true,
-			cache->IsCompiling(),
-			cache->GetCompletedTasks(),
-			cache->GetTotalTasks(),
-			cache->GetFailedTasks(),
-			cache->GetCurrentFailedCount(),
-		};
+		// Read the task counters once and derive `compiling` from the same
+		// snapshot, so callers never observe compiling=false with work still
+		// outstanding. Named-field init avoids depending on member order.
+		const uint64_t completed = cache->GetCompletedTasks();
+		const uint64_t total = cache->GetTotalTasks();
+		ShaderCompileStatus status{};
+		status.valid = true;
+		status.compiling = completed < total;
+		status.completedTasks = completed;
+		status.totalTasks = total;
+		status.failedTasks = cache->GetFailedTasks();
+		status.currentFailedCount = cache->GetCurrentFailedCount();
+		return status;
 	}
 
 	// Custom include handler to track all includes during shader compilation

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1,5 +1,6 @@
 #include "ShaderCache.h"
 #include "Globals.h"
+#include "ShaderCompileStatus.h"
 #include "ShaderFileWatcher.h"
 #include "Util.h"
 
@@ -14,6 +15,23 @@
 
 namespace SIE
 {
+	// Chrono-free snapshot of compile counters for consumers that can't include
+	// ShaderCache.h (see ShaderCompileStatus.h). Thread-safe: atomics + the
+	// shader-map lock inside GetCurrentFailedCount.
+	ShaderCompileStatus GetShaderCompileStatus()
+	{
+		auto* cache = globals::shaderCache;
+		if (!cache)
+			return {};
+		return ShaderCompileStatus{
+			true,
+			cache->IsCompiling(),
+			cache->GetCompletedTasks(),
+			cache->GetTotalTasks(),
+			cache->GetFailedTasks(),
+			cache->GetCurrentFailedCount(),
+		};
+	}
 
 	// Custom include handler to track all includes during shader compilation
 	class TrackingIncludeHandler : public ID3DInclude
@@ -1488,12 +1506,34 @@ namespace SIE
 					shaderBlob->Release();
 				}
 
+#ifdef TRACY_ENABLE
+				{
+					// Timeline annotation: a (re)compile failed. Pairs with the
+					// MCP shadercache status (failedTasks) for build-agnostic
+					// detection; this gives the exact frame for perf correlation.
+					const auto tracyMsg = std::format("Shader compile FAILED: {} {} {:X}",
+						magic_enum::enum_name(type), magic_enum::enum_name(shaderClass), descriptor);
+					TracyMessageC(tracyMsg.c_str(), tracyMsg.size(), 0xFF4444);
+				}
+#endif
+
 				cache.AddCompletedShader(shaderClass, shader, descriptor, nullptr);
 				return nullptr;
 			}
 			if (errorBlob)
 				logger::debug("Shader logs:\n{}", static_cast<char*>(errorBlob->GetBufferPointer()));
 			logger::debug("Compiled shader {}:{}:{:X}", magic_enum::enum_name(type), magic_enum::enum_name(shaderClass), descriptor);
+
+#ifdef TRACY_ENABLE
+			{
+				// Timeline annotation: a shader (re)compiled successfully. During
+				// a hot-reload this marks the exact frame the new shader went
+				// live, so A/B perf windows split precisely on it.
+				const auto tracyMsg = std::format("Shader compiled: {} {} {:X}",
+					magic_enum::enum_name(type), magic_enum::enum_name(shaderClass), descriptor);
+				TracyMessage(tracyMsg.c_str(), tracyMsg.size());
+			}
+#endif
 
 			// strip debug info
 			if (!globals::state->IsDeveloperMode()) {

--- a/src/ShaderCompileStatus.h
+++ b/src/ShaderCompileStatus.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+
+// Minimal, dependency-free view of the shader (re)compile state for consumers
+// that must NOT pull in ShaderCache.h — notably RemoteControl.cpp, where
+// ShaderCache.h's global-scope `using namespace std::chrono` would leak chrono
+// names (e.g. `last`) into the vendored cpp-mcp headers (httplib/base64) and
+// trip warning-as-error. Defined in ShaderCache.cpp against the live cache.
+namespace SIE
+{
+	struct ShaderCompileStatus
+	{
+		bool valid = false;  ///< false when the shader cache singleton is unavailable
+		bool compiling = false;
+		uint64_t completedTasks = 0;
+		uint64_t totalTasks = 0;
+		uint64_t failedTasks = 0;
+		uint64_t currentFailedCount = 0;
+	};
+
+	/// Snapshot the current shader-cache compile counters. Thread-safe: reads
+	/// atomics and takes the shader-map lock internally. Callable from the
+	/// RemoteControl listener thread.
+	ShaderCompileStatus GetShaderCompileStatus();
+}


### PR DESCRIPTION
## Summary

Surfaces shader (re)compile state two ways from one event, so hot-reload A/B testing stops relying on guesswork.

### MCP (build-agnostic) — new `inspect(kind='shadercache')`
Returns `{ compiling, completedTasks, totalTasks, failedTasks, currentFailedCount, frame_count }`, built entirely from existing thread-safe `ShaderCache` accessors (no new state on the hot class). Poll `completedTasks` against a pre-deploy snapshot to confirm a hot-reloaded shader recompiled; a rising `failedTasks`/`currentFailedCount` surfaces a failed compile that was **previously invisible** (no log-diving).

### Tracy (profiling builds) — recompile messages
`TracyMessage` on success / red `TracyMessageC` on failure at both `CompileShader` completion points, `#ifdef TRACY_ENABLE`-guarded (no formatting cost in normal builds). Gives the exact frame so A/B perf windows split on the recompile via `get_messages()`.

### Decoupling (`ShaderCompileStatus.h`)
`RemoteControl.cpp` must not include `ShaderCache.h` — its global-scope `using namespace std::chrono` leaks chrono names (e.g. `last`) into the vendored cpp-mcp httplib/base64 headers and trips warning-as-error. The status read is exposed through a tiny dependency-free header implemented in `ShaderCache.cpp`.

## Validation
- `ALL-TRACY` build green.
- **Runtime-validated in a live Skyrim SE session**: `inspect(shadercache)` counters climbed through a 3455-task cache rebuild (`compiling: true`, 0 failures), and Tracy showed `"Shader compiled: …"` messages firing per compile alongside `ShaderCompilationTask::Perform` zones.

## Notes
Success messages fire for every compile, so a cold-cache startup emits many (early-timeline, Tracy-only) — acceptable; a follow-up could gate on steady state if it's noise. The MCP counters are the primary, build-agnostic signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shader cache status inspection to diagnostic tools.

* **Bug Fixes**
  * Improved contact-shadow intensity calculations for deferred lighting with clustered lights.

* **Refactor**
  * Enhanced shader compilation diagnostics with performance profiling instrumentation.
  * Refactored Weather Editor UI code for improved readability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/open-shaders/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->