### PR TITLE
style: apply pre-commit formatting

### DIFF
--- a/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
+++ b/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
@@ -27,9 +27,7 @@ namespace WaterEffects
 			float2 causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.2, -0.5);
 
 			const float causticsHigh =
-				(causticsFade > 0.0)
-					? (min(SampleCaustics(causticsUV1), SampleCaustics(causticsUV2)) * 4.0)
-					: 1.0;
+				(causticsFade > 0.0) ? (min(SampleCaustics(causticsUV1), SampleCaustics(causticsUV2)) * 4.0) : 1.0;
 
 			causticsUV *= 0.5;
 
@@ -37,9 +35,7 @@ namespace WaterEffects
 			causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.1, -0.5);
 
 			const float causticsLow =
-				(causticsFade < 1.0)
-					? (min(SampleCaustics(causticsUV1), SampleCaustics(causticsUV2)) * 4.0)
-					: 1.0;
+				(causticsFade < 1.0) ? (min(SampleCaustics(causticsUV1), SampleCaustics(causticsUV2)) * 4.0) : 1.0;
 
 			const float caustics = lerp(causticsLow, causticsHigh, causticsFade);
 			return lerp(1.0, caustics, shoreFactorCaustics);

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -7,8 +7,8 @@ typedef VS_OUTPUT PS_INPUT;
 
 struct PS_OUTPUT
 {
-	float4 Color : SV_Target0;
-	float4 Feedback : SV_Target1;
+	float4 Color: SV_Target0;
+	float4 Feedback: SV_Target1;
 };
 
 #if defined(PSHADER)
@@ -38,9 +38,9 @@ cbuffer PerGeometry : register(b2)
 };
 
 // Decompiler comparison idiom: cmp(expr) => -(expr), used as a truthy mask in ?: selects.
-#define cmp -
+#	define cmp -
 
-#ifdef HDR_OUTPUT
+#	ifdef HDR_OUTPUT
 // Internal working space for TAA is PQ/BT2020.
 // PQ maps [0, 10000 nits] to [0, 1], so the vanilla 1.001 bracket ceiling is correct —
 // nothing in the scene legitimately exceeds 1.0 PQ. This is why PQ avoids the bracket
@@ -69,7 +69,7 @@ float DecodeFeedbackLuma(float gammaLuma)
 	float linearLuma = Color::GammaToLinearSafe(gammaLuma);
 	return DisplayMapping::LinearToPQ(linearLuma.xxx, 10000.0).x;
 }
-#endif
+#	endif
 
 static const float3 kLumaWeights = float3(0.5, 0.25, 0.25);
 
@@ -243,9 +243,9 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 colorOut, feedbackOut;
 
 	// float4 packs — component reuse matches vanilla decompile (see header comment).
-	float4 motionReject, sampleUV, history, corner, tapMin; // was r0–r4
-	float4 tapA0, tapA1, tapB0, tapB1, tapC0, tapC1;       // was r6–r13
-	float4 center, centerMeta, bracketMax, weightedColor, mergeScratch, bracketMinReg; // was r14–r19
+	float4 motionReject, sampleUV, history, corner, tapMin;                             // was r0–r4
+	float4 tapA0, tapA1, tapB0, tapB1, tapC0, tapC1;                                    // was r6–r13
+	float4 center, centerMeta, bracketMax, weightedColor, mergeScratch, bracketMinReg;  // was r14–r19
 
 	float2 drMax = GetDynamicResolutionMax(), drUVMin, drUVMax, drCenter;
 	float4 drNeighborsA, drNeighborsB, drNeighborsC;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2791,14 +2791,14 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 			const bool isClusteredLight = lightIndex >= LightLimitFix::NumStrictLights;
 			bool passesIntensityGate = !isClusteredLight;
 			if (isClusteredLight) {
-#			if defined(ISL)
+#				if defined(ISL)
 				float falloffFactor = saturate(lightDist * light.invRadius);
 				passesIntensityGate = (1.0 - falloffFactor * falloffFactor) >
 				                      SharedData::lightLimitFixSettings.ContactShadowMinIntensity;
-#			else
+#				else
 				passesIntensityGate = intensityMultiplier >
 				                      SharedData::lightLimitFixSettings.ContactShadowMinIntensity;
-#			endif
+#				endif
 			}
 
 			// Particle lights carry both Simple and Particle bits. Simple-only lights are

--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -877,7 +877,7 @@ void HDRDisplay::SetUIBuffer()
 		ID3D11RenderTargetView* targetRTV = uiBufferMode.useUIBuffer ?
 		                                        upscaling.dx12SwapChain.uiBufferWrapped->rtv :
 		                                    uiBufferMode.useFallbackCopy ? fb.RTV :
-		                                                                  upscaling.dx12SwapChain.swapChainBufferWrapped->rtv;
+		                                                                   upscaling.dx12SwapChain.swapChainBufferWrapped->rtv;
 
 		if (uiBufferMode.useUIBuffer) {
 			float clearColor[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
@@ -991,9 +991,9 @@ ID3D11BlendState* HDRDisplay::GetPatchedAlphaBlendState(ID3D11BlendState* origin
 	for (int i = 0; i < slotCount; i++) {
 		const auto& rt = desc.RenderTarget[i];
 		if (rt.BlendEnable &&
-		    (rt.SrcBlendAlpha != D3D11_BLEND_ONE ||
-		     rt.DestBlendAlpha != D3D11_BLEND_INV_SRC_ALPHA ||
-		     rt.BlendOpAlpha != D3D11_BLEND_OP_ADD)) {
+			(rt.SrcBlendAlpha != D3D11_BLEND_ONE ||
+				rt.DestBlendAlpha != D3D11_BLEND_INV_SRC_ALPHA ||
+				rt.BlendOpAlpha != D3D11_BLEND_OP_ADD)) {
 			needsPatch = true;
 			break;
 		}

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -1,7 +1,7 @@
 #include "LightLimitFix.h"
+#include "Features/InverseSquareLighting/Common.h"
 #include "Globals.h"
 #include "InverseSquareLighting.h"
-#include "Features/InverseSquareLighting/Common.h"
 #include "LinearLighting.h"
 #include "Utils/UI.h"
 
@@ -678,8 +678,7 @@ void LightLimitFix::BSLightingShader_SetupGeometry_GeometrySetupConstantPointLig
 		// and is zero-initialised by ClearStrictLightData.
 	}
 #if defined(_MSC_VER)
-	__except (1)
-	{
+	__except (1) {
 		ClearStrictLightData(strictLightDataTemp, false);
 	}
 #endif
@@ -1293,4 +1292,3 @@ void LightLimitFix::Hooks::BSWaterShader_SetupGeometry::thunk(RE::BSShader* This
 	singleton.BSLightingShader_SetupGeometry_Before(Pass);
 	singleton.BSLightingShader_SetupGeometry_After(Pass);
 }
-

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -877,8 +877,7 @@ namespace Hooks
 			       !globals::features::lightLimitFix.CheckParticleLights(a_pass, a_technique);
 		}
 #if defined(_MSC_VER)
-		__except (1)
-		{
+		__except (1) {
 			return false;
 		}
 #endif

--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -58,7 +58,7 @@ namespace ShaderConstants
 				.LandscapeTexture4GlintParameters = 55,
 				.LandscapeTexture5GlintParameters = 56,
 				.LandscapeTexture6GlintParameters = 57,
-				.MaterialObjectRGBScale = 58,	// RGB multipliers for material objects
+				.MaterialObjectRGBScale = 58,  // RGB multipliers for material objects
 
 				.ShadowSampleParam = 18,
 				.EndSplitDistances = 19,

--- a/src/Utils/RestartSettings.h
+++ b/src/Utils/RestartSettings.h
@@ -36,5 +36,4 @@ namespace Util::Settings
 // Convenience macro for building a RestartFieldInfo entry without duplicating
 // the member name string. Requires SettingsT to be standard-layout.
 #define UTIL_RESTART_FIELD(SettingsT, member, userLabel) \
-	Util::Settings::RestartFieldInfo{ #member, userLabel, offsetof(SettingsT, member), sizeof(decltype(SettingsT::member)) }
-
+	Util::Settings::RestartFieldInfo { #member, userLabel, offsetof(SettingsT, member), sizeof(decltype(SettingsT::member)) }

--- a/src/WeatherEditor/Weather/CellLightingWidget.cpp
+++ b/src/WeatherEditor/Weather/CellLightingWidget.cpp
@@ -74,7 +74,8 @@ void CellLightingWidget::DrawWidget()
 			const ImGuiTabItemFlags inheritFlags = GetTabFlagsForOverride(CellLightingTab::kInheritance);
 
 			auto drawInherited = [](bool inherited, auto draw) -> bool {
-				if (inherited) PushInheritedStyle();
+				if (inherited)
+					PushInheritedStyle();
 				const bool result = draw();
 				if (inherited) {
 					Util::AddTooltip("Inherited from lighting template");
@@ -112,23 +113,23 @@ void CellLightingWidget::DrawWidget()
 					int xyDegrees = settings.directionalXY;
 					int zDegrees = settings.directionalZ;
 					if (DrawIfMatchesSearch(CellLightingSetting::kXYRotation, [&](const char* label) {
-						    return drawInherited(settings.inheritDirectionalRotation, [&]() {
-							    return DrawWithHighlight(label, [&]() {
-								    return ImGui::SliderInt(label, &xyDegrees, 0, 360);
-							    });
-						    });
-					    })) {
+							return drawInherited(settings.inheritDirectionalRotation, [&]() {
+								return DrawWithHighlight(label, [&]() {
+									return ImGui::SliderInt(label, &xyDegrees, 0, 360);
+								});
+							});
+						})) {
 						settings.directionalXY = static_cast<uint32_t>(xyDegrees);
 						changed = true;
 					}
 					ImGui::Spacing();
 					if (DrawIfMatchesSearch(CellLightingSetting::kZRotation, [&](const char* label) {
-						    return drawInherited(settings.inheritDirectionalRotation, [&]() {
-							    return DrawWithHighlight(label, [&]() {
-								    return ImGui::SliderInt(label, &zDegrees, 0, 360);
-							    });
-						    });
-					    })) {
+							return drawInherited(settings.inheritDirectionalRotation, [&]() {
+								return DrawWithHighlight(label, [&]() {
+									return ImGui::SliderInt(label, &zDegrees, 0, 360);
+								});
+							});
+						})) {
 						settings.directionalZ = static_cast<uint32_t>(zDegrees);
 						changed = true;
 					}
@@ -570,17 +571,17 @@ std::vector<Widget::SearchResult> CellLightingWidget::CollectSearchableSettings(
 {
 	const std::vector<std::pair<std::string, std::vector<std::string>>> entries = {
 		{ CellLightingTab::kBasic, { CellLightingSetting::kAmbientColor, CellLightingSetting::kDirectionalColor,
-									    CellLightingSetting::kXYRotation, CellLightingSetting::kZRotation, CellLightingSetting::kDirectionalFade,
-									    CellLightingSetting::kLightFadeStart, CellLightingSetting::kLightFadeEnd, CellLightingSetting::kClipDistance } },
+									   CellLightingSetting::kXYRotation, CellLightingSetting::kZRotation, CellLightingSetting::kDirectionalFade,
+									   CellLightingSetting::kLightFadeStart, CellLightingSetting::kLightFadeEnd, CellLightingSetting::kClipDistance } },
 		{ CellLightingTab::kFog, { CellLightingSetting::kFogNearColor, CellLightingSetting::kFogFarColor,
-									  CellLightingSetting::kFogNear, CellLightingSetting::kFogFar, CellLightingSetting::kFogPower, CellLightingSetting::kFogClampMax } },
+									 CellLightingSetting::kFogNear, CellLightingSetting::kFogFar, CellLightingSetting::kFogPower, CellLightingSetting::kFogClampMax } },
 		{ CellLightingTab::kDalc, { CellLightingSetting::kSpecular, CellLightingSetting::kFresnelPower,
-									   CellLightingSetting::kXPlus, CellLightingSetting::kXMinus, CellLightingSetting::kYPlus, CellLightingSetting::kYMinus,
-									   CellLightingSetting::kZPlus, CellLightingSetting::kZMinus } },
+									  CellLightingSetting::kXPlus, CellLightingSetting::kXMinus, CellLightingSetting::kYPlus, CellLightingSetting::kYMinus,
+									  CellLightingSetting::kZPlus, CellLightingSetting::kZMinus } },
 		{ CellLightingTab::kInheritance, { CellLightingSetting::kInheritAmbientColor, CellLightingSetting::kInheritDirectionalColor, CellLightingSetting::kInheritFogColor,
-											  CellLightingSetting::kInheritFogNear, CellLightingSetting::kInheritFogFar, CellLightingSetting::kInheritDirectionalRotation,
-											  CellLightingSetting::kInheritDirectionalFade, CellLightingSetting::kInheritClipDistance, CellLightingSetting::kInheritFogPower,
-											  CellLightingSetting::kInheritFogMaxClamp, CellLightingSetting::kInheritLightFadeDistances } },
+											 CellLightingSetting::kInheritFogNear, CellLightingSetting::kInheritFogFar, CellLightingSetting::kInheritDirectionalRotation,
+											 CellLightingSetting::kInheritDirectionalFade, CellLightingSetting::kInheritClipDistance, CellLightingSetting::kInheritFogPower,
+											 CellLightingSetting::kInheritFogMaxClamp, CellLightingSetting::kInheritLightFadeDistances } },
 	};
 
 	std::vector<SearchResult> results;

--- a/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
@@ -322,13 +322,13 @@ std::vector<Widget::SearchResult> LightingTemplateWidget::CollectSearchableSetti
 {
 	const std::vector<std::pair<std::string, std::vector<std::string>>> entries = {
 		{ LightingTemplateTab::kBasic, { LightingTemplateSetting::kAmbientColor, LightingTemplateSetting::kDirectionalColor,
-											LightingTemplateSetting::kDirectionalXY, LightingTemplateSetting::kDirectionalZ, LightingTemplateSetting::kDirectionalFade,
-											LightingTemplateSetting::kLightFadeStart, LightingTemplateSetting::kLightFadeEnd, LightingTemplateSetting::kClipDistance } },
+										   LightingTemplateSetting::kDirectionalXY, LightingTemplateSetting::kDirectionalZ, LightingTemplateSetting::kDirectionalFade,
+										   LightingTemplateSetting::kLightFadeStart, LightingTemplateSetting::kLightFadeEnd, LightingTemplateSetting::kClipDistance } },
 		{ LightingTemplateTab::kFog, { LightingTemplateSetting::kFogColorNear, LightingTemplateSetting::kFogColorFar,
-										  LightingTemplateSetting::kFogNear, LightingTemplateSetting::kFogFar, LightingTemplateSetting::kFogPower, LightingTemplateSetting::kFogClamp } },
+										 LightingTemplateSetting::kFogNear, LightingTemplateSetting::kFogFar, LightingTemplateSetting::kFogPower, LightingTemplateSetting::kFogClamp } },
 		{ LightingTemplateTab::kDalc, { LightingTemplateSetting::kSpecular, LightingTemplateSetting::kFresnelPower,
-										   LightingTemplateSetting::kXPlus, LightingTemplateSetting::kXMinus, LightingTemplateSetting::kYPlus, LightingTemplateSetting::kYMinus,
-										   LightingTemplateSetting::kZPlus, LightingTemplateSetting::kZMinus } },
+										  LightingTemplateSetting::kXPlus, LightingTemplateSetting::kXMinus, LightingTemplateSetting::kYPlus, LightingTemplateSetting::kYMinus,
+										  LightingTemplateSetting::kZPlus, LightingTemplateSetting::kZMinus } },
 	};
 
 	std::vector<SearchResult> results;

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -50,18 +50,18 @@ void PrecipitationWidget::DrawWidget()
 			if (ImGui::BeginTabItem(PrecipitationTab::kParticle, nullptr, particleFlags)) {
 				BeginScrollableContent("##ParticleScroll");
 				if (DrawIfMatchesSearch(PrecipitationSetting::kType, [&](const char* label) {
-					ImGui::SeparatorText("Particle Type");
-					const char* types[] = { "Rain", "Snow" };
-					int currentType = static_cast<int>(settings.particleType);
-					bool comboChanged = DrawWithHighlight(label, [&]() {
-						return ImGui::Combo(label, &currentType, types, IM_ARRAYSIZE(types));
-					});
-					if (comboChanged) {
-						settings.particleType = static_cast<uint32_t>(currentType);
-						return true;
-					}
-					return false;
-				}))
+						ImGui::SeparatorText("Particle Type");
+						const char* types[] = { "Rain", "Snow" };
+						int currentType = static_cast<int>(settings.particleType);
+						bool comboChanged = DrawWithHighlight(label, [&]() {
+							return ImGui::Combo(label, &currentType, types, IM_ARRAYSIZE(types));
+						});
+						if (comboChanged) {
+							settings.particleType = static_cast<uint32_t>(currentType);
+							return true;
+						}
+						return false;
+					}))
 					changed = true;
 				if (MatchesAnySearch({ PrecipitationSetting::kSizeX, PrecipitationSetting::kSizeY })) {
 					ImGui::SeparatorText("Particle Size");
@@ -101,18 +101,18 @@ void PrecipitationWidget::DrawWidget()
 					int numX = static_cast<int>(settings.numSubtexturesX);
 					int numY = static_cast<int>(settings.numSubtexturesY);
 					if (DrawIfMatchesSearch(PrecipitationSetting::kNumSubtexturesX, [&](const char* label) {
-						    return DrawWithHighlight(label, [&]() {
-							    return ImGui::InputInt(label, &numX);
-						    });
-					    })) {
+							return DrawWithHighlight(label, [&]() {
+								return ImGui::InputInt(label, &numX);
+							});
+						})) {
 						settings.numSubtexturesX = std::max(1, numX);
 						changed = true;
 					}
 					if (DrawIfMatchesSearch(PrecipitationSetting::kNumSubtexturesY, [&](const char* label) {
-						    return DrawWithHighlight(label, [&]() {
-							    return ImGui::InputInt(label, &numY);
-						    });
-					    })) {
+							return DrawWithHighlight(label, [&]() {
+								return ImGui::InputInt(label, &numY);
+							});
+						})) {
 						settings.numSubtexturesY = std::max(1, numY);
 						changed = true;
 					}

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -311,12 +311,17 @@ void WeatherWidget::DrawWidget()
 					const bool isInherited = drawInheritCheckbox(inheritKey, recordRefs[i], parentRefs[i]);
 					ImGui::Text("%s:", label.c_str());
 					ImGui::SameLine(todLabelOffset);
-					if (isInherited) PushInheritedStyle();
+					if (isInherited)
+						PushInheritedStyle();
 					if (WeatherUtils::DrawFormPickerCached(pickerId, recordRefs[i], widgets, false, true, pickerWidth)) {
 						pendingReinit = true;
-						if (isInherited) settings.inheritFlags[inheritKey] = false;
+						if (isInherited)
+							settings.inheritFlags[inheritKey] = false;
 					}
-					if (isInherited) { Util::AddTooltip("Inherited from parent weather"); PopInheritedStyle(); }
+					if (isInherited) {
+						Util::AddTooltip("Inherited from parent weather");
+						PopInheritedStyle();
+					}
 					drawOpenButton(recordRefs[i], widgets, std::format("Open##{}", i), openTooltip);
 
 					if (recordHighlighted)
@@ -337,12 +342,17 @@ void WeatherWidget::DrawWidget()
 				const bool isInherited = drawInheritCheckbox(inheritKey, recordRef, parentRef);
 				ImGui::Text("%s:", valueLabel);
 				ImGui::SameLine(formLabelOffset);
-				if (isInherited) PushInheritedStyle();
+				if (isInherited)
+					PushInheritedStyle();
 				if (WeatherUtils::DrawFormPickerCached(pickerId, recordRef, widgets, false, true, pickerWidth)) {
 					pendingReinit = true;
-					if (isInherited) settings.inheritFlags[inheritKey] = false;
+					if (isInherited)
+						settings.inheritFlags[inheritKey] = false;
 				}
-				if (isInherited) { Util::AddTooltip("Inherited from parent weather"); PopInheritedStyle(); }
+				if (isInherited) {
+					Util::AddTooltip("Inherited from parent weather");
+					PopInheritedStyle();
+				}
 				drawOpenButton(recordRef, widgets, buttonId, openTooltip);
 
 				if (recordHighlighted)
@@ -821,12 +831,12 @@ void WeatherWidget::DrawDALCSettings()
 		}
 
 		// Draw with per-parameter inheritance
-		auto drawDalcColor = [&](const char* settingId, const char* label, float3 (&values)[4], bool* inheritFlag = nullptr, float3* parentValues = nullptr) {
+		auto drawDalcColor = [&](const char* settingId, const char* label, float3(&values)[4], bool* inheritFlag = nullptr, float3* parentValues = nullptr) {
 			return DrawIfMatchesSearch(settingId, [&](const char*) {
 				return DrawWithHighlight(settingId, [&]() {
 					return inheritFlag ?
-						TOD::DrawTODColorRow(label, values, *inheritFlag, parentValues) :
-						TOD::DrawTODColorRow(label, values);
+					           TOD::DrawTODColorRow(label, values, *inheritFlag, parentValues) :
+					           TOD::DrawTODColorRow(label, values);
 				});
 			});
 		};
@@ -834,8 +844,8 @@ void WeatherWidget::DrawDALCSettings()
 			return DrawIfMatchesSearch(settingId, [&](const char*) {
 				return DrawWithHighlight(settingId, [&]() {
 					return inheritFlag ?
-						TOD::DrawTODFloatRow(label, values, *inheritFlag, parentValues, 0.0f, 10.0f) :
-						TOD::DrawTODFloatRow(label, values, 0.0f, 10.0f);
+					           TOD::DrawTODFloatRow(label, values, *inheritFlag, parentValues, 0.0f, 10.0f) :
+					           TOD::DrawTODFloatRow(label, values, 0.0f, 10.0f);
 				});
 			});
 		};
@@ -1222,10 +1232,10 @@ void WeatherWidget::DrawFogSettings()
 		ImGui::TableSetColumnIndex(2);
 		ImGui::Separator();
 
-		DrawFogRow(nearMatches,  WeatherInherit::kFogNear,  "Near",  WeatherSetting::kDayNear,  WeatherSetting::kNightNear,  0.0f, 1000000.0f, "%.0f", hasParent, parentWidget, changed);
-		DrawFogRow(farMatches,   WeatherInherit::kFogFar,   "Far",   WeatherSetting::kDayFar,   WeatherSetting::kNightFar,   0.0f, 1000000.0f, "%.0f", hasParent, parentWidget, changed);
-		DrawFogRow(powerMatches, WeatherInherit::kFogPower, "Power", WeatherSetting::kDayPower, WeatherSetting::kNightPower, 0.0f, 10.0f,      "%.3f", hasParent, parentWidget, changed);
-		DrawFogRow(maxMatches,   WeatherInherit::kFogMax,   "Max",   WeatherSetting::kDayMax,   WeatherSetting::kNightMax,   0.0f, 1.0f,       "%.3f", hasParent, parentWidget, changed);
+		DrawFogRow(nearMatches, WeatherInherit::kFogNear, "Near", WeatherSetting::kDayNear, WeatherSetting::kNightNear, 0.0f, 1000000.0f, "%.0f", hasParent, parentWidget, changed);
+		DrawFogRow(farMatches, WeatherInherit::kFogFar, "Far", WeatherSetting::kDayFar, WeatherSetting::kNightFar, 0.0f, 1000000.0f, "%.0f", hasParent, parentWidget, changed);
+		DrawFogRow(powerMatches, WeatherInherit::kFogPower, "Power", WeatherSetting::kDayPower, WeatherSetting::kNightPower, 0.0f, 10.0f, "%.3f", hasParent, parentWidget, changed);
+		DrawFogRow(maxMatches, WeatherInherit::kFogMax, "Max", WeatherSetting::kDayMax, WeatherSetting::kNightMax, 0.0f, 1.0f, "%.3f", hasParent, parentWidget, changed);
 
 		ImGui::EndTable();
 	}
@@ -1238,12 +1248,16 @@ void WeatherWidget::DrawFogSettings()
 void WeatherWidget::DrawFogSlider(const char* id, float& prop, float min, float max, const char* fmt, bool& inheritRef, bool isInherited, bool& changed)
 {
 	ImGui::SetNextItemWidth(-1);
-	if (isInherited) PushInheritedStyle();
+	if (isInherited)
+		PushInheritedStyle();
 	if (WeatherUtils::DrawSliderFloat(id, prop, min, max, nullptr, fmt)) {
 		changed = true;
 		inheritRef = false;
 	}
-	if (isInherited) { Util::AddTooltip("Inherited from parent weather"); PopInheritedStyle(); }
+	if (isInherited) {
+		Util::AddTooltip("Inherited from parent weather");
+		PopInheritedStyle();
+	}
 }
 
 void WeatherWidget::DrawFogRow(bool matches, const char* inheritKey, const char* label,
@@ -1290,7 +1304,8 @@ void WeatherWidget::DrawFogRow(bool matches, const char* inheritKey, const char*
 	ImGui::TableSetColumnIndex(2);
 	DrawFogSlider(std::format("##Night {}", label).c_str(), settings.fogProperties[nightPropKey], min, max, fmt, inheritRef, isInherited, changed);
 
-	if (highlightId) PopHighlightIfNeeded(highlightId, true);
+	if (highlightId)
+		PopHighlightIfNeeded(highlightId, true);
 }
 
 void WeatherWidget::DrawProperties(std::string category, std::map<std::string, int> properties)
@@ -1324,20 +1339,34 @@ void WeatherWidget::DrawProperties(std::string category, std::map<std::string, i
 				ImGui::SameLine();
 			}
 
-			if (isInherited) PushInheritedStyle();
+			if (isInherited)
+				PushInheritedStyle();
 			bool controlChanged = false;
 			switch (p.second) {
-			case 0: controlChanged = WeatherUtils::DrawSliderInt8(p.first, settings.weatherProperties[p.first]); break;
-			case 1: controlChanged = WeatherUtils::DrawColorEdit(p.first, settings.weatherColors[p.first]); break;
-			case 2: controlChanged = WeatherUtils::DrawSliderUint8(p.first, settings.weatherProperties[p.first]); break;
-			case 3: controlChanged = WeatherUtils::DrawSliderFloat(p.first, settings.fogProperties[p.first]); break;
-			default: break;
+			case 0:
+				controlChanged = WeatherUtils::DrawSliderInt8(p.first, settings.weatherProperties[p.first]);
+				break;
+			case 1:
+				controlChanged = WeatherUtils::DrawColorEdit(p.first, settings.weatherColors[p.first]);
+				break;
+			case 2:
+				controlChanged = WeatherUtils::DrawSliderUint8(p.first, settings.weatherProperties[p.first]);
+				break;
+			case 3:
+				controlChanged = WeatherUtils::DrawSliderFloat(p.first, settings.fogProperties[p.first]);
+				break;
+			default:
+				break;
 			}
 			if (controlChanged) {
 				changed = true;
-				if (isInherited) settings.inheritFlags[p.first] = false;
+				if (isInherited)
+					settings.inheritFlags[p.first] = false;
 			}
-			if (isInherited) { Util::AddTooltip("Inherited from parent weather"); PopInheritedStyle(); }
+			if (isInherited) {
+				Util::AddTooltip("Inherited from parent weather");
+				PopInheritedStyle();
+			}
 		});
 	}
 
@@ -1388,23 +1417,23 @@ void WeatherWidget::SyncInheritedValuesFromParent()
 		if (inherited(key))
 			value = parentWidget->settings.weatherColors[key];
 
-	syncFogPair(WeatherInherit::kFogNear,  WeatherSetting::kDayNear,  WeatherSetting::kNightNear);
-	syncFogPair(WeatherInherit::kFogFar,   WeatherSetting::kDayFar,   WeatherSetting::kNightFar);
+	syncFogPair(WeatherInherit::kFogNear, WeatherSetting::kDayNear, WeatherSetting::kNightNear);
+	syncFogPair(WeatherInherit::kFogFar, WeatherSetting::kDayFar, WeatherSetting::kNightFar);
 	syncFogPair(WeatherInherit::kFogPower, WeatherSetting::kDayPower, WeatherSetting::kNightPower);
-	syncFogPair(WeatherInherit::kFogMax,   WeatherSetting::kDayMax,   WeatherSetting::kNightMax);
+	syncFogPair(WeatherInherit::kFogMax, WeatherSetting::kDayMax, WeatherSetting::kNightMax);
 
 	for (int i = 0; i < ColorTypes::kTotal; i++)
 		if (inherited("Atmosphere_" + ColorTypeLabel(i)))
 			settings.atmosphereColors[i] = parentWidget->settings.atmosphereColors[i];
 
 	syncDalcTOD(WeatherInherit::kDalcSpecular, [](DALC& d) -> auto& { return d.specular; });
-	syncDalcTOD(WeatherInherit::kDalcFresnel,  [](DALC& d) -> auto& { return d.fresnelPower; });
-	syncDalcTOD(WeatherInherit::kDalcDirXMax,  [](DALC& d) -> auto& { return d.directional[0].max; });
-	syncDalcTOD(WeatherInherit::kDalcDirXMin,  [](DALC& d) -> auto& { return d.directional[0].min; });
-	syncDalcTOD(WeatherInherit::kDalcDirYMax,  [](DALC& d) -> auto& { return d.directional[1].max; });
-	syncDalcTOD(WeatherInherit::kDalcDirYMin,  [](DALC& d) -> auto& { return d.directional[1].min; });
-	syncDalcTOD(WeatherInherit::kDalcDirZMax,  [](DALC& d) -> auto& { return d.directional[2].max; });
-	syncDalcTOD(WeatherInherit::kDalcDirZMin,  [](DALC& d) -> auto& { return d.directional[2].min; });
+	syncDalcTOD(WeatherInherit::kDalcFresnel, [](DALC& d) -> auto& { return d.fresnelPower; });
+	syncDalcTOD(WeatherInherit::kDalcDirXMax, [](DALC& d) -> auto& { return d.directional[0].max; });
+	syncDalcTOD(WeatherInherit::kDalcDirXMin, [](DALC& d) -> auto& { return d.directional[0].min; });
+	syncDalcTOD(WeatherInherit::kDalcDirYMax, [](DALC& d) -> auto& { return d.directional[1].max; });
+	syncDalcTOD(WeatherInherit::kDalcDirYMin, [](DALC& d) -> auto& { return d.directional[1].min; });
+	syncDalcTOD(WeatherInherit::kDalcDirZMax, [](DALC& d) -> auto& { return d.directional[2].max; });
+	syncDalcTOD(WeatherInherit::kDalcDirZMin, [](DALC& d) -> auto& { return d.directional[2].min; });
 
 	for (int i = 0; i < TESWeather::kTotalLayers; i++) {
 		if (inherited(std::format("Cloud{}_Color", i)))
@@ -1416,11 +1445,11 @@ void WeatherWidget::SyncInheritedValuesFromParent()
 	}
 
 	for (size_t i = 0; i < ColorTimes::kTotal; i++) {
-		syncRecord("ImageSpace_" + std::to_string(i),         settings.imageSpaceRefs[i],         parentWidget->settings.imageSpaceRefs[i]);
+		syncRecord("ImageSpace_" + std::to_string(i), settings.imageSpaceRefs[i], parentWidget->settings.imageSpaceRefs[i]);
 		syncRecord("VolumetricLighting_" + std::to_string(i), settings.volumetricLightingRefs[i], parentWidget->settings.volumetricLightingRefs[i]);
 	}
-	syncRecord("Precipitation",   settings.precipitationData, parentWidget->settings.precipitationData);
-	syncRecord("ReferenceEffect", settings.referenceEffect,   parentWidget->settings.referenceEffect);
+	syncRecord("Precipitation", settings.precipitationData, parentWidget->settings.precipitationData);
+	syncRecord("ReferenceEffect", settings.referenceEffect, parentWidget->settings.referenceEffect);
 
 	ApplyChanges();
 }
@@ -1440,7 +1469,10 @@ void WeatherWidget::PropagateToChildren()
 		if (child != this && child->settings.parent == myId) {
 			bool hasAnyInherit = false;
 			for (const auto& [key, val] : child->settings.inheritFlags)
-				if (val) { hasAnyInherit = true; break; }
+				if (val) {
+					hasAnyInherit = true;
+					break;
+				}
 			if (hasAnyInherit && !visiting.contains(child))
 				child->SyncInheritedValuesFromParent();
 		}
@@ -1488,10 +1520,14 @@ void WeatherWidget::InheritAllFromParent()
 
 	// DALC tab
 	static constexpr const char* kDalcFlags[] = {
-		WeatherInherit::kDalcSpecular, WeatherInherit::kDalcFresnel,
-		WeatherInherit::kDalcDirXMax,  WeatherInherit::kDalcDirXMin,
-		WeatherInherit::kDalcDirYMax,  WeatherInherit::kDalcDirYMin,
-		WeatherInherit::kDalcDirZMax,  WeatherInherit::kDalcDirZMin,
+		WeatherInherit::kDalcSpecular,
+		WeatherInherit::kDalcFresnel,
+		WeatherInherit::kDalcDirXMax,
+		WeatherInherit::kDalcDirXMin,
+		WeatherInherit::kDalcDirYMax,
+		WeatherInherit::kDalcDirYMin,
+		WeatherInherit::kDalcDirZMax,
+		WeatherInherit::kDalcDirZMin,
 	};
 	for (int i = 0; i < ColorTimes::kTotal; i++)
 		settings.dalc[i] = parentWidget->settings.dalc[i];
@@ -1514,8 +1550,10 @@ void WeatherWidget::InheritAllFromParent()
 	// Fog tab
 	settings.fogProperties = parentWidget->settings.fogProperties;
 	static constexpr const char* kFogFlags[] = {
-		WeatherInherit::kFogNear, WeatherInherit::kFogFar,
-		WeatherInherit::kFogPower, WeatherInherit::kFogMax,
+		WeatherInherit::kFogNear,
+		WeatherInherit::kFogFar,
+		WeatherInherit::kFogPower,
+		WeatherInherit::kFogMax,
 	};
 	for (const auto* key : kFogFlags)
 		settings.inheritFlags[key] = true;
@@ -1992,12 +2030,12 @@ std::vector<Widget::SearchResult> WeatherWidget::CollectSearchableSettings() con
 
 	const std::vector<std::pair<std::string, std::vector<std::string>>> tabEntries = {
 		{ WeatherTab::kBasic, { "Sun Damage", "Wind Speed", "Wind Direction", "Wind Direction Range",
-					   "Precipitation Begin Fade In", "Precipitation End Fade Out",
-					   "Thunder Lightning Begin Fade In", "Thunder Lightning End Fade Out",
-					   "Thunder Lightning Frequency", "Lightning Color",
-					   "Visual Effect Begin", "Visual Effect End", "Trans Delta" } },
+								  "Precipitation Begin Fade In", "Precipitation End Fade Out",
+								  "Thunder Lightning Begin Fade In", "Thunder Lightning End Fade Out",
+								  "Thunder Lightning Frequency", "Lightning Color",
+								  "Visual Effect Begin", "Visual Effect End", "Trans Delta" } },
 		{ WeatherTab::kFog, { WeatherSetting::kDayNear, WeatherSetting::kDayFar, WeatherSetting::kDayPower, WeatherSetting::kDayMax,
-								 WeatherSetting::kNightNear, WeatherSetting::kNightFar, WeatherSetting::kNightPower, WeatherSetting::kNightMax } },
+								WeatherSetting::kNightNear, WeatherSetting::kNightFar, WeatherSetting::kNightPower, WeatherSetting::kNightMax } },
 	};
 
 	for (const auto& [tab, names] : tabEntries) {


### PR DESCRIPTION
## Summary

Isolates the repo-wide formatting drift that `pre-commit.ci` auto-applies to every PR into its own `style:`-only change, so feature PRs stay reviewable (their diffs show logic, not formatter noise).

These are the exact normalizations `pre-commit.ci` produced (clang-format include ordering, brace placement, preprocessor/whitespace, ternary wrapping) across files that had drifted from the hooks in `dev` — no logic changes:

- `package/Shaders/{Lighting,ISTemporalAA}.hlsl`, `features/.../WaterCaustics.hlsli`
- `src/Features/{HDRDisplay,LightLimitFix}.cpp`, `src/Hooks.cpp`, `src/ShaderCache.h`, `src/Utils/RestartSettings.h`
- `src/WeatherEditor/Weather/*.cpp`

## Merge first
Land this before the in-flight feature PRs (#62 shader recompile observability, #63 cluster Tracy zones); once it's on `dev` and those are rebased, their diffs drop the formatter churn and show only their actual changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
