### PR TITLE
docs: correct upstream/fork Nexus mod IDs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,11 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Fork identity
 
-This repository is **Open Shaders** ([alandtse/open-shaders](https://github.com/alandtse/open-shaders)), a fork of [Community Shaders](https://github.com/community-shaders/skyrim-community-shaders) ([Nexus mod 180419](https://www.nexusmods.com/skyrimspecialedition/mods/180419)). The public/display name is "Open Shaders"; the runtime identity is intentionally kept as upstream Community Shaders so user installs are drop-in compatible:
+This repository is **Open Shaders** ([alandtse/open-shaders](https://github.com/alandtse/open-shaders), [Nexus mod 180419](https://www.nexusmods.com/skyrimspecialedition/mods/180419)), a fork of [Community Shaders](https://github.com/community-shaders/skyrim-community-shaders) ([Nexus mod 86492](https://www.nexusmods.com/skyrimspecialedition/mods/86492)). The public/display name is "Open Shaders"; the runtime identity is intentionally kept as upstream Community Shaders so user installs are drop-in compatible:
 
 -   **Keep as `CommunityShaders`** (do NOT rename): the CMake `PROJECT_NAME`, the DLL filename, the `SKSE/Plugins/CommunityShaders/` runtime directory, the `CommunityShaders.log` log file, the ImGui window ID after `###`, asset paths under `package/Interface/CommunityShaders/`, and any HLSL include paths.
 -   **Use "Open Shaders"**: in-game menu titles, README/AI-INSTRUCTIONS public-facing copy, the AIO Nexus mod filename, the GitHub release name, the in-game Welcome / FAQ / About text.
--   **Link "Community Shaders" explicitly to upstream**: when the text or comment refers to the upstream project (its Nexus page is 180419, its repo is `community-shaders/skyrim-community-shaders`, its wiki lives on that repo). Never link `doodlum/skyrim-community-shaders` — that path is dead.
+-   **Link "Community Shaders" explicitly to upstream**: when the text or comment refers to the upstream project (its Nexus page is 86492, its repo is `community-shaders/skyrim-community-shaders`, its wiki lives on that repo). Never link `doodlum/skyrim-community-shaders` — that path is dead. The fork's own Nexus page is 180419.
 
 The AIO bundle ships only features whose `Shaders/Features/*.ini` has `autoupload = true` (CORE features always included). The `AIO_INCLUDE_NON_AUTOUPLOAD=ON` CMake option overrides for local dev builds. The Nexus upload workflow ships only the AIO archive — there is no per-feature matrix distribution. See `.github/workflows/nexus-upload.yaml`.
 

--- a/AI-INSTRUCTIONS.md
+++ b/AI-INSTRUCTIONS.md
@@ -1,6 +1,6 @@
 # AI Development Instructions
 
-This file provides guidance for AI assistants working with the Open Shaders codebase — a fork of [Community Shaders](https://github.com/community-shaders/skyrim-community-shaders) ([Nexus](https://www.nexusmods.com/skyrimspecialedition/mods/180419)). The runtime layout (DLL name, settings path, log file) intentionally matches upstream Community Shaders so users can switch without losing settings; only the public display name and in-game branding are "Open Shaders".
+This file provides guidance for AI assistants working with the Open Shaders codebase — a fork of [Community Shaders](https://github.com/community-shaders/skyrim-community-shaders) ([Nexus mod 86492](https://www.nexusmods.com/skyrimspecialedition/mods/86492)). Open Shaders' own Nexus page is [mod 180419](https://www.nexusmods.com/skyrimspecialedition/mods/180419). The runtime layout (DLL name, settings path, log file) intentionally matches upstream Community Shaders so users can switch without losing settings; only the public display name and in-game branding are "Open Shaders".
 
 ## Primary Documentation
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ SKSE core plugin for advanced graphics modifications for Skyrim and fork of Comm
 
 The upstream branding (logo, Nexus icon, typography) is non-GPL and not redistributed by this fork — see the "Icons" section under [License](#license) below.
 
-An Open Shaders Nexus mod page does not exist yet; for now, install from [GitHub releases](https://github.com/alandtse/open-shaders/releases) or build from source.
+Install from the [Open Shaders Nexus page](https://www.nexusmods.com/skyrimspecialedition/mods/180419), from [GitHub releases](https://github.com/alandtse/open-shaders/releases), or build from source.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 SKSE core plugin for advanced graphics modifications for Skyrim and fork of Community Shaders.
 
-[Open Shaders developer wiki](https://github.com/alandtse/open-shaders/wiki) · [Upstream Community Shaders on Nexus](https://www.nexusmods.com/skyrimspecialedition/mods/180419) · [Upstream source](https://github.com/community-shaders/skyrim-community-shaders) · [Upstream developer wiki](https://github.com/community-shaders/skyrim-community-shaders/wiki)
+[Open Shaders developer wiki](https://github.com/alandtse/open-shaders/wiki) · [Upstream Community Shaders on Nexus](https://www.nexusmods.com/skyrimspecialedition/mods/86492) · [Upstream source](https://github.com/community-shaders/skyrim-community-shaders) · [Upstream developer wiki](https://github.com/community-shaders/skyrim-community-shaders/wiki)
 
 ## About this fork
 
@@ -25,8 +25,8 @@ SKSE core plugin for advanced graphics modifications for Skyrim and fork of Comm
 
 | Term                                                             | Refers to                                                                                                                                 |
 | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Community Shaders                                                | The upstream project (`community-shaders/skyrim-community-shaders`, Nexus mod 180419)                                                     |
-| Open Shaders                                                     | This fork (`alandtse/open-shaders`)                                                                                                       |
+| Community Shaders                                                | The upstream project (`community-shaders/skyrim-community-shaders`, Nexus mod 86492)                                                      |
+| Open Shaders                                                     | This fork (`alandtse/open-shaders`, Nexus mod 180419)                                                                                     |
 | `CommunityShaders` (as a path / filename / identifier in source) | Runtime-compat identifier; intentionally kept identical to upstream so settings, themes, and SKSE plugin discovery work without migration |
 
 The upstream branding (logo, Nexus icon, typography) is non-GPL and not redistributed by this fork — see the "Icons" section under [License](#license) below.


### PR DESCRIPTION
## What

Fix the Nexus mod IDs in the fork-identity docs:

- **86492** = upstream Community Shaders
- **180419** = Open Shaders (this fork)

Previously CLAUDE.md, README.md, and AI-INSTRUCTIONS.md labeled **180419 as upstream**, which is wrong — 180419 is the fork's own Nexus page.

## Files

- `.claude/CLAUDE.md` — fork-identity line + upstream-link guidance
- `README.md` — header link + naming-convention table
- `AI-INSTRUCTIONS.md` — intro fork reference

## Note

The `nexus-upload.yaml` workflow and `feature_version_audit.py` already use **86492** for the upstream CORE row, so no code change is needed there — this is docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)