### PR TITLE
fix(truepbr): honor DisableTerrainVertexColors on PBR landscape

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2152,8 +2152,16 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	material.Metallic = saturate(rawRMAOS.y);
 	material.AO = rawRMAOS.z;
 
-	// Apply vertex color to base color so PBR metals use it
-	float3 pbrVertexColor = Color::SrgbToLinear(input.Color.xyz);
+	// Apply vertex color to base color so PBR metals use it. On LANDSCAPE,
+	// honor DisableTerrainVertexColors (as the non-PBR path does) by
+	// neutralizing the source color so terrain vertex colors don't tint PBR;
+	// a white source yields VertexAO == 1, i.e. no AO darkening either.
+	float3 pbrVertexColorSrc = input.Color.xyz;
+#		if defined(LANDSCAPE)
+	if (SharedData::lodBlendingSettings.DisableTerrainVertexColors)
+		pbrVertexColorSrc = 1;
+#		endif
+	float3 pbrVertexColor = Color::SrgbToLinear(pbrVertexColorSrc);
 	float pbrVertexAO = max(max(pbrVertexColor.x, pbrVertexColor.y), pbrVertexColor.z);
 	pbrVertexColor = pbrVertexAO == 0.0f ? 1.0f : pbrVertexColor * lerp(1 / max(pbrVertexAO, 0.001), 1, SharedData::truePBRSettings.VertexAOStrength);
 


### PR DESCRIPTION
## Summary

The non-PBR landscape path in `Lighting.hlsl` already honors `lodBlendingSettings.DisableTerrainVertexColors` (it neutralizes terrain vertex colors when the toggle is set). The **TruePBR path ignored it**, so the toggle had no effect on PBR terrain — an inconsistency between the two paths.

This neutralizes the source vertex color on `LANDSCAPE` before our sRGB + vertex-AO step. Forcing the source to white yields `VertexAO == 1`, so it matches the "no vertex color" intent without introducing AO darkening.

## Change

`package/Shaders/Lighting.hlsl` (TruePBR section) — restructure `pbrVertexColor` to read from a `pbrVertexColorSrc` that is forced to `1` under `#if defined(LANDSCAPE)` when `DisableTerrainVertexColors` is set, before `SrgbToLinear` + our existing `VertexAOStrength` logic (which is preserved unchanged).

The symbol is already used by the non-PBR path (`Lighting.hlsl` ~line 2996) and `RunGrass.hlsl`, so no new constant is introduced. CI shader validation covers the affected permutations.

## Note on adaptation

The upstream fork's version simply forces `pbrVertexColor = 1`. Our `pbrVertexColor` path diverged with VertexAO logic (`VertexAOStrength`), so this is adapted to neutralize the *source* color before that step rather than the final value — same end result, compatible with our divergence.

## Attribution

Ported from [ParticleTroned/skyrim-community-shaders](https://github.com/ParticleTroned/skyrim-community-shaders) (`fix(truepbr): honor LOD terrain vertex color toggle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected terrain vertex color handling in material rendering to respect the terrain vertex color setting, preventing unwanted color influence on material appearance when the setting is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->