### PR TITLE
build: drop HDR/Terrain Variation/Helper from AIO

### DIFF
--- a/features/HDR Display/Shaders/Features/HDRDisplay.ini
+++ b/features/HDR Display/Shaders/Features/HDRDisplay.ini
@@ -5,7 +5,7 @@ Version = 1-0-2
 nexusmodid = 179371
 nexusfilegroupid = 7420943
 nexusfilename = HDR
-autoupload = true
+autoupload = false
 # nexusartifactpattern overrides the default artifact glob, which derives
 # from `nexusfilename.replace(' ', '.')` and would resolve to `HDR-*.7z`.
 # The actual build artifact is named after the feature folder ("HDR Display"),

--- a/features/Terrain Helper/Shaders/Features/TerrainHelper.ini
+++ b/features/Terrain Helper/Shaders/Features/TerrainHelper.ini
@@ -5,4 +5,4 @@ Version = 1-0-1
 nexusmodid = 143149
 nexusfilegroupid = 000000
 nexusfilename = Terrain Helper
-autoupload = true
+autoupload = false

--- a/features/Terrain Variation/Shaders/Features/TerrainVariation.ini
+++ b/features/Terrain Variation/Shaders/Features/TerrainVariation.ini
@@ -5,4 +5,4 @@ Version = 1-0-1
 nexusmodid = 148123
 nexusfilegroupid = 3231070
 nexusfilename = Terrain Variation
-autoupload = true
+autoupload = false


### PR DESCRIPTION
## What

Exclude three non-CORE features from the AIO bundle by setting `autoupload = false`:

| Feature | Nexus |
|---|---|
| HDR Display | [179371](https://www.nexusmods.com/skyrimspecialedition/mods/179371) |
| Terrain Variation | [148123](https://www.nexusmods.com/skyrimspecialedition/mods/148123) |
| Terrain Helper | [143149](https://www.nexusmods.com/skyrimspecialedition/mods/143149) |

## Why

These are davo's features; the fork does not redistribute them in the AIO. Users who want them install from their own Nexus pages.

## How it works

The AIO ships CORE features plus any non-CORE feature whose `.ini` sets `autoupload = true` (`feature_is_autoupload` in `CMakeLists.txt`). Flipping these three to `false` drops them from the AIO stage/archive.

## Scope

`.ini`-only — no shader, HLSL, or runtime behavior change. Affects only AIO packaging composition, hence `build:` (no release impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic upload for HDR Display, Terrain Helper, and Terrain Variation features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->