### PR TITLE
ci: default aio Nexus mod id to 180419

### DIFF
--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -24,7 +24,7 @@ on:
                 required: false
                 default: "skyrimspecialedition"
             nexus_mod_id:
-                description: "Target Nexus mod ID. In `aio` mode this is the fork's single mod page. In `matrix` mode this seeds the CORE row of the upstream matrix (defaults to 86492 if empty)."
+                description: "Target Nexus mod ID. In `aio` mode this is the fork's single mod page (defaults to 180419 if empty). In `matrix` mode this seeds the CORE row of the upstream matrix (defaults to 86492 if empty)."
                 required: false
                 default: ""
             artifact_pattern:
@@ -167,7 +167,7 @@ jobs:
                   # Workflow inputs default to empty so matrix mode keeps
                   # its upstream defaults below; aio mode uses fork defaults.
                   if [ "$MODE" = "aio" ]; then
-                    EFFECTIVE_MOD_ID="${INPUT_NEXUS_MOD_ID}"
+                    EFFECTIVE_MOD_ID="${INPUT_NEXUS_MOD_ID:-180419}"
                     EFFECTIVE_ARTIFACT="${INPUT_ARTIFACT_PATTERN:-CommunityShaders_AIO-*.7z}"
                     EFFECTIVE_FILENAME="${INPUT_MOD_FILENAME:-Open Shaders}"
                   else


### PR DESCRIPTION
## What

Default the `aio` branch of `nexus-upload.yaml` to `nexus_mod_id = 180419` (the Open Shaders fork's Nexus page) when no ID is passed — mirroring how `matrix` mode falls back to `86492` for upstream CORE.

## Why

`aio` mode had no default, so a real upload (and the post-release dry-run) required typing `nexus_mod_id` on every dispatch. With 180419 confirmed as the fork's page, this makes the Nexus publish step one-click.

## Note

The shared `nexus_mod_id` workflow **input** default stays empty on purpose — only the `aio` code branch defaults to 180419, so `matrix` mode keeps its 86492 fallback. No behavior change for matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)