### PR TITLE
fix(upscaling): guard OpenComposite conflict

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -16,14 +16,10 @@
 #include "Utils/UI.h"
 #include <Windows.h>
 #include <algorithm>
-#include <cctype>
 #include <cfloat>
 #include <cmath>
-#include <cwctype>
 #include <directx/d3dx12.h>
-#include <filesystem>
 #include <format>
-#include <string_view>
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	Upscaling::Settings,
@@ -186,232 +182,6 @@ HRESULT WINAPI hk_D3D11CreateDeviceAndSwapChainUpscaling(
 	}
 
 	return ret;
-}
-
-namespace
-{
-	// OpenComposite (OpenXR-over-OpenVR shim) can run its own DLSS/FSR/DLAA
-	// upscaling. If our upscaler also runs, the two stack — double jitter,
-	// double upscale, conflicting dynamic-resolution sizing — which wrecks the
-	// VR image. We detect OpenComposite's upscaling from its config and stand
-	// down so it owns the upscale. VR-only; SteamVR users are unaffected.
-	struct OpenCompositeSettingValue
-	{
-		bool value = false;
-		std::string configPath;
-	};
-
-	struct OpenCompositeUpscalingSettings
-	{
-		OpenCompositeSettingValue dlssEnabled;
-		OpenCompositeSettingValue fsrEnabled;
-		OpenCompositeSettingValue dlaaEnabled;
-		OpenCompositeSettingValue fsrNativeAA;
-		OpenCompositeSettingValue fsr3PostAAEnabled;
-	};
-
-	struct DetectedOpenCompositeUpscalingBlocker
-	{
-		bool active = false;
-		std::string settingName;
-		std::string configPath;
-	};
-
-	std::string_view TrimAsciiWhitespace(std::string_view value)
-	{
-		while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front())))
-			value.remove_prefix(1);
-		while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back())))
-			value.remove_suffix(1);
-		return value;
-	}
-
-	std::string ToLowerAscii(std::string_view value)
-	{
-		std::string result(value);
-		std::ranges::transform(result, result.begin(), [](unsigned char c) {
-			return static_cast<char>(std::tolower(c));
-		});
-		return result;
-	}
-
-	bool TryParseOpenCompositeBool(std::string value, bool& outValue)
-	{
-		value = ToLowerAscii(TrimAsciiWhitespace(value));
-		if (value == "true" || value == "on" || value == "enabled" || value == "1") {
-			outValue = true;
-			return true;
-		}
-		if (value == "false" || value == "off" || value == "disabled" || value == "0") {
-			outValue = false;
-			return true;
-		}
-		return false;
-	}
-
-	void AddUniquePath(std::vector<std::filesystem::path>& paths, const std::filesystem::path& path)
-	{
-		if (path.empty())
-			return;
-
-		auto normalized = path.lexically_normal().wstring();
-		std::ranges::transform(normalized, normalized.begin(), [](wchar_t c) {
-			return static_cast<wchar_t>(std::towlower(c));
-		});
-
-		const bool alreadyAdded = std::ranges::any_of(paths, [&](const std::filesystem::path& existing) {
-			auto existingNormalized = existing.lexically_normal().wstring();
-			std::ranges::transform(existingNormalized, existingNormalized.begin(), [](wchar_t c) {
-				return static_cast<wchar_t>(std::towlower(c));
-			});
-			return existingNormalized == normalized;
-		});
-		if (!alreadyAdded)
-			paths.push_back(path);
-	}
-
-	std::filesystem::path GetCurrentDirectoryPath()
-	{
-		std::wstring buffer(MAX_PATH, L'\0');
-		const DWORD length = GetCurrentDirectoryW(static_cast<DWORD>(buffer.size()), buffer.data());
-		if (length == 0)
-			return {};
-
-		if (length >= buffer.size()) {
-			buffer.resize(length + 1);
-			const DWORD retryLength = GetCurrentDirectoryW(static_cast<DWORD>(buffer.size()), buffer.data());
-			if (retryLength == 0 || retryLength >= buffer.size())
-				return {};
-			buffer.resize(retryLength);
-		} else {
-			buffer.resize(length);
-		}
-
-		return std::filesystem::path(buffer);
-	}
-
-	// Resolves the directory of the already-loaded openvr_api.dll. Self-contained
-	// rather than reusing VRDetection::GatherDLLInfo, which also parses version
-	// info and enumerates the file — more work than the directory lookup needs.
-	std::filesystem::path GetLoadedOpenVRDirectory()
-	{
-		HMODULE openVRModule = GetModuleHandleW(L"openvr_api.dll");
-		if (!openVRModule)
-			return {};
-
-		std::wstring buffer(MAX_PATH, L'\0');
-		const DWORD length = GetModuleFileNameW(openVRModule, buffer.data(), static_cast<DWORD>(buffer.size()));
-		if (length == 0 || length >= buffer.size())
-			return {};
-
-		buffer.resize(length);
-		return std::filesystem::path(buffer).parent_path();
-	}
-
-	std::vector<std::filesystem::path> GetOpenCompositeConfigCandidates()
-	{
-		std::vector<std::filesystem::path> candidates;
-
-		const auto loadedOpenVRDirectory = GetLoadedOpenVRDirectory();
-		if (!loadedOpenVRDirectory.empty())
-			AddUniquePath(candidates, loadedOpenVRDirectory / L"opencomposite.ini");
-
-		const auto currentDirectory = GetCurrentDirectoryPath();
-		if (!currentDirectory.empty()) {
-			AddUniquePath(candidates, currentDirectory / L"opencomposite.ini");
-			AddUniquePath(candidates, currentDirectory / L"opencomposite_ext.ini");
-		}
-
-		return candidates;
-	}
-
-	// OpenComposite writes upscaling keys at top level or under a section
-	// depending on build, so probe the unnamed section first then every named
-	// one.
-	bool TryReadIniBoolSetting(const CSimpleIniA& ini, const char* key, bool& outValue)
-	{
-		auto tryReadSection = [&](const char* section) {
-			const char* rawValue = ini.GetValue(section, key, nullptr);
-			return rawValue && TryParseOpenCompositeBool(rawValue, outValue);
-		};
-
-		if (tryReadSection(""))
-			return true;
-
-		CSimpleIniA::TNamesDepend sections;
-		ini.GetAllSections(sections);
-		for (const auto& section : sections) {
-			if (section.pItem && tryReadSection(section.pItem))
-				return true;
-		}
-
-		return false;
-	}
-
-	void UpdateOpenCompositeSettingValue(OpenCompositeSettingValue& setting, const CSimpleIniA& ini, const char* key, const std::filesystem::path& path)
-	{
-		bool parsedValue = false;
-		if (!TryReadIniBoolSetting(ini, key, parsedValue))
-			return;
-
-		setting.value = parsedValue;
-		setting.configPath = path.string();
-	}
-
-	OpenCompositeUpscalingSettings ReadOpenCompositeUpscalingSettings()
-	{
-		OpenCompositeUpscalingSettings settings;
-
-		std::error_code ec;
-		for (const auto& path : GetOpenCompositeConfigCandidates()) {
-			if (!std::filesystem::exists(path, ec))
-				continue;
-			ec.clear();
-
-			CSimpleIniA ini;
-			ini.SetUnicode();
-			const SI_Error rc = ini.LoadFile(path.c_str());
-			if (rc < 0) {
-				logger::warn("[Upscaling] Failed to read OpenComposite config '{}': {}", path.string(), static_cast<int>(rc));
-				continue;
-			}
-
-			UpdateOpenCompositeSettingValue(settings.dlssEnabled, ini, "dlssEnabled", path);
-			UpdateOpenCompositeSettingValue(settings.fsrEnabled, ini, "fsrEnabled", path);
-			UpdateOpenCompositeSettingValue(settings.dlaaEnabled, ini, "dlaaEnabled", path);
-			UpdateOpenCompositeSettingValue(settings.fsrNativeAA, ini, "fsrNativeAA", path);
-			UpdateOpenCompositeSettingValue(settings.fsr3PostAAEnabled, ini, "fsr3PostAAEnabled", path);
-		}
-
-		return settings;
-	}
-
-	DetectedOpenCompositeUpscalingBlocker FindOpenCompositeUpscalingBlocker()
-	{
-		DetectedOpenCompositeUpscalingBlocker blocker;
-		if (!globals::game::isVR)
-			return blocker;
-
-		const auto settings = ReadOpenCompositeUpscalingSettings();
-		auto setBlocker = [&](const char* settingName, const OpenCompositeSettingValue& setting) {
-			blocker.active = true;
-			blocker.settingName = settingName;
-			blocker.configPath = setting.configPath;
-		};
-
-		if (settings.dlaaEnabled.value)
-			setBlocker("dlaaEnabled", settings.dlaaEnabled);
-		else if (settings.fsrNativeAA.value)
-			setBlocker("fsrNativeAA", settings.fsrNativeAA);
-		else if (settings.fsr3PostAAEnabled.value)
-			setBlocker("fsr3PostAAEnabled", settings.fsr3PostAAEnabled);
-		else if (settings.dlssEnabled.value)
-			setBlocker("dlssEnabled", settings.dlssEnabled);
-		else if (settings.fsrEnabled.value)
-			setBlocker("fsrEnabled", settings.fsrEnabled);
-
-		return blocker;
-	}
 }
 
 void Upscaling::DrawSettings()
@@ -851,17 +621,17 @@ void Upscaling::DrawSettings()
 	}
 }
 
-const Upscaling::OpenCompositeUpscalingBlocker& Upscaling::GetOpenCompositeUpscalingBlocker(bool a_forceRefresh) const
+const VRDetection::OpenCompositeUpscalingState& Upscaling::GetOpenCompositeUpscalingBlocker(bool a_forceRefresh) const
 {
 	// Cached after the first probe; lifecycle entry points pass forceRefresh so
 	// per-frame callers (GetUpscaleMethod, DrawSettings) only read the bool.
 	if (!a_forceRefresh && openCompositeUpscalingBlockerCacheValid)
 		return openCompositeUpscalingBlocker;
 
-	const auto detected = FindOpenCompositeUpscalingBlocker();
-	openCompositeUpscalingBlocker.active = detected.active;
-	openCompositeUpscalingBlocker.settingName = detected.settingName;
-	openCompositeUpscalingBlocker.configPath = detected.configPath;
+	// Only OpenComposite VR users can hit this conflict — skip the probe otherwise.
+	openCompositeUpscalingBlocker = globals::game::isVR ?
+	                                    VRDetection::DetectOpenCompositeUpscaling() :
+	                                    VRDetection::OpenCompositeUpscalingState{};
 	openCompositeUpscalingBlockerCacheValid = true;
 
 	return openCompositeUpscalingBlocker;

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -186,8 +186,7 @@ HRESULT WINAPI hk_D3D11CreateDeviceAndSwapChainUpscaling(
 
 void Upscaling::DrawSettings()
 {
-	// When OpenComposite owns upscaling, force our method to None up front so
-	// the picker below reflects the locked state.
+	// Force method to None up front so the picker reflects the locked state.
 	ApplyOpenCompositeUpscalingBlocker();
 	const auto& openCompositeBlocker = GetOpenCompositeUpscalingBlocker();
 	const bool openCompositeBlocksUpscaling = openCompositeBlocker.active;
@@ -233,9 +232,6 @@ void Upscaling::DrawSettings()
 	*currentUpscaleMode = std::min(availableModes, *currentUpscaleMode);
 
 	if (openCompositeBlocksUpscaling) {
-		// Re-assert None in case the combo above was somehow edited, then
-		// explain why the control is locked.
-		ApplyOpenCompositeUpscalingBlocker();
 		if (openCompositeBlocker.configPath.empty())
 			Util::Text::WrappedWarning(
 				"Upscaling is locked to None because OpenComposite has %s=true.",
@@ -623,12 +619,11 @@ void Upscaling::DrawSettings()
 
 const VRDetection::OpenCompositeUpscalingState& Upscaling::GetOpenCompositeUpscalingBlocker(bool a_forceRefresh) const
 {
-	// Cached after the first probe; lifecycle entry points pass forceRefresh so
-	// per-frame callers (GetUpscaleMethod, DrawSettings) only read the bool.
+	// Cached after first probe; lifecycle entry points force a refresh.
 	if (!a_forceRefresh && openCompositeUpscalingBlockerCacheValid)
 		return openCompositeUpscalingBlocker;
 
-	// Only OpenComposite VR users can hit this conflict — skip the probe otherwise.
+	// VR-only; non-VR never probes the filesystem.
 	openCompositeUpscalingBlocker = globals::game::isVR ?
 	                                    VRDetection::DetectOpenCompositeUpscaling() :
 	                                    VRDetection::OpenCompositeUpscalingState{};
@@ -813,9 +808,7 @@ struct BSImageSpace_Init_FXAA
 };
 void Upscaling::PostPostLoad()
 {
-	// Stand down entirely when OpenComposite owns upscaling — this also skips
-	// FoveatedRender, whose subrect/jitter hooks ride on our upscaling path and
-	// would conflict just the same.
+	// Guard before foveatedRender.PostPostLoad() so its hooks also stand down.
 	ApplyOpenCompositeUpscalingBlocker(true);
 	if (const auto& blocker = GetOpenCompositeUpscalingBlocker(); blocker.active) {
 		logger::warn("[Upscaling] Skipping upscaling render hooks because OpenComposite has {}=true.", blocker.settingName);
@@ -870,8 +863,8 @@ float Upscaling::GetQualityModeRatio(uint qualityMode)
 
 Upscaling::UpscaleMethod Upscaling::GetUpscaleMethod() const
 {
-	// OpenComposite owning upscaling wins over everything else (incl. PerfMode).
-	if (GetOpenCompositeUpscalingBlocker().active)
+	// OpenComposite owning upscaling wins over everything (incl. PerfMode); VR-only.
+	if (globals::game::isVR && GetOpenCompositeUpscalingBlocker().active)
 		return UpscaleMethod::kNONE;
 
 	// Lock runtime to the boot upscaler under PerfMode — engine RTs are

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -16,10 +16,14 @@
 #include "Utils/UI.h"
 #include <Windows.h>
 #include <algorithm>
+#include <cctype>
 #include <cfloat>
 #include <cmath>
+#include <cwctype>
 #include <directx/d3dx12.h>
+#include <filesystem>
 #include <format>
+#include <string_view>
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	Upscaling::Settings,
@@ -184,8 +188,240 @@ HRESULT WINAPI hk_D3D11CreateDeviceAndSwapChainUpscaling(
 	return ret;
 }
 
+namespace
+{
+	// OpenComposite (OpenXR-over-OpenVR shim) can run its own DLSS/FSR/DLAA
+	// upscaling. If our upscaler also runs, the two stack — double jitter,
+	// double upscale, conflicting dynamic-resolution sizing — which wrecks the
+	// VR image. We detect OpenComposite's upscaling from its config and stand
+	// down so it owns the upscale. VR-only; SteamVR users are unaffected.
+	struct OpenCompositeSettingValue
+	{
+		bool value = false;
+		std::string configPath;
+	};
+
+	struct OpenCompositeUpscalingSettings
+	{
+		OpenCompositeSettingValue dlssEnabled;
+		OpenCompositeSettingValue fsrEnabled;
+		OpenCompositeSettingValue dlaaEnabled;
+		OpenCompositeSettingValue fsrNativeAA;
+		OpenCompositeSettingValue fsr3PostAAEnabled;
+	};
+
+	struct DetectedOpenCompositeUpscalingBlocker
+	{
+		bool active = false;
+		std::string settingName;
+		std::string configPath;
+	};
+
+	std::string_view TrimAsciiWhitespace(std::string_view value)
+	{
+		while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front())))
+			value.remove_prefix(1);
+		while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back())))
+			value.remove_suffix(1);
+		return value;
+	}
+
+	std::string ToLowerAscii(std::string_view value)
+	{
+		std::string result(value);
+		std::ranges::transform(result, result.begin(), [](unsigned char c) {
+			return static_cast<char>(std::tolower(c));
+		});
+		return result;
+	}
+
+	bool TryParseOpenCompositeBool(std::string value, bool& outValue)
+	{
+		value = ToLowerAscii(TrimAsciiWhitespace(value));
+		if (value == "true" || value == "on" || value == "enabled" || value == "1") {
+			outValue = true;
+			return true;
+		}
+		if (value == "false" || value == "off" || value == "disabled" || value == "0") {
+			outValue = false;
+			return true;
+		}
+		return false;
+	}
+
+	void AddUniquePath(std::vector<std::filesystem::path>& paths, const std::filesystem::path& path)
+	{
+		if (path.empty())
+			return;
+
+		auto normalized = path.lexically_normal().wstring();
+		std::ranges::transform(normalized, normalized.begin(), [](wchar_t c) {
+			return static_cast<wchar_t>(std::towlower(c));
+		});
+
+		const bool alreadyAdded = std::ranges::any_of(paths, [&](const std::filesystem::path& existing) {
+			auto existingNormalized = existing.lexically_normal().wstring();
+			std::ranges::transform(existingNormalized, existingNormalized.begin(), [](wchar_t c) {
+				return static_cast<wchar_t>(std::towlower(c));
+			});
+			return existingNormalized == normalized;
+		});
+		if (!alreadyAdded)
+			paths.push_back(path);
+	}
+
+	std::filesystem::path GetCurrentDirectoryPath()
+	{
+		std::wstring buffer(MAX_PATH, L'\0');
+		const DWORD length = GetCurrentDirectoryW(static_cast<DWORD>(buffer.size()), buffer.data());
+		if (length == 0)
+			return {};
+
+		if (length >= buffer.size()) {
+			buffer.resize(length + 1);
+			const DWORD retryLength = GetCurrentDirectoryW(static_cast<DWORD>(buffer.size()), buffer.data());
+			if (retryLength == 0 || retryLength >= buffer.size())
+				return {};
+			buffer.resize(retryLength);
+		} else {
+			buffer.resize(length);
+		}
+
+		return std::filesystem::path(buffer);
+	}
+
+	// Resolves the directory of the already-loaded openvr_api.dll. Self-contained
+	// rather than reusing VRDetection::GatherDLLInfo, which also parses version
+	// info and enumerates the file — more work than the directory lookup needs.
+	std::filesystem::path GetLoadedOpenVRDirectory()
+	{
+		HMODULE openVRModule = GetModuleHandleW(L"openvr_api.dll");
+		if (!openVRModule)
+			return {};
+
+		std::wstring buffer(MAX_PATH, L'\0');
+		const DWORD length = GetModuleFileNameW(openVRModule, buffer.data(), static_cast<DWORD>(buffer.size()));
+		if (length == 0 || length >= buffer.size())
+			return {};
+
+		buffer.resize(length);
+		return std::filesystem::path(buffer).parent_path();
+	}
+
+	std::vector<std::filesystem::path> GetOpenCompositeConfigCandidates()
+	{
+		std::vector<std::filesystem::path> candidates;
+
+		const auto loadedOpenVRDirectory = GetLoadedOpenVRDirectory();
+		if (!loadedOpenVRDirectory.empty())
+			AddUniquePath(candidates, loadedOpenVRDirectory / L"opencomposite.ini");
+
+		const auto currentDirectory = GetCurrentDirectoryPath();
+		if (!currentDirectory.empty()) {
+			AddUniquePath(candidates, currentDirectory / L"opencomposite.ini");
+			AddUniquePath(candidates, currentDirectory / L"opencomposite_ext.ini");
+		}
+
+		return candidates;
+	}
+
+	// OpenComposite writes upscaling keys at top level or under a section
+	// depending on build, so probe the unnamed section first then every named
+	// one.
+	bool TryReadIniBoolSetting(const CSimpleIniA& ini, const char* key, bool& outValue)
+	{
+		auto tryReadSection = [&](const char* section) {
+			const char* rawValue = ini.GetValue(section, key, nullptr);
+			return rawValue && TryParseOpenCompositeBool(rawValue, outValue);
+		};
+
+		if (tryReadSection(""))
+			return true;
+
+		CSimpleIniA::TNamesDepend sections;
+		ini.GetAllSections(sections);
+		for (const auto& section : sections) {
+			if (section.pItem && tryReadSection(section.pItem))
+				return true;
+		}
+
+		return false;
+	}
+
+	void UpdateOpenCompositeSettingValue(OpenCompositeSettingValue& setting, const CSimpleIniA& ini, const char* key, const std::filesystem::path& path)
+	{
+		bool parsedValue = false;
+		if (!TryReadIniBoolSetting(ini, key, parsedValue))
+			return;
+
+		setting.value = parsedValue;
+		setting.configPath = path.string();
+	}
+
+	OpenCompositeUpscalingSettings ReadOpenCompositeUpscalingSettings()
+	{
+		OpenCompositeUpscalingSettings settings;
+
+		std::error_code ec;
+		for (const auto& path : GetOpenCompositeConfigCandidates()) {
+			if (!std::filesystem::exists(path, ec))
+				continue;
+			ec.clear();
+
+			CSimpleIniA ini;
+			ini.SetUnicode();
+			const SI_Error rc = ini.LoadFile(path.c_str());
+			if (rc < 0) {
+				logger::warn("[Upscaling] Failed to read OpenComposite config '{}': {}", path.string(), static_cast<int>(rc));
+				continue;
+			}
+
+			UpdateOpenCompositeSettingValue(settings.dlssEnabled, ini, "dlssEnabled", path);
+			UpdateOpenCompositeSettingValue(settings.fsrEnabled, ini, "fsrEnabled", path);
+			UpdateOpenCompositeSettingValue(settings.dlaaEnabled, ini, "dlaaEnabled", path);
+			UpdateOpenCompositeSettingValue(settings.fsrNativeAA, ini, "fsrNativeAA", path);
+			UpdateOpenCompositeSettingValue(settings.fsr3PostAAEnabled, ini, "fsr3PostAAEnabled", path);
+		}
+
+		return settings;
+	}
+
+	DetectedOpenCompositeUpscalingBlocker FindOpenCompositeUpscalingBlocker()
+	{
+		DetectedOpenCompositeUpscalingBlocker blocker;
+		if (!globals::game::isVR)
+			return blocker;
+
+		const auto settings = ReadOpenCompositeUpscalingSettings();
+		auto setBlocker = [&](const char* settingName, const OpenCompositeSettingValue& setting) {
+			blocker.active = true;
+			blocker.settingName = settingName;
+			blocker.configPath = setting.configPath;
+		};
+
+		if (settings.dlaaEnabled.value)
+			setBlocker("dlaaEnabled", settings.dlaaEnabled);
+		else if (settings.fsrNativeAA.value)
+			setBlocker("fsrNativeAA", settings.fsrNativeAA);
+		else if (settings.fsr3PostAAEnabled.value)
+			setBlocker("fsr3PostAAEnabled", settings.fsr3PostAAEnabled);
+		else if (settings.dlssEnabled.value)
+			setBlocker("dlssEnabled", settings.dlssEnabled);
+		else if (settings.fsrEnabled.value)
+			setBlocker("fsrEnabled", settings.fsrEnabled);
+
+		return blocker;
+	}
+}
+
 void Upscaling::DrawSettings()
 {
+	// When OpenComposite owns upscaling, force our method to None up front so
+	// the picker below reflects the locked state.
+	ApplyOpenCompositeUpscalingBlocker();
+	const auto& openCompositeBlocker = GetOpenCompositeUpscalingBlocker();
+	const bool openCompositeBlocksUpscaling = openCompositeBlocker.active;
+
 	// Display upscaling options in the UI
 	std::vector<std::string> upscaleModes = { "None", "TAA" };
 
@@ -212,9 +448,34 @@ void Upscaling::DrawSettings()
 	std::vector<const char*> modeLabels;
 	for (uint32_t i = 0; i <= availableModes; ++i)
 		modeLabels.push_back(upscaleModes[i].c_str());
+	if (openCompositeBlocksUpscaling)
+		ImGui::BeginDisabled();
 	ImGui::Combo("Method", (int*)currentUpscaleMode, modeLabels.data(), (int)modeLabels.size());
+	if (openCompositeBlocksUpscaling)
+		ImGui::EndDisabled();
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		if (openCompositeBlocksUpscaling)
+			ImGui::Text("Locked to None while OpenComposite has %s=true.", openCompositeBlocker.settingName.c_str());
+		else
+			ImGui::TextUnformatted("Selects the upscaling backend.");
+	}
 
 	*currentUpscaleMode = std::min(availableModes, *currentUpscaleMode);
+
+	if (openCompositeBlocksUpscaling) {
+		// Re-assert None in case the combo above was somehow edited, then
+		// explain why the control is locked.
+		ApplyOpenCompositeUpscalingBlocker();
+		if (openCompositeBlocker.configPath.empty())
+			Util::Text::WrappedWarning(
+				"Upscaling is locked to None because OpenComposite has %s=true.",
+				openCompositeBlocker.settingName.c_str());
+		else
+			Util::Text::WrappedWarning(
+				"Upscaling is locked to None because OpenComposite has %s=true in %s.",
+				openCompositeBlocker.settingName.c_str(),
+				openCompositeBlocker.configPath.c_str());
+	}
 
 	// Check the current upscale method
 	auto upscaleMethod = GetUpscaleMethod();
@@ -590,8 +851,46 @@ void Upscaling::DrawSettings()
 	}
 }
 
+const Upscaling::OpenCompositeUpscalingBlocker& Upscaling::GetOpenCompositeUpscalingBlocker(bool a_forceRefresh) const
+{
+	// Cached after the first probe; lifecycle entry points pass forceRefresh so
+	// per-frame callers (GetUpscaleMethod, DrawSettings) only read the bool.
+	if (!a_forceRefresh && openCompositeUpscalingBlockerCacheValid)
+		return openCompositeUpscalingBlocker;
+
+	const auto detected = FindOpenCompositeUpscalingBlocker();
+	openCompositeUpscalingBlocker.active = detected.active;
+	openCompositeUpscalingBlocker.settingName = detected.settingName;
+	openCompositeUpscalingBlocker.configPath = detected.configPath;
+	openCompositeUpscalingBlockerCacheValid = true;
+
+	return openCompositeUpscalingBlocker;
+}
+
+void Upscaling::ApplyOpenCompositeUpscalingBlocker(bool a_forceRefresh)
+{
+	const auto& blocker = GetOpenCompositeUpscalingBlocker(a_forceRefresh);
+	if (!blocker.active)
+		return;
+
+	const bool wasOverriding =
+		settings.upscaleMethod != static_cast<uint>(UpscaleMethod::kNONE) ||
+		settings.upscaleMethodNoDLSS != static_cast<uint>(UpscaleMethod::kNONE);
+	if (wasOverriding) {
+		if (blocker.configPath.empty())
+			logger::warn("[Upscaling] Forcing upscaling to None because OpenComposite has {}=true.", blocker.settingName);
+		else
+			logger::warn("[Upscaling] Forcing upscaling to None because OpenComposite has {}=true in {}.", blocker.settingName, blocker.configPath);
+	}
+
+	settings.upscaleMethod = static_cast<uint>(UpscaleMethod::kNONE);
+	settings.upscaleMethodNoDLSS = static_cast<uint>(UpscaleMethod::kNONE);
+}
+
 void Upscaling::SaveSettings(json& o_json)
 {
+	// Persist None, not the user's prior method, while OpenComposite owns upscaling.
+	ApplyOpenCompositeUpscalingBlocker(true);
 	o_json = settings;
 	// Nest FoveatedRender's settings under a sub-key so they round-trip alongside
 	// Upscaling's own. Subrect controller persistence is owned by FoveatedRender.
@@ -643,6 +942,8 @@ void Upscaling::LoadSettings(json& o_json)
 	// LoadSettings (which fired before this block ran). Idempotent — no-op
 	// if FoveatedRender is inactive or the preset is already compatible.
 	foveatedRender.ClampSettings();
+	// Override a loaded method with None when OpenComposite owns upscaling.
+	ApplyOpenCompositeUpscalingBlocker(true);
 	const float originalReflexFPSLimit = settings.reflexFPSLimit;
 	if (!std::isfinite(settings.reflexFPSLimit)) {
 		settings.reflexFPSLimit = 60.0f;
@@ -672,10 +973,17 @@ void Upscaling::RestoreDefaultSettings()
 {
 	settings = {};
 	foveatedRender.RestoreDefaultSettings();
+	ApplyOpenCompositeUpscalingBlocker(true);
 }
 
 void Upscaling::DataLoaded()
 {
+	ApplyOpenCompositeUpscalingBlocker(true);
+	if (const auto& blocker = GetOpenCompositeUpscalingBlocker(); blocker.active) {
+		logger::warn("[Upscaling] Skipping data-loaded upscaling adjustments because OpenComposite has {}=true.", blocker.settingName);
+		return;
+	}
+
 	// Fix screenshots fix from Engine Fixes
 	RE::GetINISetting("bUseTAA:Display")->data.b = false;
 
@@ -712,6 +1020,12 @@ bool Upscaling::MenuOpenCloseEventHandler::Register()
 
 void Upscaling::Load()
 {
+	ApplyOpenCompositeUpscalingBlocker(true);
+	if (const auto& blocker = GetOpenCompositeUpscalingBlocker(); blocker.active) {
+		logger::warn("[Upscaling] Skipping D3D11 device hook because OpenComposite has {}=true.", blocker.settingName);
+		return;
+	}
+
 	*(uintptr_t*)&ptrD3D11CreateDeviceAndSwapChainUpscaling = SKSE::PatchIAT(hk_D3D11CreateDeviceAndSwapChainUpscaling, "d3d11.dll", "D3D11CreateDeviceAndSwapChain");
 }
 
@@ -729,6 +1043,15 @@ struct BSImageSpace_Init_FXAA
 };
 void Upscaling::PostPostLoad()
 {
+	// Stand down entirely when OpenComposite owns upscaling — this also skips
+	// FoveatedRender, whose subrect/jitter hooks ride on our upscaling path and
+	// would conflict just the same.
+	ApplyOpenCompositeUpscalingBlocker(true);
+	if (const auto& blocker = GetOpenCompositeUpscalingBlocker(); blocker.active) {
+		logger::warn("[Upscaling] Skipping upscaling render hooks because OpenComposite has {}=true.", blocker.settingName);
+		return;
+	}
+
 	// Subrect controller defaults + stereo flag (FoveatedRender is no longer a
 	// Feature subclass so we drive its lifecycle from here).
 	foveatedRender.PostPostLoad();
@@ -777,6 +1100,10 @@ float Upscaling::GetQualityModeRatio(uint qualityMode)
 
 Upscaling::UpscaleMethod Upscaling::GetUpscaleMethod() const
 {
+	// OpenComposite owning upscaling wins over everything else (incl. PerfMode).
+	if (GetOpenCompositeUpscalingBlocker().active)
+		return UpscaleMethod::kNONE;
+
 	// Lock runtime to the boot upscaler under PerfMode — engine RTs are
 	// sized for it, and routing a different method through testTexture/
 	// renderRes paths breaks the HMD.
@@ -1463,6 +1790,12 @@ void Upscaling::ConfigureUpscaling(RE::BSGraphics::State* a_viewport)
 
 void Upscaling::SetupResources()
 {
+	ApplyOpenCompositeUpscalingBlocker(true);
+	if (const auto& blocker = GetOpenCompositeUpscalingBlocker(); blocker.active) {
+		logger::warn("[Upscaling] Skipping upscaling resource setup because OpenComposite has {}=true.", blocker.settingName);
+		return;
+	}
+
 	QueryPerformanceFrequency(&qpf);
 
 	auto renderer = globals::game::renderer;
@@ -1813,6 +2146,20 @@ float Upscaling::GetFrameGenerationFrameTime() const
 // Unified interface methods
 void Upscaling::LoadUpscalingSDKs()
 {
+	// Hooked into device creation, so this can fire repeatedly — log the skip once.
+	ApplyOpenCompositeUpscalingBlocker(true);
+	const auto& blocker = GetOpenCompositeUpscalingBlocker();
+	if (blocker.active) {
+		if (!openCompositeUpscalingBackendSkipLogged) {
+			if (blocker.configPath.empty())
+				logger::warn("[Upscaling] Skipping Streamline/FidelityFX backend init because OpenComposite has {}=true.", blocker.settingName);
+			else
+				logger::warn("[Upscaling] Skipping Streamline/FidelityFX backend init because OpenComposite has {}=true in {}.", blocker.settingName, blocker.configPath);
+			openCompositeUpscalingBackendSkipLogged = true;
+		}
+		return;
+	}
+
 	// Initialize upscaling SDK components during plugin startup
 	// This ensures all SDKs are available before any D3D device creation
 	streamline.LoadInterposer();

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -328,14 +328,10 @@ public:
 
 private:
 	// OpenComposite conflict guard: when the OpenComposite VR shim runs its own
-	// DLSS/FSR/DLAA upscaling, ours must stand down to avoid double upscaling.
-	// Detection lives in VRDetection; this class owns only the force-to-None
-	// policy and the lifecycle/UI gating.
-	//
-	// forceRefresh re-probes the OpenComposite config; otherwise the cached
-	// result is returned so per-frame callers stay cheap.
+	// DLSS/FSR/DLAA upscaling, ours stands down to avoid double upscaling.
+	// Detection lives in VRDetection; this class owns the force-to-None policy.
+	// forceRefresh re-probes the config; otherwise the cached result is returned.
 	const VRDetection::OpenCompositeUpscalingState& GetOpenCompositeUpscalingBlocker(bool a_forceRefresh = false) const;
-	// Forces upscaleMethod/upscaleMethodNoDLSS to None when the guard is active.
 	void ApplyOpenCompositeUpscalingBlocker(bool a_forceRefresh = false);
 
 	mutable VRDetection::OpenCompositeUpscalingState openCompositeUpscalingBlocker;

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -8,6 +8,7 @@
 #include "Upscaling/RCAS/RCAS.h"
 #include "Upscaling/Streamline.h"
 #include "Utils/BootSnapshot.h"
+#include "VR/OpenVRDetection.h"
 #include <d3d11_4.h>
 #include <d3d12.h>
 #include <winrt/base.h>
@@ -328,20 +329,16 @@ public:
 private:
 	// OpenComposite conflict guard: when the OpenComposite VR shim runs its own
 	// DLSS/FSR/DLAA upscaling, ours must stand down to avoid double upscaling.
-	struct OpenCompositeUpscalingBlocker
-	{
-		bool active = false;
-		std::string settingName;
-		std::string configPath;
-	};
-
-	// forceRefresh re-probes opencomposite.ini; otherwise the cached result is
-	// returned so per-frame callers stay cheap.
-	const OpenCompositeUpscalingBlocker& GetOpenCompositeUpscalingBlocker(bool a_forceRefresh = false) const;
+	// Detection lives in VRDetection; this class owns only the force-to-None
+	// policy and the lifecycle/UI gating.
+	//
+	// forceRefresh re-probes the OpenComposite config; otherwise the cached
+	// result is returned so per-frame callers stay cheap.
+	const VRDetection::OpenCompositeUpscalingState& GetOpenCompositeUpscalingBlocker(bool a_forceRefresh = false) const;
 	// Forces upscaleMethod/upscaleMethodNoDLSS to None when the guard is active.
 	void ApplyOpenCompositeUpscalingBlocker(bool a_forceRefresh = false);
 
-	mutable OpenCompositeUpscalingBlocker openCompositeUpscalingBlocker;
+	mutable VRDetection::OpenCompositeUpscalingState openCompositeUpscalingBlocker;
 	mutable bool openCompositeUpscalingBlockerCacheValid = false;
 	bool openCompositeUpscalingBackendSkipLogged = false;
 

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -326,6 +326,25 @@ public:
 	BlurResources GetBlurResources() const;
 
 private:
+	// OpenComposite conflict guard: when the OpenComposite VR shim runs its own
+	// DLSS/FSR/DLAA upscaling, ours must stand down to avoid double upscaling.
+	struct OpenCompositeUpscalingBlocker
+	{
+		bool active = false;
+		std::string settingName;
+		std::string configPath;
+	};
+
+	// forceRefresh re-probes opencomposite.ini; otherwise the cached result is
+	// returned so per-frame callers stay cheap.
+	const OpenCompositeUpscalingBlocker& GetOpenCompositeUpscalingBlocker(bool a_forceRefresh = false) const;
+	// Forces upscaleMethod/upscaleMethodNoDLSS to None when the guard is active.
+	void ApplyOpenCompositeUpscalingBlocker(bool a_forceRefresh = false);
+
+	mutable OpenCompositeUpscalingBlocker openCompositeUpscalingBlocker;
+	mutable bool openCompositeUpscalingBlockerCacheValid = false;
+	bool openCompositeUpscalingBackendSkipLogged = false;
+
 	struct Main_UpdateJitter
 	{
 		static void thunk(RE::BSGraphics::State* a_state);

--- a/src/Features/VR/OpenVRDetection.cpp
+++ b/src/Features/VR/OpenVRDetection.cpp
@@ -168,11 +168,14 @@ namespace
 
 	void UpdateOpenCompositeSettingValue(OpenCompositeSettingValue& setting, const CSimpleIniA& ini, const char* key, const std::filesystem::path& path)
 	{
+		// Enabled-by-any-config wins: only an explicit true updates the setting, so
+		// a later file's false can't clobber an earlier file's true. configPath
+		// then names the file that enabled it (for the UI/log message).
 		bool parsedValue = false;
-		if (!TryReadIniBoolSetting(ini, key, parsedValue))
+		if (!TryReadIniBoolSetting(ini, key, parsedValue) || !parsedValue)
 			return;
 
-		setting.value = parsedValue;
+		setting.value = true;
 		setting.configPath = path.string();
 	}
 

--- a/src/Features/VR/OpenVRDetection.cpp
+++ b/src/Features/VR/OpenVRDetection.cpp
@@ -1,10 +1,209 @@
 #include "OpenVRDetection.h"
+#include <algorithm>
+#include <cctype>
+#include <cwctype>
+#include <filesystem>
 #include <format>
 #include <openvr.h>
+#include <string_view>
 #include <vector>
 #include <windows.h>
 #include <winver.h>
 #pragma comment(lib, "version.lib")
+
+namespace
+{
+	struct OpenCompositeSettingValue
+	{
+		bool value = false;
+		std::string configPath;
+	};
+
+	struct OpenCompositeUpscalingSettings
+	{
+		OpenCompositeSettingValue dlssEnabled;
+		OpenCompositeSettingValue fsrEnabled;
+		OpenCompositeSettingValue dlaaEnabled;
+		OpenCompositeSettingValue fsrNativeAA;
+		OpenCompositeSettingValue fsr3PostAAEnabled;
+	};
+
+	std::string_view TrimAsciiWhitespace(std::string_view value)
+	{
+		while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front())))
+			value.remove_prefix(1);
+		while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back())))
+			value.remove_suffix(1);
+		return value;
+	}
+
+	std::string ToLowerAscii(std::string_view value)
+	{
+		std::string result(value);
+		std::ranges::transform(result, result.begin(), [](unsigned char c) {
+			return static_cast<char>(std::tolower(c));
+		});
+		return result;
+	}
+
+	bool TryParseOpenCompositeBool(std::string value, bool& outValue)
+	{
+		value = ToLowerAscii(TrimAsciiWhitespace(value));
+		if (value == "true" || value == "on" || value == "enabled" || value == "1") {
+			outValue = true;
+			return true;
+		}
+		if (value == "false" || value == "off" || value == "disabled" || value == "0") {
+			outValue = false;
+			return true;
+		}
+		return false;
+	}
+
+	void AddUniquePath(std::vector<std::filesystem::path>& paths, const std::filesystem::path& path)
+	{
+		if (path.empty())
+			return;
+
+		auto normalized = path.lexically_normal().wstring();
+		std::ranges::transform(normalized, normalized.begin(), [](wchar_t c) {
+			return static_cast<wchar_t>(std::towlower(c));
+		});
+
+		const bool alreadyAdded = std::ranges::any_of(paths, [&](const std::filesystem::path& existing) {
+			auto existingNormalized = existing.lexically_normal().wstring();
+			std::ranges::transform(existingNormalized, existingNormalized.begin(), [](wchar_t c) {
+				return static_cast<wchar_t>(std::towlower(c));
+			});
+			return existingNormalized == normalized;
+		});
+		if (!alreadyAdded)
+			paths.push_back(path);
+	}
+
+	std::filesystem::path GetCurrentDirectoryPath()
+	{
+		std::wstring buffer(MAX_PATH, L'\0');
+		const DWORD length = GetCurrentDirectoryW(static_cast<DWORD>(buffer.size()), buffer.data());
+		if (length == 0)
+			return {};
+
+		if (length >= buffer.size()) {
+			buffer.resize(length + 1);
+			const DWORD retryLength = GetCurrentDirectoryW(static_cast<DWORD>(buffer.size()), buffer.data());
+			if (retryLength == 0 || retryLength >= buffer.size())
+				return {};
+			buffer.resize(retryLength);
+		} else {
+			buffer.resize(length);
+		}
+
+		return std::filesystem::path(buffer);
+	}
+
+	// Full path of the already-loaded openvr_api.dll, or empty if it isn't
+	// loaded. Shared by the config probe and GatherDLLInfo so the module lookup
+	// lives in one place.
+	std::filesystem::path GetLoadedOpenVRDllPath()
+	{
+		HMODULE openVRModule = GetModuleHandleW(L"openvr_api.dll");
+		if (!openVRModule)
+			return {};
+
+		std::wstring buffer(MAX_PATH, L'\0');
+		const DWORD length = GetModuleFileNameW(openVRModule, buffer.data(), static_cast<DWORD>(buffer.size()));
+		if (length == 0 || length >= buffer.size())
+			return {};
+
+		buffer.resize(length);
+		return std::filesystem::path(buffer);
+	}
+
+	std::filesystem::path GetLoadedOpenVRDirectory()
+	{
+		return GetLoadedOpenVRDllPath().parent_path();
+	}
+
+	std::vector<std::filesystem::path> GetOpenCompositeConfigCandidates()
+	{
+		std::vector<std::filesystem::path> candidates;
+
+		const auto loadedOpenVRDirectory = GetLoadedOpenVRDirectory();
+		if (!loadedOpenVRDirectory.empty()) {
+			AddUniquePath(candidates, loadedOpenVRDirectory / L"opencomposite.ini");
+			AddUniquePath(candidates, loadedOpenVRDirectory / L"opencomposite_ext.ini");
+		}
+
+		const auto currentDirectory = GetCurrentDirectoryPath();
+		if (!currentDirectory.empty()) {
+			AddUniquePath(candidates, currentDirectory / L"opencomposite.ini");
+			AddUniquePath(candidates, currentDirectory / L"opencomposite_ext.ini");
+		}
+
+		return candidates;
+	}
+
+	// OpenComposite writes upscaling keys at top level or under a section
+	// depending on build, so probe the unnamed section first then every named
+	// one.
+	bool TryReadIniBoolSetting(const CSimpleIniA& ini, const char* key, bool& outValue)
+	{
+		auto tryReadSection = [&](const char* section) {
+			const char* rawValue = ini.GetValue(section, key, nullptr);
+			return rawValue && TryParseOpenCompositeBool(rawValue, outValue);
+		};
+
+		if (tryReadSection(""))
+			return true;
+
+		CSimpleIniA::TNamesDepend sections;
+		ini.GetAllSections(sections);
+		for (const auto& section : sections) {
+			if (section.pItem && tryReadSection(section.pItem))
+				return true;
+		}
+
+		return false;
+	}
+
+	void UpdateOpenCompositeSettingValue(OpenCompositeSettingValue& setting, const CSimpleIniA& ini, const char* key, const std::filesystem::path& path)
+	{
+		bool parsedValue = false;
+		if (!TryReadIniBoolSetting(ini, key, parsedValue))
+			return;
+
+		setting.value = parsedValue;
+		setting.configPath = path.string();
+	}
+
+	OpenCompositeUpscalingSettings ReadOpenCompositeUpscalingSettings()
+	{
+		OpenCompositeUpscalingSettings settings;
+
+		std::error_code ec;
+		for (const auto& path : GetOpenCompositeConfigCandidates()) {
+			if (!std::filesystem::exists(path, ec))
+				continue;
+			ec.clear();
+
+			CSimpleIniA ini;
+			ini.SetUnicode();
+			const SI_Error rc = ini.LoadFile(path.c_str());
+			if (rc < 0) {
+				logger::warn("[VRDetection] Failed to read OpenComposite config '{}': {}", path.string(), static_cast<int>(rc));
+				continue;
+			}
+
+			UpdateOpenCompositeSettingValue(settings.dlssEnabled, ini, "dlssEnabled", path);
+			UpdateOpenCompositeSettingValue(settings.fsrEnabled, ini, "fsrEnabled", path);
+			UpdateOpenCompositeSettingValue(settings.dlaaEnabled, ini, "dlaaEnabled", path);
+			UpdateOpenCompositeSettingValue(settings.fsrNativeAA, ini, "fsrNativeAA", path);
+			UpdateOpenCompositeSettingValue(settings.fsr3PostAAEnabled, ini, "fsr3PostAAEnabled", path);
+		}
+
+		return settings;
+	}
+}
 
 namespace VRDetection
 {
@@ -41,27 +240,21 @@ namespace VRDetection
 
 	void GatherDLLInfo(OpenVRDetectionResult& result)
 	{
-		HMODULE hModule = GetModuleHandleA("openvr_api.dll");
-		if (!hModule) {
+		const auto dllPathFs = GetLoadedOpenVRDllPath();
+		if (dllPathFs.empty()) {
 			result.isAvailable = false;
 			return;
 		}
 
 		result.isAvailable = true;
 
-		char dllPath[MAX_PATH];
-		DWORD fileLength = GetModuleFileNameA(hModule, dllPath, MAX_PATH);
-		if (fileLength == 0 || (fileLength == MAX_PATH && GetLastError() == ERROR_INSUFFICIENT_BUFFER)) {
-			result.isAvailable = false;
-			return;
-		}
-
+		const std::string dllPath = dllPathFs.string();
 		result.dllPath = dllPath;
 
-		DWORD dwSize = GetFileVersionInfoSizeA(dllPath, nullptr);
+		DWORD dwSize = GetFileVersionInfoSizeA(dllPath.c_str(), nullptr);
 		if (dwSize > 0) {
 			std::vector<BYTE> buffer(dwSize);
-			if (GetFileVersionInfoA(dllPath, 0, dwSize, buffer.data())) {
+			if (GetFileVersionInfoA(dllPath.c_str(), 0, dwSize, buffer.data())) {
 				VS_FIXEDFILEINFO* pFileInfo = nullptr;
 				UINT len = 0;
 				if (VerQueryValueA(buffer.data(), "\\", reinterpret_cast<LPVOID*>(&pFileInfo), &len)) {
@@ -78,7 +271,7 @@ namespace VRDetection
 			result.version = "Unknown";
 
 		WIN32_FIND_DATAA findData;
-		HANDLE hFind = FindFirstFileA(dllPath, &findData);
+		HANDLE hFind = FindFirstFileA(dllPath.c_str(), &findData);
 		if (hFind != INVALID_HANDLE_VALUE) {
 			FindClose(hFind);
 			ULARGE_INTEGER fileSize;
@@ -132,5 +325,32 @@ namespace VRDetection
 		result.isCompatible = ProbeRuntimeInterfaces(result);
 
 		return result;
+	}
+
+	OpenCompositeUpscalingState DetectOpenCompositeUpscaling()
+	{
+		const auto settings = ReadOpenCompositeUpscalingSettings();
+
+		OpenCompositeUpscalingState state;
+		auto setActive = [&](const char* settingName, const OpenCompositeSettingValue& setting) {
+			state.active = true;
+			state.settingName = settingName;
+			state.configPath = setting.configPath;
+		};
+
+		// Report the most representative enabled setting (AA modes first) as the
+		// trigger shown in the UI/log.
+		if (settings.dlaaEnabled.value)
+			setActive("dlaaEnabled", settings.dlaaEnabled);
+		else if (settings.fsrNativeAA.value)
+			setActive("fsrNativeAA", settings.fsrNativeAA);
+		else if (settings.fsr3PostAAEnabled.value)
+			setActive("fsr3PostAAEnabled", settings.fsr3PostAAEnabled);
+		else if (settings.dlssEnabled.value)
+			setActive("dlssEnabled", settings.dlssEnabled);
+		else if (settings.fsrEnabled.value)
+			setActive("fsrEnabled", settings.fsrEnabled);
+
+		return state;
 	}
 }

--- a/src/Features/VR/OpenVRDetection.h
+++ b/src/Features/VR/OpenVRDetection.h
@@ -32,9 +32,9 @@ namespace VRDetection
 		bool probingSucceeded = false;
 	};
 
-	// Whether OpenComposite is running its own DLSS/FSR/DLAA upscaling, read
-	// from its config. Lets a feature (e.g. Upscaling) stand down so the two
-	// don't stack. settingName/configPath identify the trigger for UI/logs.
+	// Whether OpenComposite is running its own DLSS/FSR/DLAA upscaling (so a
+	// feature like Upscaling can stand down). settingName/configPath name the
+	// trigger for UI/logs.
 	struct OpenCompositeUpscalingState
 	{
 		bool active = false;
@@ -54,10 +54,9 @@ namespace VRDetection
 	// Full detection via interface probing
 	OpenVRDetectionResult Detect();
 
-	// Probe opencomposite.ini / opencomposite_ext.ini (next to the loaded
-	// openvr_api.dll and in the CWD) for an enabled DLSS/FSR/DLAA upscaler.
-	// Returns an inactive state when no config or no upscaler is found. Does
-	// not itself check whether VR is active — callers gate on that.
+	// Probe opencomposite.ini / opencomposite_ext.ini (by the loaded
+	// openvr_api.dll and in the CWD) for an enabled upscaler. Inactive when none
+	// found. Does not check whether VR is active — callers gate on that.
 	OpenCompositeUpscalingState DetectOpenCompositeUpscaling();
 
 	const char* RuntimeTypeToString(RuntimeType type);

--- a/src/Features/VR/OpenVRDetection.h
+++ b/src/Features/VR/OpenVRDetection.h
@@ -32,6 +32,16 @@ namespace VRDetection
 		bool probingSucceeded = false;
 	};
 
+	// Whether OpenComposite is running its own DLSS/FSR/DLAA upscaling, read
+	// from its config. Lets a feature (e.g. Upscaling) stand down so the two
+	// don't stack. settingName/configPath identify the trigger for UI/logs.
+	struct OpenCompositeUpscalingState
+	{
+		bool active = false;
+		std::string settingName;
+		std::string configPath;
+	};
+
 	// Runtime interface probing via VR_IsInterfaceVersionValid
 	bool ProbeRuntimeInterfaces(OpenVRDetectionResult& result);
 
@@ -43,6 +53,12 @@ namespace VRDetection
 
 	// Full detection via interface probing
 	OpenVRDetectionResult Detect();
+
+	// Probe opencomposite.ini / opencomposite_ext.ini (next to the loaded
+	// openvr_api.dll and in the CWD) for an enabled DLSS/FSR/DLAA upscaler.
+	// Returns an inactive state when no config or no upscaler is found. Does
+	// not itself check whether VR is active — callers gate on that.
+	OpenCompositeUpscalingState DetectOpenCompositeUpscaling();
 
 	const char* RuntimeTypeToString(RuntimeType type);
 }


### PR DESCRIPTION
## Summary

Ports the OpenComposite upscaling conflict guard from
[ParticleTroned/skyrim-community-shaders#1](https://github.com/ParticleTroned/skyrim-community-shaders/pull/1)
(by @ColdBomb1) into Open Shaders.

When the OpenComposite VR shim (OpenXR-over-OpenVR) runs its own DLSS/FSR/DLAA
upscaling, our upscaler stacking on top causes double upscaling, double jitter,
and conflicting dynamic-resolution sizing — blur/ghosting/broken AA in the
headset. This detects OpenComposite's upscaling from `opencomposite.ini` and
makes our Upscaling feature stand down so OpenComposite owns the upscale.

## What it does

- Probes `opencomposite.ini` / `opencomposite_ext.ini` (loaded `openvr_api.dll`
  directory + CWD) for `dlssEnabled`, `fsrEnabled`, `dlaaEnabled`, `fsrNativeAA`,
  `fsr3PostAAEnabled` (section-agnostic).
- When any is enabled (**VR only**): forces `upscaleMethod` /
  `upscaleMethodNoDLSS` to None, locks the Method picker with a warning, and
  short-circuits `Load` (IAT hook), `PostPostLoad` (render hooks),
  `SetupResources`, and `LoadUpscalingSDKs` (Streamline/FFX init).
- `GetUpscaleMethod()` returns None while blocked; `Save`/`Load`/`Restore`
  re-assert None so the override persists.
- Result is cached; lifecycle entry points force-refresh, per-frame callers read
  the cached bool.

## Differences from the source PR (re-authored, not cherry-picked)

- **UI**: our method picker is `ImGui::Combo` + `BootSnapshot`, not the source's
  `SliderInt`/`UpscaleUiChoice`. The lock + warning are re-authored against ours.
- **Foveated ordering**: the `PostPostLoad` early-return is placed *before*
  `foveatedRender.PostPostLoad()`, and the `GetUpscaleMethod` check *before* the
  PerfMode branch, so our DLSS-foveated divergence stands down too.
- Dropped the source PR's unused refresh-timestamp field (dead code).
- Self-contained `GetLoadedOpenVRDirectory()` rather than reusing
  `VRDetection::GatherDLLInfo` (which also parses version info / enumerates the
  file — more work than a directory lookup needs). Possible future consolidation.
- In-menu/log text is brand-neutral ("OpenComposite" / "Upscaling") per our
  naming rules; warning uses `Util::Text::WrappedWarning`.

## Testing

- Builds clean: `BuildRelease.bat ALL` (universal SE/AE/VR), exit 0, no warnings
  on `Upscaling.cpp`.
- **Not yet runtime-tested** in a VR + OpenComposite session. The guard is gated
  on `globals::game::isVR` and only fires when `opencomposite.ini` actually has
  an upscaler enabled, so SteamVR and flat-screen users are unaffected. In-game
  VR validation recommended before merge.

## Attribution

Original work by @ColdBomb1 in ParticleTroned/skyrim-community-shaders#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detect when an external VR compositor is applying upscaling and automatically lock the app's upscaling to "None", showing a warning.
  * Disable the upscaling method selector while blocked and persist the "None" selection until the external setting is cleared.
  * Prevent upscaling initialization and apply no upscaling during the blocked state to avoid conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->