### PR TITLE
fix(aio): include Terrain Helper in AIO bundle

### DIFF
--- a/features/Terrain Helper/Shaders/Features/TerrainHelper.ini
+++ b/features/Terrain Helper/Shaders/Features/TerrainHelper.ini
@@ -1,5 +1,8 @@
 [Info]
 Version = 1-0-1
+# Activation-only feature (all code lives in the core mod, no shaders here), so
+# opt out of version auditing — bumping this toggle .ini on every edit is churn.
+AuditVersion = false
 
 [Nexus]
 nexusmodid = 143149

--- a/features/Terrain Helper/Shaders/Features/TerrainHelper.ini
+++ b/features/Terrain Helper/Shaders/Features/TerrainHelper.ini
@@ -5,4 +5,4 @@ Version = 1-0-1
 nexusmodid = 143149
 nexusfilegroupid = 000000
 nexusfilename = Terrain Helper
-autoupload = false
+autoupload = true

--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -186,7 +186,7 @@ def get_feature_ini_metadata(feature_dir_or_ini_path):
     if not sections:
         sections = ['Info'] if parser.has_section('Info') else []
 
-    metadata = {'auto_upload': False}
+    metadata = {'auto_upload': False, 'audit_version': True}
     for section in sections:
         if not parser.has_section(section):
             continue
@@ -195,6 +195,15 @@ def get_feature_ini_metadata(feature_dir_or_ini_path):
         auto_upload_str = section_items.get('autoupload') or section_items.get('auto_upload')
         if auto_upload_str is not None:
             metadata['auto_upload'] = str(auto_upload_str).strip().lower() not in ('false', '0', 'no', 'off', '')
+
+        # Activation-only features keep all code in the core mod; their toggle
+        # .ini opts out of version auditing/bumping with `AuditVersion = false`.
+        # Auditing is on by default, so a blank value must NOT exclude the ini:
+        # only explicit falsy values opt out (unlike auto_upload, which is opt-in
+        # and treats blank as off).
+        audit_version_str = section_items.get('auditversion') or section_items.get('audit_version')
+        if audit_version_str is not None:
+            metadata['audit_version'] = str(audit_version_str).strip().lower() not in ('false', '0', 'no', 'off')
 
         section_metadata = {
             'mod_id': section_items.get('nexusmodid') or section_items.get('nexus_mod_id') or section_items.get('mod_id'),
@@ -630,6 +639,12 @@ def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=Fals
 
         meta = feature_meta_map.get(feature_key)
         ini_path = get_feature_ini(feature_dir)
+        # Activation-only features (e.g. Terrain Helper) opt out of version
+        # auditing via `AuditVersion = false` in their .ini: all their code lives
+        # in the core mod, so bumping the toggle .ini on every edit is meaningless
+        # churn. Skip them entirely from bump suggestions and PR-check failures.
+        if ini_path and not get_feature_ini_metadata(ini_path).get('audit_version', True):
+            continue
         # Use last release tag (version_ref) as the baseline for version proposals so that
         # multiple PRs between releases don't accumulate spurious bumps.
         prior_ver = get_prior_version(ini_path, version_ref) if ini_path else None


### PR DESCRIPTION
## What

Re-enable Terrain Helper in the AIO (`autoupload = true`) now that its author approved bundling, and stop the feature audit from churning on it.

## Changes
- `features/Terrain Helper/.../TerrainHelper.ini`: `autoupload = true` + **`AuditVersion = false`**.
- `tools/feature_version_audit.py`: **path-scoped cherry-pick** of the `AuditVersion` opt-out from upstream community-shaders #2444 — applied **only** to the audit script (the other 5 files that PR touched are pipeline workflows our fork has diverged on; a full cherry-pick would conflict).

## Why `AuditVersion = false`

Terrain Helper is activation-only: `features/Terrain Helper/` has no shaders (just the toggle `.ini` + `.esp`); all logic is in `src/Features/TerrainHelper.cpp`. So a version bump when only its `.ini` changes is meaningless churn. With the opt-out, the audit skips it — the PR check passes **and** the release `--apply-bumps` won't spuriously bump it (stays `1-0-1`), while it ships in the AIO.

## Release

`fix(aio):` → semantic-release cuts **v1.6.1** (patch). Supersedes v1.6.0 (which shipped a partial Terrain Helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)