### PR TITLE
docs: fix stale Nexus-button comment in home menu

### DIFF
--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -103,8 +103,7 @@ void HomePageRenderer::RenderQuickLinksSection()
 	ImGui::SetCursorPosX((windowSize.x - titleSize.x) * 0.5f);
 	ImGui::Text("Quick Links");
 
-	// The Nexus button points at upstream Community Shaders until the
-	// Open Shaders Nexus mod page exists; swap when ready.
+	// Nexus button → the Open Shaders fork page (mod 180419).
 	ImGui::Columns(3, nullptr, false);
 
 	if (ImGui::Button("Nexus Mods", ImVec2(-1, 0))) {


### PR DESCRIPTION
## What

The home-page **Nexus Mods** button already opens the Open Shaders fork page (`mods/180419`), but the comment above it still read:

> // The Nexus button points at upstream Community Shaders until the
> // Open Shaders Nexus mod page exists; swap when ready.

Updated the comment to describe current behavior (button → Open Shaders page, mod 180419).

## Scope

Comment-only — no code/behavior change. The button URL was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)