### PR TITLE
ci: auto-upload AIO to Nexus on stable release

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -188,7 +188,7 @@ jobs:
                   body-file: ${{ steps.combined_notes.outputs.body_file }}
                   download-artifact: "false"
 
-    nexus-dry-run:
+    nexus-upload:
         # Chained from `release` to avoid the artifact-attachment race a
         # parallel `release: published` trigger on a separate workflow had:
         # the prior release-nexus-trigger.yaml fired in parallel with this

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -194,7 +194,7 @@ jobs:
         # the prior release-nexus-trigger.yaml fired in parallel with this
         # build and tried to download artifacts before they existed.
         # Stable tags only (no '-' in the tag name).
-        name: Nexus Upload (dry run)
+        name: Nexus Upload
         needs: [release]
         if: >
             always() && !cancelled() &&
@@ -205,7 +205,11 @@ jobs:
         uses: ./.github/workflows/nexus-upload.yaml
         with:
             tag: ${{ github.event.release.tag_name }}
-            artifact_pattern: "CommunityShaders-*.7z"
-            dry_run: "true"
-        secrets:
-            UNEX_APIKEY: ${{ secrets.UNEX_APIKEY }}
+            # aio mode (the default) ships CommunityShaders_AIO-*.7z to the fork
+            # page (180419); leave artifact_pattern unset so it uses that default
+            # rather than the CORE archive. Real upload (dry_run=false): the
+            # reusable workflow skips a version already on Nexus, so re-runs are safe.
+            dry_run: "false"
+        # Nested reusable workflows don't auto-inherit repo secrets; inherit
+        # passes the UNEX_* set (cookie + API key) without enumerating each.
+        secrets: inherit


### PR DESCRIPTION
## What
Turn the release-build Nexus step from a dry-run-of-the-wrong-artifact into a real AIO upload on stable releases:

- **Correctness:** drop `artifact_pattern: "CommunityShaders-*.7z"` (the CORE archive) so `aio` mode uses its default `CommunityShaders_AIO-*.7z` — the actual fork distributable.
- **Auto-upload:** `dry_run: "false"` → a published stable tag now uploads the AIO to mod **180419** automatically (matching the manual flow that shipped v1.6.1).
- Pass `UNEX_NEXUSMODS_SESSION_COOKIE` (real upload needs it).

## Safety
- Pre-release tags still skipped (`!contains(tag, '-')`).
- The reusable `upload-nexus` runs with `check_existing` → a version already on Nexus is skipped, so re-runs / re-published releases are idempotent.

Validated by the v1.6.1 manual upload (same aio path) succeeding end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release build workflow to perform actual artifact uploads instead of test deployments, with enhanced authentication configuration for improved deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->