### PR TITLE
feat(vr): foveated SSR raymarching

### DIFF
--- a/package/Shaders/Common/FoveatedMask.hlsli
+++ b/package/Shaders/Common/FoveatedMask.hlsli
@@ -1,10 +1,8 @@
 #ifndef FOVEATED_MASK_HLSLI
 #define FOVEATED_MASK_HLSLI
 
-// Superellipse (shape power 4 = squircle) foveation mask. Produces a smooth
-// radial center->periphery weight that matches peripheral-vision falloff and
-// avoids the hard rectangular seam a rect mask would show. CPU mirror of the
-// parameter clamping lives in src/Features/FoveatedCommon.h.
+// Superellipse (shape power 4 = squircle) foveation mask: a smooth center->periphery weight that
+// avoids the hard seam of a rect mask. CPU mirror of the clamping is in src/Features/FoveatedCommon.h.
 
 #ifndef FOVEATED_CENTER_SCALE_MIN
 #	define FOVEATED_CENTER_SCALE_MIN 0.25

--- a/package/Shaders/Common/FoveatedMask.hlsli
+++ b/package/Shaders/Common/FoveatedMask.hlsli
@@ -61,10 +61,19 @@ float FoveatedComputeMaskDistance(float2 eyeUv, float centerScale, float centerH
 	float2 centerUv = FoveatedComputeCenterUV(centerOffset);
 	float2 normalized = (eyeUv - centerUv) / radii;
 	float2 absoluteNormalized = abs(normalized);
+#if FOVEATED_MASK_SHAPE_POWER == 4
+	// Squircle fast path: pow(t,4) == (t*t)^2 and pow(sum,1/4) == sqrt(sqrt(sum)),
+	// so the default shape avoids three transcendental pow() calls per pixel in
+	// the SSR path that is explicitly trying to save GPU time.
+	float2 sq = absoluteNormalized * absoluteNormalized;
+	float pNorm = sq.x * sq.x + sq.y * sq.y;
+	return sqrt(sqrt(max(pNorm, 0.0)));
+#else
 	float shapePower = max((float)FOVEATED_MASK_SHAPE_POWER, 1.0);
 	float invShapePower = 1.0 / shapePower;
 	float pNorm = pow(absoluteNormalized.x, shapePower) + pow(absoluteNormalized.y, shapePower);
 	return pow(max(pNorm, 0.0), invShapePower);
+#endif
 }
 
 float FoveatedComputeCenterBlendWeight(float2 eyeUv, float centerScale, float centerFeather, float centerHorizontalScale, float2 centerOffset)

--- a/package/Shaders/Common/FoveatedMask.hlsli
+++ b/package/Shaders/Common/FoveatedMask.hlsli
@@ -6,11 +6,11 @@
 // avoids the hard rectangular seam a rect mask would show. CPU mirror of the
 // parameter clamping lives in src/Features/FoveatedCommon.h.
 
-#ifndef FOVEATED_CENTER_AREA_MIN
-#	define FOVEATED_CENTER_AREA_MIN 0.25
+#ifndef FOVEATED_CENTER_SCALE_MIN
+#	define FOVEATED_CENTER_SCALE_MIN 0.25
 #endif
-#ifndef FOVEATED_CENTER_AREA_MAX
-#	define FOVEATED_CENTER_AREA_MAX 1.0
+#ifndef FOVEATED_CENTER_SCALE_MAX
+#	define FOVEATED_CENTER_SCALE_MAX 1.0
 #endif
 #ifndef FOVEATED_CENTER_FEATHER_MIN
 #	define FOVEATED_CENTER_FEATHER_MIN 1e-4
@@ -25,9 +25,9 @@
 #	define FOVEATED_MASK_SHAPE_POWER 4
 #endif
 
-float FoveatedClampCenterArea(float centerScale)
+float FoveatedClampCenterScale(float centerScale)
 {
-	return clamp(centerScale, FOVEATED_CENTER_AREA_MIN, FOVEATED_CENTER_AREA_MAX);
+	return clamp(centerScale, FOVEATED_CENTER_SCALE_MIN, FOVEATED_CENTER_SCALE_MAX);
 }
 
 float2 FoveatedComputeCenterUV(float2 centerOffset)
@@ -42,7 +42,7 @@ float FoveatedClampCenterHorizontalScale(float centerHorizontalScale)
 
 float2 FoveatedComputeMaskRadii(float centerScale, float centerHorizontalScale)
 {
-	float clampedCenterScale = FoveatedClampCenterArea(centerScale);
+	float clampedCenterScale = FoveatedClampCenterScale(centerScale);
 	float clampedCenterHorizontalScale = FoveatedClampCenterHorizontalScale(centerHorizontalScale);
 	float2 radii = float2(clampedCenterScale * clampedCenterHorizontalScale * 0.5, clampedCenterScale * 0.5);
 	return max(radii, FOVEATED_CENTER_FEATHER_MIN.xx);

--- a/package/Shaders/Common/FoveatedMask.hlsli
+++ b/package/Shaders/Common/FoveatedMask.hlsli
@@ -1,0 +1,77 @@
+#ifndef FOVEATED_MASK_HLSLI
+#define FOVEATED_MASK_HLSLI
+
+// Superellipse (shape power 4 = squircle) foveation mask. Produces a smooth
+// radial center->periphery weight that matches peripheral-vision falloff and
+// avoids the hard rectangular seam a rect mask would show. CPU mirror of the
+// parameter clamping lives in src/Features/FoveatedCommon.h.
+
+#ifndef FOVEATED_CENTER_AREA_MIN
+#	define FOVEATED_CENTER_AREA_MIN 0.25
+#endif
+#ifndef FOVEATED_CENTER_AREA_MAX
+#	define FOVEATED_CENTER_AREA_MAX 1.0
+#endif
+#ifndef FOVEATED_CENTER_FEATHER_MIN
+#	define FOVEATED_CENTER_FEATHER_MIN 1e-4
+#endif
+#ifndef FOVEATED_CENTER_HORIZONTAL_SCALE_MIN
+#	define FOVEATED_CENTER_HORIZONTAL_SCALE_MIN 1.0
+#endif
+#ifndef FOVEATED_CENTER_HORIZONTAL_SCALE_MAX
+#	define FOVEATED_CENTER_HORIZONTAL_SCALE_MAX 2.0
+#endif
+#ifndef FOVEATED_MASK_SHAPE_POWER
+#	define FOVEATED_MASK_SHAPE_POWER 4
+#endif
+
+float FoveatedClampCenterArea(float centerScale)
+{
+	return clamp(centerScale, FOVEATED_CENTER_AREA_MIN, FOVEATED_CENTER_AREA_MAX);
+}
+
+float2 FoveatedComputeCenterUV(float2 centerOffset)
+{
+	return clamp(float2(0.5, 0.5) + centerOffset, float2(0.0, 0.0), float2(1.0, 1.0));
+}
+
+float FoveatedClampCenterHorizontalScale(float centerHorizontalScale)
+{
+	return clamp(centerHorizontalScale, FOVEATED_CENTER_HORIZONTAL_SCALE_MIN, FOVEATED_CENTER_HORIZONTAL_SCALE_MAX);
+}
+
+float2 FoveatedComputeMaskRadii(float centerScale, float centerHorizontalScale)
+{
+	float clampedCenterScale = FoveatedClampCenterArea(centerScale);
+	float clampedCenterHorizontalScale = FoveatedClampCenterHorizontalScale(centerHorizontalScale);
+	float2 radii = float2(clampedCenterScale * clampedCenterHorizontalScale * 0.5, clampedCenterScale * 0.5);
+	return max(radii, FOVEATED_CENTER_FEATHER_MIN.xx);
+}
+
+float FoveatedComputeNormalizedFeather(float centerScale, float centerFeather, float centerHorizontalScale)
+{
+	float2 radii = FoveatedComputeMaskRadii(centerScale, centerHorizontalScale);
+	float baseRadius = max(min(radii.x, radii.y), FOVEATED_CENTER_FEATHER_MIN);
+	return max(centerFeather, FOVEATED_CENTER_FEATHER_MIN) / baseRadius;
+}
+
+float FoveatedComputeMaskDistance(float2 eyeUv, float centerScale, float centerHorizontalScale, float2 centerOffset)
+{
+	float2 radii = FoveatedComputeMaskRadii(centerScale, centerHorizontalScale);
+	float2 centerUv = FoveatedComputeCenterUV(centerOffset);
+	float2 normalized = (eyeUv - centerUv) / radii;
+	float2 absoluteNormalized = abs(normalized);
+	float shapePower = max((float)FOVEATED_MASK_SHAPE_POWER, 1.0);
+	float invShapePower = 1.0 / shapePower;
+	float pNorm = pow(absoluteNormalized.x, shapePower) + pow(absoluteNormalized.y, shapePower);
+	return pow(max(pNorm, 0.0), invShapePower);
+}
+
+float FoveatedComputeCenterBlendWeight(float2 eyeUv, float centerScale, float centerFeather, float centerHorizontalScale, float2 centerOffset)
+{
+	float normalizedFeather = FoveatedComputeNormalizedFeather(centerScale, centerFeather, centerHorizontalScale);
+	float maskDistance = FoveatedComputeMaskDistance(eyeUv, centerScale, centerHorizontalScale, centerOffset);
+	return 1.0 - smoothstep(1.0, 1.0 + normalizedFeather, maskDistance);
+}
+
+#endif

--- a/package/Shaders/Common/FoveatedShaderDetail.hlsli
+++ b/package/Shaders/Common/FoveatedShaderDetail.hlsli
@@ -1,10 +1,8 @@
 #ifndef FOVEATED_SHADER_DETAIL_HLSLI
 #define FOVEATED_SHADER_DETAIL_HLSLI
 
-// Per-pixel detail weight for foveated effects. Effects pass their mode
-// (0=off, 1=feathered, 2=hard cutoff; see FoveatedCommon::GetShaderMode) plus
-// the active foveation mask params, and get back a 0..1 weight to scale their
-// work by. Outside the mask the weight is 0, letting the effect skip entirely.
+// Per-pixel detail weight for foveated effects: pass the mode (0=off/1=feathered/2=hard, see
+// FoveatedCommon::GetShaderMode) + mask params, get a 0..1 weight (0 outside the mask = skip).
 
 #include "Common/FoveatedMask.hlsli"
 

--- a/package/Shaders/Common/FoveatedShaderDetail.hlsli
+++ b/package/Shaders/Common/FoveatedShaderDetail.hlsli
@@ -1,0 +1,34 @@
+#ifndef FOVEATED_SHADER_DETAIL_HLSLI
+#define FOVEATED_SHADER_DETAIL_HLSLI
+
+// Per-pixel detail weight for foveated effects. Effects pass their mode
+// (0=off, 1=feathered, 2=hard cutoff; see FoveatedCommon::GetShaderMode) plus
+// the active foveation mask params, and get back a 0..1 weight to scale their
+// work by. Outside the mask the weight is 0, letting the effect skip entirely.
+
+#include "Common/FoveatedMask.hlsli"
+
+static const float FOVEATED_SHADER_DETAIL_MODE_FEATHERED = 1.0;
+static const float FOVEATED_SHADER_DETAIL_MODE_HARD_CUTOFF = 2.0;
+
+float FoveatedEvaluateShaderDetailWeight(float mode, float2 eyeUv, float centerScale, float centerFeather, float centerHorizontalScale, float2 centerOffset)
+{
+	bool detailModeEnabled = mode >= FOVEATED_SHADER_DETAIL_MODE_FEATHERED;
+	if (!detailModeEnabled)
+		return 1.0f;
+
+	bool hardCutoffMode = mode >= FOVEATED_SHADER_DETAIL_MODE_HARD_CUTOFF;
+	if (hardCutoffMode) {
+		float edgeDistance = FoveatedComputeMaskDistance(eyeUv, centerScale, centerHorizontalScale, centerOffset);
+		return edgeDistance > 1.0f ? 0.0f : 1.0f;
+	}
+
+	return FoveatedComputeCenterBlendWeight(eyeUv, centerScale, centerFeather, centerHorizontalScale, centerOffset);
+}
+
+bool FoveatedIsShaderDetailActive(float detailWeight)
+{
+	return detailWeight > 0.0001f;
+}
+
+#endif

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -30,6 +30,8 @@ namespace SharedData
 		float4 AmbientSHR;
 		float4 AmbientSHG;
 		float4 AmbientSHB;
+		float4 VRFoveationData0;          // x=center scale, y=feather, z=horizontal scale, w=SSR raymarch mode (0 off, 1 feathered, 2 hard cutoff)
+		float4 VRFoveationCenterOffsets;  // xy=left eye center offset, zw=right eye center offset
 		float4 HDRData;
 	};
 

--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -30,7 +30,7 @@ namespace SharedData
 		float4 AmbientSHR;
 		float4 AmbientSHG;
 		float4 AmbientSHB;
-		float4 VRFoveationData0;          // x=center scale, y=feather, z=horizontal scale, w=SSR raymarch mode (0 off, 1 feathered, 2 hard cutoff)
+		float4 VRFoveationData0;          // x=center coverage scale, y=feather, z=horizontal scale, w=SSR raymarch mode (0 off, 1 feathered, 2 hard cutoff)
 		float4 VRFoveationCenterOffsets;  // xy=left eye center offset, zw=right eye center offset
 		float4 HDRData;
 	};

--- a/package/Shaders/ISReflectionsRayTracing.hlsl
+++ b/package/Shaders/ISReflectionsRayTracing.hlsl
@@ -33,6 +33,40 @@ static const int binaryIterations = ceil(log2(iterations));
 
 static const float rayLength = 1.0;
 
+#	if defined(VR)
+#		include "Common/FoveatedShaderDetail.hlsli"
+
+static const int minFoveatedIterations = 16;
+
+// Per-pixel SSR foveation weight from the active foveation mask (VRFoveationData0
+// + per-eye center offset). 1 in the center, falling to 0 in the periphery.
+float GetVRSSRFoveationWeight(float ssrFoveationMode, float2 eyeUv, uint eyeIndex)
+{
+	float2 centerOffset = eyeIndex == 0 ? SharedData::VRFoveationCenterOffsets.xy : SharedData::VRFoveationCenterOffsets.zw;
+	return FoveatedEvaluateShaderDetailWeight(
+		ssrFoveationMode,
+		eyeUv,
+		SharedData::VRFoveationData0.x,
+		SharedData::VRFoveationData0.y,
+		SharedData::VRFoveationData0.z,
+		centerOffset);
+}
+
+// Scale the raymarch count by the foveation weight: full in the center, down to
+// minFoveatedIterations toward the periphery.
+int GetSSRRaymarchIterations(float foveationWeight)
+{
+	int iterationCount = (int)ceil(lerp((float)minFoveatedIterations, (float)iterations, saturate(foveationWeight)));
+	return min(max(iterationCount, minFoveatedIterations), iterations);
+}
+
+int GetSSRBinaryIterations(int raymarchIterations)
+{
+	int iterationCount = (int)ceil(log2((float)raymarchIterations));
+	return min(max(iterationCount, 1), binaryIterations);
+}
+#	endif
+
 float2 ConvertRaySample(float2 raySample, uint eyeIndex)
 {
 	return FrameBuffer::GetDynamicResolutionAdjustedScreenPosition(Stereo::ConvertToStereoUV(raySample, eyeIndex));
@@ -46,14 +80,35 @@ float2 ConvertRaySamplePrevious(float2 raySample, uint eyeIndex)
 float4 GetReflectionColor(
 	float3 projReflectionDirection,
 	float3 projPosition,
-	uint eyeIndex)
+	uint eyeIndex
+#	if defined(VR)
+	,
+	int raymarchIterations,
+	int binaryIterationsCount,
+	float foveationWeight
+#	endif
+)
 {
 	float3 prevRaySample;
 	float3 raySample = projPosition;
 
-	for (int i = 0; i < iterations; i++) {
+	// VR foveation reduces the raymarch/binary counts toward the periphery and
+	// fades the result; non-VR uses the full counts and no fade. The loop bounds
+	// are runtime values in VR, so [loop] is required (cannot unroll).
+#	if defined(VR)
+	int rayCount = raymarchIterations;
+	int binCount = binaryIterationsCount;
+	float fovWeight = foveationWeight;
+	[loop] for (int i = 0; i < rayCount; i++)
+	{
+#	else
+	int rayCount = iterations;
+	int binCount = binaryIterations;
+	float fovWeight = 1.0;
+	for (int i = 0; i < rayCount; i++) {
+#	endif
 		prevRaySample = raySample;
-		raySample = projPosition + (float(i) / float(iterations)) * projReflectionDirection;
+		raySample = projPosition + (float(i) / float(rayCount)) * projReflectionDirection;
 
 		float2 sampleUV;
 		uint sampleEyeIndex;
@@ -71,7 +126,12 @@ float4 GetReflectionColor(
 			float depthThicknessFactor;
 			uint hitEyeIndex = sampleEyeIndex;
 
-			for (int k = 0; k < binaryIterations; k++) {
+#	if defined(VR)
+			[loop] for (int k = 0; k < binCount; k++)
+			{
+#	else
+			for (int k = 0; k < binCount; k++) {
+#	endif
 				binaryRaySample = lerp(binaryMinRaySample, binaryMaxRaySample, 0.5);
 
 				Stereo::ResolveMonoUVForEye(binaryRaySample, eyeIndex, sampleUV, hitEyeIndex);
@@ -134,7 +194,7 @@ float4 GetReflectionColor(
 					alpha = float4(AlphaTex.SampleLevel(AlphaSampler, ConvertRaySamplePrevious(reprojectedRaySample.xy, finalEyeIndex), 0).xyz, 1.0);
 
 				float3 reflectionColor = color + SSRParams.z * alpha.xyz * alpha.w;
-				return float4(reflectionColor, fadeFactor);
+				return float4(reflectionColor, fadeFactor * fovWeight);
 			}
 
 			return 0.0;
@@ -159,6 +219,18 @@ PS_OUTPUT main(PS_INPUT input)
 	float2 screenPosition = FrameBuffer::GetDynamicResolutionAdjustedScreenPosition(uv);
 
 	uv = Stereo::ConvertFromStereoUV(uv, eyeIndex);
+
+#	if defined(VR)
+	float ssrFoveationWeight = 1.0;
+	float ssrFoveationMode = SharedData::VRFoveationData0.w;
+	[branch] if (ssrFoveationMode >= FOVEATED_SHADER_DETAIL_MODE_FEATHERED)
+	{
+		ssrFoveationWeight = GetVRSSRFoveationWeight(ssrFoveationMode, uv, eyeIndex);
+		// Outside the foveation mask: skip SSR entirely. The cubemap/water
+		// reflection fallback already covers these pixels.
+		[branch] if (!FoveatedIsShaderDetailActive(ssrFoveationWeight)) return psout;
+	}
+#	endif
 
 	[branch] if (NormalTex.Sample(NormalSampler, screenPosition).z <= 0)
 	{
@@ -191,7 +263,18 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 projPosition = float3(uv, depth);
 	float3 projReflectionDirection = normalize(projReflectionPosition.xyz - projPosition) * rayLength;
 
+#	if defined(VR)
+	int raymarchIterations = iterations;
+	int binaryIterationsCount = binaryIterations;
+	[branch] if (ssrFoveationWeight < 0.9999)
+	{
+		raymarchIterations = GetSSRRaymarchIterations(ssrFoveationWeight);
+		binaryIterationsCount = GetSSRBinaryIterations(raymarchIterations);
+	}
+	psout.Color = GetReflectionColor(projReflectionDirection, projPosition, eyeIndex, raymarchIterations, binaryIterationsCount, ssrFoveationWeight);
+#	else
 	psout.Color = GetReflectionColor(projReflectionDirection, projPosition, eyeIndex);
+#	endif
 
 	return psout;
 }

--- a/package/Shaders/ISReflectionsRayTracing.hlsl
+++ b/package/Shaders/ISReflectionsRayTracing.hlsl
@@ -92,9 +92,8 @@ float4 GetReflectionColor(
 	float3 prevRaySample;
 	float3 raySample = projPosition;
 
-	// VR foveation reduces the raymarch/binary counts toward the periphery and
-	// fades the result; non-VR uses the full counts and no fade. The loop bounds
-	// are runtime values in VR, so [loop] is required (cannot unroll).
+	// VR scales the raymarch/binary counts by the foveation weight and fades the result; non-VR uses
+	// full counts. Bounds are runtime in VR, so [loop] is required (cannot unroll).
 #	if defined(VR)
 	int rayCount = raymarchIterations;
 	int binCount = binaryIterationsCount;

--- a/src/Features/FoveatedCommon.h
+++ b/src/Features/FoveatedCommon.h
@@ -3,9 +3,8 @@
 #include <algorithm>
 #include <cmath>
 
-// Shared CPU-side helpers for VR foveated shader detail; GPU mirror in
-// package/Shaders/Common/FoveatedMask.hlsli, with GetShaderMode's 0/1/2 encoding as the contract.
-// Only the SSR-consumed pieces exist; compute-dispatch helpers are omitted until a CS effect needs them.
+// Shared CPU-side helpers for VR foveated shader detail; GPU mirror in FoveatedMask.hlsli, with
+// GetShaderMode's 0/1/2 encoding as the contract. Only SSR-consumed pieces exist (compute helpers omitted).
 namespace FoveatedCommon
 {
 	constexpr float kCenterScaleMin = 0.25f;

--- a/src/Features/FoveatedCommon.h
+++ b/src/Features/FoveatedCommon.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+
+// Shared CPU-side helpers for VR foveated shader detail. The matching GPU math
+// lives in package/Shaders/Common/FoveatedMask.hlsli; the 0/1/2 mode encoding
+// produced by GetShaderMode is the contract both sides agree on.
+//
+// Scope note: only the pieces consumed by foveated SSR are present. The
+// compute-dispatch helpers (inscribed/bounding rects, thread-group alignment)
+// from the upstream fork are intentionally omitted until a compute-shader
+// foveation effect needs them.
+namespace FoveatedCommon
+{
+	constexpr float kCenterAreaMin = 0.25f;
+	constexpr float kCenterAreaMax = 1.0f;
+	constexpr float kCenterFeather = 0.05f;
+	constexpr float kCenterHorizontalScaleMin = 1.0f;
+	constexpr float kCenterHorizontalScaleMax = 2.0f;
+	constexpr float kFullCoverageThreshold = 0.999f;
+
+	enum class DetailMode
+	{
+		Off,
+		Feathered,
+		HardCutoff
+	};
+
+	constexpr DetailMode GetDetailMode(bool a_enabled, bool a_hardCutoff)
+	{
+		if (!a_enabled)
+			return DetailMode::Off;
+		return a_hardCutoff ? DetailMode::HardCutoff : DetailMode::Feathered;
+	}
+
+	// 0 = off, 1 = feathered, 2 = hard cutoff. Must match the
+	// FOVEATED_SHADER_DETAIL_MODE_* constants in FoveatedShaderDetail.hlsli.
+	constexpr float GetShaderMode(DetailMode a_mode)
+	{
+		switch (a_mode) {
+		case DetailMode::Feathered:
+			return 1.0f;
+		case DetailMode::HardCutoff:
+			return 2.0f;
+		case DetailMode::Off:
+		default:
+			return 0.0f;
+		}
+	}
+
+	inline float ClampCenterArea(float a_value)
+	{
+		if (!std::isfinite(a_value))
+			return kCenterAreaMax;
+		return std::clamp(a_value, kCenterAreaMin, kCenterAreaMax);
+	}
+
+	// A near-full center means foveation does nothing useful — callers skip the
+	// per-pixel mask in that case to avoid paying its cost for no saving.
+	inline bool IsActiveCoverage(float a_centerArea)
+	{
+		return ClampCenterArea(a_centerArea) < kFullCoverageThreshold;
+	}
+
+	inline float ClampCenterHorizontalScale(float a_value)
+	{
+		if (!std::isfinite(a_value))
+			return 1.0f;
+		return std::clamp(a_value, kCenterHorizontalScaleMin, kCenterHorizontalScaleMax);
+	}
+}

--- a/src/Features/FoveatedCommon.h
+++ b/src/Features/FoveatedCommon.h
@@ -13,8 +13,8 @@
 // foveation effect needs them.
 namespace FoveatedCommon
 {
-	constexpr float kCenterAreaMin = 0.25f;
-	constexpr float kCenterAreaMax = 1.0f;
+	constexpr float kCenterScaleMin = 0.25f;
+	constexpr float kCenterScaleMax = 1.0f;
 	constexpr float kCenterFeather = 0.05f;
 	constexpr float kCenterHorizontalScaleMin = 1.0f;
 	constexpr float kCenterHorizontalScaleMax = 2.0f;
@@ -49,18 +49,18 @@ namespace FoveatedCommon
 		}
 	}
 
-	inline float ClampCenterArea(float a_value)
+	inline float ClampCenterScale(float a_value)
 	{
 		if (!std::isfinite(a_value))
-			return kCenterAreaMax;
-		return std::clamp(a_value, kCenterAreaMin, kCenterAreaMax);
+			return kCenterScaleMax;
+		return std::clamp(a_value, kCenterScaleMin, kCenterScaleMax);
 	}
 
 	// A near-full center means foveation does nothing useful — callers skip the
 	// per-pixel mask in that case to avoid paying its cost for no saving.
-	inline bool IsActiveCoverage(float a_centerArea)
+	inline bool IsActiveCoverage(float a_centerScale)
 	{
-		return ClampCenterArea(a_centerArea) < kFullCoverageThreshold;
+		return ClampCenterScale(a_centerScale) < kFullCoverageThreshold;
 	}
 
 	inline float ClampCenterHorizontalScale(float a_value)

--- a/src/Features/FoveatedCommon.h
+++ b/src/Features/FoveatedCommon.h
@@ -3,14 +3,9 @@
 #include <algorithm>
 #include <cmath>
 
-// Shared CPU-side helpers for VR foveated shader detail. The matching GPU math
-// lives in package/Shaders/Common/FoveatedMask.hlsli; the 0/1/2 mode encoding
-// produced by GetShaderMode is the contract both sides agree on.
-//
-// Scope note: only the pieces consumed by foveated SSR are present. The
-// compute-dispatch helpers (inscribed/bounding rects, thread-group alignment)
-// from the upstream fork are intentionally omitted until a compute-shader
-// foveation effect needs them.
+// Shared CPU-side helpers for VR foveated shader detail; GPU mirror in
+// package/Shaders/Common/FoveatedMask.hlsli, with GetShaderMode's 0/1/2 encoding as the contract.
+// Only the SSR-consumed pieces exist; compute-dispatch helpers are omitted until a CS effect needs them.
 namespace FoveatedCommon
 {
 	constexpr float kCenterScaleMin = 0.25f;

--- a/src/Features/Upscaling/FoveatedRender.cpp
+++ b/src/Features/Upscaling/FoveatedRender.cpp
@@ -3,6 +3,7 @@
 #include "../../Globals.h"
 #include "../../Utils/Subrect.h"
 #include "../../Utils/UI.h"
+#include "../FoveatedCommon.h"
 #include "../Upscaling.h"
 #include "FoveatedRender/Core.h"
 
@@ -116,6 +117,34 @@ bool FoveatedRender::IsActive() const
 bool FoveatedRender::IsRuntimeSupported() const
 {
 	return globals::game::isVR && globals::features::upscaling.streamline.featureDLSS;
+}
+
+FoveatedRender::FoveationProfile FoveatedRender::GetFoveationProfile() const
+{
+	FoveationProfile profile;
+	if (!IsActive())
+		return profile;
+
+	const auto& leftUV = subrectController.GetUV();
+	const auto& rightUV = subrectController.GetRightEyeUV();
+
+	// A full-eye region means no foveation is in effect — nothing to gate on.
+	if (leftUV.w >= 0.999f && leftUV.h >= 0.999f)
+		return profile;
+
+	// Map the rectangular subrect onto the centered-superellipse the mask helper
+	// expects: vertical extent drives coverageArea (radiusY = coverageArea/2),
+	// the rect aspect drives the horizontal stretch (radiusX = coverageArea *
+	// hScale / 2), and rect-center minus screen-center gives the per-eye offset.
+	// Feather is the framework constant. Approximate (rect vs superellipse) but
+	// sufficient for the per-pixel center/periphery weight.
+	profile.available = true;
+	profile.coverageArea = FoveatedCommon::ClampCenterArea(leftUV.h);
+	profile.centerHorizontalScale = FoveatedCommon::ClampCenterHorizontalScale(
+		leftUV.h > 1e-4f ? leftUV.w / leftUV.h : 1.0f);
+	profile.centerOffsets[0] = { (leftUV.x + leftUV.w * 0.5f) - 0.5f, (leftUV.y + leftUV.h * 0.5f) - 0.5f };
+	profile.centerOffsets[1] = { (rightUV.x + rightUV.w * 0.5f) - 0.5f, (rightUV.y + rightUV.h * 0.5f) - 0.5f };
+	return profile;
 }
 
 void FoveatedRender::LatchQualityMode()

--- a/src/Features/Upscaling/FoveatedRender.cpp
+++ b/src/Features/Upscaling/FoveatedRender.cpp
@@ -128,16 +128,12 @@ FoveatedRender::FoveationProfile FoveatedRender::GetFoveationProfile() const
 	const auto& leftUV = subrectController.GetUV();
 	const auto& rightUV = subrectController.GetRightEyeUV();
 
-	// Map the rectangular subrect onto the centered-superellipse the mask helper
-	// expects: vertical extent drives coverageScale (radiusY = coverageScale/2),
-	// the rect aspect drives the horizontal stretch (radiusX = coverageScale *
-	// hScale / 2). The mask carries one scale for both eyes (only the center
-	// offset is per-eye), so size comes from the less-foveated (larger) extent of
-	// the two eyes — the mask then stays inside each eye's full-quality region and
-	// never foveates a sharp zone. A full eye therefore yields full coverage and
-	// disables foveation entirely (the gate below). Seeded presets are symmetric
-	// in size, so left == right and this is a no-op for them. Approximate (rect vs
-	// superellipse) but sufficient for the per-pixel center/periphery weight.
+	// Map the rectangular subrect onto the centered superellipse the mask helper expects: vertical
+	// extent drives coverageScale (radiusY = coverageScale/2), the rect aspect drives the horizontal
+	// stretch (radiusX = coverageScale * hScale/2). The mask carries one scale for both eyes (only
+	// the center offset is per-eye), so size comes from the less-foveated (larger) extent of the two,
+	// keeping the mask inside each eye's full-quality region so it never foveates a sharp zone. A
+	// full eye therefore yields full coverage and disables foveation (the gate below).
 	const float coverageH = std::max(leftUV.h, rightUV.h);
 	const float coverageW = std::max(leftUV.w, rightUV.w);
 	const float coverageScale = FoveatedCommon::ClampCenterScale(coverageH);

--- a/src/Features/Upscaling/FoveatedRender.cpp
+++ b/src/Features/Upscaling/FoveatedRender.cpp
@@ -137,8 +137,8 @@ FoveatedRender::FoveationProfile FoveatedRender::GetFoveationProfile() const
 		return profile;
 
 	// Map the rectangular subrect onto the centered-superellipse the mask helper
-	// expects: vertical extent drives coverageArea (radiusY = coverageArea/2),
-	// the rect aspect drives the horizontal stretch (radiusX = coverageArea *
+	// expects: vertical extent drives coverageScale (radiusY = coverageScale/2),
+	// the rect aspect drives the horizontal stretch (radiusX = coverageScale *
 	// hScale / 2). The mask carries one scale for both eyes (only the center
 	// offset is per-eye), so size comes from the less-foveated (larger) extent of
 	// the two eyes — the mask then stays inside each eye's full-quality region and
@@ -148,7 +148,7 @@ FoveatedRender::FoveationProfile FoveatedRender::GetFoveationProfile() const
 	const float coverageH = std::max(leftUV.h, rightUV.h);
 	const float coverageW = std::max(leftUV.w, rightUV.w);
 	profile.available = true;
-	profile.coverageArea = FoveatedCommon::ClampCenterArea(coverageH);
+	profile.coverageScale = FoveatedCommon::ClampCenterScale(coverageH);
 	profile.centerHorizontalScale = FoveatedCommon::ClampCenterHorizontalScale(
 		coverageH > 1e-4f ? coverageW / coverageH : 1.0f);
 	profile.centerOffsets[0] = { (leftUV.x + leftUV.w * 0.5f) - 0.5f, (leftUV.y + leftUV.h * 0.5f) - 0.5f };

--- a/src/Features/Upscaling/FoveatedRender.cpp
+++ b/src/Features/Upscaling/FoveatedRender.cpp
@@ -131,8 +131,9 @@ FoveatedRender::FoveationProfile FoveatedRender::GetFoveationProfile() const
 	// Map the rectangular subrect onto the centered superellipse the mask helper expects: vertical
 	// extent drives coverageScale (radiusY = coverageScale/2), the rect aspect drives the horizontal
 	// stretch (radiusX = coverageScale * hScale/2). The mask carries one scale for both eyes (only
-	// the center offset is per-eye), so size comes from the less-foveated (larger) extent of the two,
-	// keeping the mask inside each eye's full-quality region so it never foveates a sharp zone. A
+	// the center offset is per-eye), so size comes from the less-foveated (larger) extent of the two:
+	// the center is the superset enclosing both eyes' full-quality regions, so neither eye's sharp
+	// zone is ever foveated (min would shrink it below an eye's sharp region and foveate it). A
 	// full eye therefore yields full coverage and disables foveation (the gate below).
 	const float coverageH = std::max(leftUV.h, rightUV.h);
 	const float coverageW = std::max(leftUV.w, rightUV.w);

--- a/src/Features/Upscaling/FoveatedRender.cpp
+++ b/src/Features/Upscaling/FoveatedRender.cpp
@@ -139,9 +139,8 @@ FoveatedRender::FoveationProfile FoveatedRender::GetFoveationProfile() const
 	const float coverageW = std::max(leftUV.w, rightUV.w);
 	const float coverageScale = FoveatedCommon::ClampCenterScale(coverageH);
 
-	// Decide availability from the final clamped scale so the contract holds: if
-	// the larger eye rounds up to full coverage there is nothing to foveate, so
-	// leave the default (available == false) and callers need no separate check.
+	// Availability keys off the clamped scale: if the larger eye rounds up to full coverage there is
+	// nothing to foveate, leave the default (available == false).
 	if (!FoveatedCommon::IsActiveCoverage(coverageScale))
 		return profile;
 

--- a/src/Features/Upscaling/FoveatedRender.cpp
+++ b/src/Features/Upscaling/FoveatedRender.cpp
@@ -128,21 +128,29 @@ FoveatedRender::FoveationProfile FoveatedRender::GetFoveationProfile() const
 	const auto& leftUV = subrectController.GetUV();
 	const auto& rightUV = subrectController.GetRightEyeUV();
 
-	// A full-eye region means no foveation is in effect — nothing to gate on.
-	if (leftUV.w >= FoveatedCommon::kFullCoverageThreshold && leftUV.h >= FoveatedCommon::kFullCoverageThreshold)
+	// Disable only when BOTH eyes cover the full eye — if either eye is foveated
+	// we still build a profile.
+	const auto isFullEye = [](const Util::Subrect::UVRegion& uv) {
+		return uv.w >= FoveatedCommon::kFullCoverageThreshold && uv.h >= FoveatedCommon::kFullCoverageThreshold;
+	};
+	if (isFullEye(leftUV) && isFullEye(rightUV))
 		return profile;
 
 	// Map the rectangular subrect onto the centered-superellipse the mask helper
 	// expects: vertical extent drives coverageArea (radiusY = coverageArea/2),
 	// the rect aspect drives the horizontal stretch (radiusX = coverageArea *
-	// hScale / 2). The mask carries a single scale for both eyes, so size is taken
-	// from the left eye — seeded presets are symmetric in size and only the
-	// per-eye center offset differs (applied below). Approximate (rect vs
+	// hScale / 2). The mask carries one scale for both eyes (only the center
+	// offset is per-eye), so size comes from the less-foveated (larger) extent of
+	// the two eyes — the mask then stays inside each eye's full-quality region and
+	// never foveates a sharp zone. Seeded presets are symmetric in size, so
+	// left == right and this is a no-op for them. Approximate (rect vs
 	// superellipse) but sufficient for the per-pixel center/periphery weight.
+	const float coverageH = std::max(leftUV.h, rightUV.h);
+	const float coverageW = std::max(leftUV.w, rightUV.w);
 	profile.available = true;
-	profile.coverageArea = FoveatedCommon::ClampCenterArea(leftUV.h);
+	profile.coverageArea = FoveatedCommon::ClampCenterArea(coverageH);
 	profile.centerHorizontalScale = FoveatedCommon::ClampCenterHorizontalScale(
-		leftUV.h > 1e-4f ? leftUV.w / leftUV.h : 1.0f);
+		coverageH > 1e-4f ? coverageW / coverageH : 1.0f);
 	profile.centerOffsets[0] = { (leftUV.x + leftUV.w * 0.5f) - 0.5f, (leftUV.y + leftUV.h * 0.5f) - 0.5f };
 	profile.centerOffsets[1] = { (rightUV.x + rightUV.w * 0.5f) - 0.5f, (rightUV.y + rightUV.h * 0.5f) - 0.5f };
 	return profile;

--- a/src/Features/Upscaling/FoveatedRender.cpp
+++ b/src/Features/Upscaling/FoveatedRender.cpp
@@ -128,27 +128,28 @@ FoveatedRender::FoveationProfile FoveatedRender::GetFoveationProfile() const
 	const auto& leftUV = subrectController.GetUV();
 	const auto& rightUV = subrectController.GetRightEyeUV();
 
-	// Disable only when BOTH eyes cover the full eye — if either eye is foveated
-	// we still build a profile.
-	const auto isFullEye = [](const Util::Subrect::UVRegion& uv) {
-		return uv.w >= FoveatedCommon::kFullCoverageThreshold && uv.h >= FoveatedCommon::kFullCoverageThreshold;
-	};
-	if (isFullEye(leftUV) && isFullEye(rightUV))
-		return profile;
-
 	// Map the rectangular subrect onto the centered-superellipse the mask helper
 	// expects: vertical extent drives coverageScale (radiusY = coverageScale/2),
 	// the rect aspect drives the horizontal stretch (radiusX = coverageScale *
 	// hScale / 2). The mask carries one scale for both eyes (only the center
 	// offset is per-eye), so size comes from the less-foveated (larger) extent of
 	// the two eyes — the mask then stays inside each eye's full-quality region and
-	// never foveates a sharp zone. Seeded presets are symmetric in size, so
-	// left == right and this is a no-op for them. Approximate (rect vs
+	// never foveates a sharp zone. A full eye therefore yields full coverage and
+	// disables foveation entirely (the gate below). Seeded presets are symmetric
+	// in size, so left == right and this is a no-op for them. Approximate (rect vs
 	// superellipse) but sufficient for the per-pixel center/periphery weight.
 	const float coverageH = std::max(leftUV.h, rightUV.h);
 	const float coverageW = std::max(leftUV.w, rightUV.w);
+	const float coverageScale = FoveatedCommon::ClampCenterScale(coverageH);
+
+	// Decide availability from the final clamped scale so the contract holds: if
+	// the larger eye rounds up to full coverage there is nothing to foveate, so
+	// leave the default (available == false) and callers need no separate check.
+	if (!FoveatedCommon::IsActiveCoverage(coverageScale))
+		return profile;
+
 	profile.available = true;
-	profile.coverageScale = FoveatedCommon::ClampCenterScale(coverageH);
+	profile.coverageScale = coverageScale;
 	profile.centerHorizontalScale = FoveatedCommon::ClampCenterHorizontalScale(
 		coverageH > 1e-4f ? coverageW / coverageH : 1.0f);
 	profile.centerOffsets[0] = { (leftUV.x + leftUV.w * 0.5f) - 0.5f, (leftUV.y + leftUV.h * 0.5f) - 0.5f };

--- a/src/Features/Upscaling/FoveatedRender.cpp
+++ b/src/Features/Upscaling/FoveatedRender.cpp
@@ -129,15 +129,16 @@ FoveatedRender::FoveationProfile FoveatedRender::GetFoveationProfile() const
 	const auto& rightUV = subrectController.GetRightEyeUV();
 
 	// A full-eye region means no foveation is in effect — nothing to gate on.
-	if (leftUV.w >= 0.999f && leftUV.h >= 0.999f)
+	if (leftUV.w >= FoveatedCommon::kFullCoverageThreshold && leftUV.h >= FoveatedCommon::kFullCoverageThreshold)
 		return profile;
 
 	// Map the rectangular subrect onto the centered-superellipse the mask helper
 	// expects: vertical extent drives coverageArea (radiusY = coverageArea/2),
 	// the rect aspect drives the horizontal stretch (radiusX = coverageArea *
-	// hScale / 2), and rect-center minus screen-center gives the per-eye offset.
-	// Feather is the framework constant. Approximate (rect vs superellipse) but
-	// sufficient for the per-pixel center/periphery weight.
+	// hScale / 2). The mask carries a single scale for both eyes, so size is taken
+	// from the left eye — seeded presets are symmetric in size and only the
+	// per-eye center offset differs (applied below). Approximate (rect vs
+	// superellipse) but sufficient for the per-pixel center/periphery weight.
 	profile.available = true;
 	profile.coverageArea = FoveatedCommon::ClampCenterArea(leftUV.h);
 	profile.centerHorizontalScale = FoveatedCommon::ClampCenterHorizontalScale(

--- a/src/Features/Upscaling/FoveatedRender.h
+++ b/src/Features/Upscaling/FoveatedRender.h
@@ -104,7 +104,7 @@ struct FoveatedRender
 	struct FoveationProfile
 	{
 		bool available = false;
-		float coverageArea = 1.0f;           // [0.25, 1.0]
+		float coverageScale = 1.0f;          // linear center coverage scale [0.25, 1.0]
 		float centerHorizontalScale = 1.0f;  // [1.0, 2.0]
 		float2 centerOffsets[2] = {};        // [0]=left eye, [1]=right eye
 	};

--- a/src/Features/Upscaling/FoveatedRender.h
+++ b/src/Features/Upscaling/FoveatedRender.h
@@ -97,6 +97,19 @@ struct FoveatedRender
 	bool IsActive() const;
 	bool IsLoaded() const { return enabledAtBoot; }
 
+	// Foveation region profile consumed by per-pixel foveated effects (e.g.
+	// foveated SSR). Our canonical region is the rectangular DLSS subrect; this
+	// synthesizes the centered-superellipse parameters those effects expect from
+	// it. available is false when foveation is inactive or covers the full eye.
+	struct FoveationProfile
+	{
+		bool available = false;
+		float coverageArea = 1.0f;           // [0.25, 1.0]
+		float centerHorizontalScale = 1.0f;  // [1.0, 2.0]
+		float2 centerOffsets[2] = {};        // [0]=left eye, [1]=right eye
+	};
+	FoveationProfile GetFoveationProfile() const;
+
 	// Main enable: latched at boot, change requires restart
 	void LatchEnabled() { enabledAtBoot = (settings.enabled != 0); }
 

--- a/src/Features/Upscaling/FoveatedRender.h
+++ b/src/Features/Upscaling/FoveatedRender.h
@@ -97,10 +97,8 @@ struct FoveatedRender
 	bool IsActive() const;
 	bool IsLoaded() const { return enabledAtBoot; }
 
-	// Foveation region profile consumed by per-pixel foveated effects (e.g.
-	// foveated SSR). Our canonical region is the rectangular DLSS subrect; this
-	// synthesizes the centered-superellipse parameters those effects expect from
-	// it. available is false when foveation is inactive or covers the full eye.
+	// Foveation region for per-pixel foveated effects (e.g. SSR): the rectangular DLSS subrect mapped
+	// to centered-superellipse params. available is false when foveation is inactive or full-eye.
 	struct FoveationProfile
 	{
 		bool available = false;

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -46,7 +46,9 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	StereoBlendDepthSigma,
 	StereoBlendMaxFactor,
 	StereoBlendColorThreshold,
-	StereoBlendDebugMode)
+	StereoBlendDebugMode,
+	EnableSSRFoveation,
+	EnableSSRFoveationHardCutoff)
 
 //=============================================================================
 // FEATURE BASE CLASS OVERRIDES

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -178,6 +178,12 @@ public:
 		float StereoBlendColorThreshold = 0.02f;  ///< Minimum color difference to trigger blending (luminance)
 		int StereoBlendDebugMode = 0;             ///< 0=off, 1=back-check, 2=blend weight, 3=edge detection, 4=overwrite, 5=overwrite Eye1
 
+		// VR foveated shader detail — render expensive screen-space effects at
+		// reduced detail in the periphery, driven by the active Foveated DLSS
+		// region. Currently consumed by foveated SSR.
+		bool EnableSSRFoveation = false;            ///< Foveate screen-space reflection raymarching in the periphery
+		bool EnableSSRFoveationHardCutoff = false;  ///< Hard-skip SSR outside the center (vs feathered falloff)
+
 		// VR Menu Overlay positioning settings
 		float VRMenuScale = Config::kDefaultMenuScale;  ///< Scale factor for overlay UI (0.5-2.0)
 		int VRMenuPositioningMethod = 1;                ///< 0 = HMD relative, 1 = Fixed world position

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -178,9 +178,8 @@ public:
 		float StereoBlendColorThreshold = 0.02f;  ///< Minimum color difference to trigger blending (luminance)
 		int StereoBlendDebugMode = 0;             ///< 0=off, 1=back-check, 2=blend weight, 3=edge detection, 4=overwrite, 5=overwrite Eye1
 
-		// VR foveated shader detail — render expensive screen-space effects at
-		// reduced detail in the periphery, driven by the active Foveated DLSS
-		// region. Currently consumed by foveated SSR.
+		// VR foveated shader detail: render expensive screen-space effects at reduced detail in the
+		// periphery, driven by the active Foveated DLSS region. Consumed by foveated SSR.
 		bool EnableSSRFoveation = false;            ///< Foveate screen-space reflection raymarching in the periphery
 		bool EnableSSRFoveationHardCutoff = false;  ///< Hard-skip SSR outside the center (vs feathered falloff)
 

--- a/src/Features/VR/SettingsUI.cpp
+++ b/src/Features/VR/SettingsUI.cpp
@@ -2,6 +2,7 @@
 #include "Features/DynamicCubemaps.h"
 #include "Features/ScreenSpaceGI.h"
 #include "Features/ScreenSpaceShadows.h"
+#include "Features/Upscaling.h"
 #include "Features/VR.h"
 #include "Menu.h"
 #include "Menu/Fonts.h"
@@ -367,6 +368,37 @@ namespace
 					"  Green=edge  Pink=edge neighbour  Blue=disoccluded  Orange=full blend\n"
 					"Overwrite Eye1: POM depth heatmap for Eye 1 (auto-enables Reprojection -- restart required)");
 			}
+		}
+
+		if (ImGui::CollapsingHeader("Foveated Effects")) {
+			auto& upscaling = globals::features::upscaling;
+			auto& dynamicCubemaps = globals::features::dynamicCubemaps;
+			const bool foveatedDLSSActive = upscaling.foveatedRender.IsActive();
+			const bool ssrEnabled = dynamicCubemaps.loaded && dynamicCubemaps.settings.EnabledSSR;
+
+			if (!foveatedDLSSActive)
+				ImGui::TextColored(ImVec4(1.0f, 0.7f, 0.3f, 1.0f), "Requires Foveated DLSS to be active (Upscaling settings).");
+			if (!ssrEnabled)
+				ImGui::TextColored(ImVec4(1.0f, 0.7f, 0.3f, 1.0f), "Requires Screen Space Reflections (Dynamic Cubemaps).");
+
+			ImGui::BeginDisabled(!foveatedDLSSActive || !ssrEnabled);
+			ImGui::Checkbox("Foveate SSR Raymarching", &settings.EnableSSRFoveation);
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text(
+					"Reduces screen-space reflection raymarching toward the periphery, using the\n"
+					"active Foveated DLSS region. Central reflections stay full quality; peripheral\n"
+					"pixels fall back to the cubemap / water reflection. VR only.");
+			}
+
+			ImGui::BeginDisabled(!settings.EnableSSRFoveation);
+			ImGui::Checkbox("Hard Cutoff Outside Center##SSRFoveation", &settings.EnableSSRFoveationHardCutoff);
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text(
+					"Hard-skip SSR outside the center region instead of a feathered falloff.\n"
+					"Cheaper, but the transition edge may be visible. Default off (feathered).");
+			}
+			ImGui::EndDisabled();
+			ImGui::EndDisabled();
 		}
 	}
 

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -1025,7 +1025,7 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 			                                 dynamicCubemaps.loaded && dynamicCubemaps.settings.EnabledSSR;
 			if (ssrFoveationEnabled) {
 				const auto profile = upscaling.foveatedRender.GetFoveationProfile();
-				if (profile.available && FoveatedCommon::IsActiveCoverage(profile.coverageScale)) {
+				if (profile.available) {  // available already implies an active (non-full) coverage scale
 					const float ssrMode = FoveatedCommon::GetShaderMode(FoveatedCommon::GetDetailMode(
 						true, vr.settings.EnableSSRFoveationHardCutoff));
 					data.VRFoveationData0 = { profile.coverageScale, FoveatedCommon::kCenterFeather,

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -7,12 +7,15 @@
 #include "Deferred.h"
 #include "FeatureIssues.h"
 #include "Features/CloudShadows.h"
+#include "Features/DynamicCubemaps.h"
+#include "Features/FoveatedCommon.h"
 #include "Features/HDRDisplay.h"
 #include "Features/InteriorSun.h"
 #include "Features/PerformanceOverlay.h"
 #include "Features/TerrainBlending.h"
 #include "Features/TerrainHelper.h"
 #include "Features/Upscaling.h"
+#include "Features/VR.h"
 #include "Features/VRStereoOptimizations.h"
 #include "Features/VolumetricShadows.h"
 #include "Features/WeatherEditor.h"
@@ -1007,6 +1010,33 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 		data.AmbientSHB = { dalcSH.b.c0, dalcSH.b.c1[0], dalcSH.b.c1[1], dalcSH.b.c1[2] };
 
 		data.HDRData = globals::features::hdrDisplay.GetSharedDataHDR();
+
+		// VR foveated shader detail (consumed by foveated SSR). Default to off;
+		// populate from the active foveation region when SSR foveation is enabled
+		// and SSR is running. If SSR isn't running the SSR pass never executes, so
+		// these constants are simply ignored.
+		data.VRFoveationData0 = { FoveatedCommon::kCenterAreaMax, FoveatedCommon::kCenterFeather, 1.0f,
+			FoveatedCommon::GetShaderMode(FoveatedCommon::DetailMode::Off) };
+		data.VRFoveationCenterOffsets = { 0.0f, 0.0f, 0.0f, 0.0f };
+		if (globals::game::isVR) {
+			const auto& vr = globals::features::vr;
+			const auto& dynamicCubemaps = globals::features::dynamicCubemaps;
+			const bool ssrFoveationEnabled = vr.loaded && vr.settings.EnableSSRFoveation &&
+			                                 dynamicCubemaps.loaded && dynamicCubemaps.settings.EnabledSSR;
+			if (ssrFoveationEnabled) {
+				const auto profile = upscaling.foveatedRender.GetFoveationProfile();
+				if (profile.available && FoveatedCommon::IsActiveCoverage(profile.coverageArea)) {
+					const float ssrMode = FoveatedCommon::GetShaderMode(FoveatedCommon::GetDetailMode(
+						true, vr.settings.EnableSSRFoveationHardCutoff));
+					data.VRFoveationData0 = { profile.coverageArea, FoveatedCommon::kCenterFeather,
+						profile.centerHorizontalScale, ssrMode };
+					data.VRFoveationCenterOffsets = {
+						profile.centerOffsets[0].x, profile.centerOffsets[0].y,
+						profile.centerOffsets[1].x, profile.centerOffsets[1].y
+					};
+				}
+			}
+		}
 
 		sharedDataCB->Update(data);
 	}

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -1011,10 +1011,8 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 
 		data.HDRData = globals::features::hdrDisplay.GetSharedDataHDR();
 
-		// VR foveated shader detail (consumed by foveated SSR). Default to off;
-		// populate from the active foveation region when SSR foveation is enabled
-		// and SSR is running. If SSR isn't running the SSR pass never executes, so
-		// these constants are simply ignored.
+		// VR foveated shader detail (consumed by foveated SSR). Default to off; populate from the
+		// active foveation region only when SSR foveation is enabled and SSR is actually running.
 		data.VRFoveationData0 = { FoveatedCommon::kCenterScaleMax, FoveatedCommon::kCenterFeather, 1.0f,
 			FoveatedCommon::GetShaderMode(FoveatedCommon::DetailMode::Off) };
 		data.VRFoveationCenterOffsets = { 0.0f, 0.0f, 0.0f, 0.0f };

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -1015,7 +1015,7 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 		// populate from the active foveation region when SSR foveation is enabled
 		// and SSR is running. If SSR isn't running the SSR pass never executes, so
 		// these constants are simply ignored.
-		data.VRFoveationData0 = { FoveatedCommon::kCenterAreaMax, FoveatedCommon::kCenterFeather, 1.0f,
+		data.VRFoveationData0 = { FoveatedCommon::kCenterScaleMax, FoveatedCommon::kCenterFeather, 1.0f,
 			FoveatedCommon::GetShaderMode(FoveatedCommon::DetailMode::Off) };
 		data.VRFoveationCenterOffsets = { 0.0f, 0.0f, 0.0f, 0.0f };
 		if (globals::game::isVR) {
@@ -1025,10 +1025,10 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 			                                 dynamicCubemaps.loaded && dynamicCubemaps.settings.EnabledSSR;
 			if (ssrFoveationEnabled) {
 				const auto profile = upscaling.foveatedRender.GetFoveationProfile();
-				if (profile.available && FoveatedCommon::IsActiveCoverage(profile.coverageArea)) {
+				if (profile.available && FoveatedCommon::IsActiveCoverage(profile.coverageScale)) {
 					const float ssrMode = FoveatedCommon::GetShaderMode(FoveatedCommon::GetDetailMode(
 						true, vr.settings.EnableSSRFoveationHardCutoff));
-					data.VRFoveationData0 = { profile.coverageArea, FoveatedCommon::kCenterFeather,
+					data.VRFoveationData0 = { profile.coverageScale, FoveatedCommon::kCenterFeather,
 						profile.centerHorizontalScale, ssrMode };
 					data.VRFoveationCenterOffsets = {
 						profile.centerOffsets[0].x, profile.centerOffsets[0].y,

--- a/src/State.h
+++ b/src/State.h
@@ -256,7 +256,7 @@ public:
 		float4 AmbientSHR;
 		float4 AmbientSHG;
 		float4 AmbientSHB;
-		float4 VRFoveationData0;          // x=center scale, y=feather, z=horizontal scale, w=SSR raymarch mode (0 off, 1 feathered, 2 hard cutoff)
+		float4 VRFoveationData0;          // x=center coverage scale, y=feather, z=horizontal scale, w=SSR raymarch mode (0 off, 1 feathered, 2 hard cutoff)
 		float4 VRFoveationCenterOffsets;  // xy=left eye center offset, zw=right eye center offset
 		float4 HDRData;                   // xyz + menu scene encoding in w — see HDRDisplay::GetSharedDataHDR
 	};

--- a/src/State.h
+++ b/src/State.h
@@ -261,6 +261,11 @@ public:
 		float4 HDRData;                   // xyz + menu scene encoding in w — see HDRDisplay::GetSharedDataHDR
 	};
 	STATIC_ASSERT_ALIGNAS_16(SharedDataCB);
+	// Each float4 cbuffer field must start on a 16-byte boundary to match the HLSL SharedData
+	// layout — a stray scalar inserted above would silently shift these and corrupt shader reads.
+	static_assert(offsetof(SharedDataCB, VRFoveationData0) % 16 == 0);
+	static_assert(offsetof(SharedDataCB, VRFoveationCenterOffsets) % 16 == 0);
+	static_assert(offsetof(SharedDataCB, HDRData) % 16 == 0);
 
 	ConstantBuffer* sharedDataCB = nullptr;
 	ConstantBuffer* featureDataCB = nullptr;

--- a/src/State.h
+++ b/src/State.h
@@ -256,7 +256,9 @@ public:
 		float4 AmbientSHR;
 		float4 AmbientSHG;
 		float4 AmbientSHB;
-		float4 HDRData;  // xyz + menu scene encoding in w — see HDRDisplay::GetSharedDataHDR
+		float4 VRFoveationData0;          // x=center scale, y=feather, z=horizontal scale, w=SSR raymarch mode (0 off, 1 feathered, 2 hard cutoff)
+		float4 VRFoveationCenterOffsets;  // xy=left eye center offset, zw=right eye center offset
+		float4 HDRData;                   // xyz + menu scene encoding in w — see HDRDisplay::GetSharedDataHDR
 	};
 	STATIC_ASSERT_ALIGNAS_16(SharedDataCB);
 


### PR DESCRIPTION
﻿## Summary

Adds **foveated SSR raymarching** for VR: screen-space reflections raymarch at full cost in the center of view and progressively cheaper toward the periphery, using the active **Foveated DLSS** region as the mask. Central reflections are unchanged; peripheral pixels fall back to the cubemap / water reflection. A net VR GPU-time saving on reflective scenes, at the cost of peripheral SSR detail.

Ported from the foveation framework in [ParticleTroned/skyrim-community-shaders](https://github.com/ParticleTroned/skyrim-community-shaders), **scoped to SSR only** with no dead code (compute-dispatch helpers omitted).

## How it works

- **Region model:** we keep our existing rectangular DLSS subrect as the canonical foveation region. `FoveatedRender::GetFoveationProfile()` synthesizes the centered-superellipse params (coverage / horizontal scale / per-eye center offset) the mask consumes. We deliberately do **not** adopt the upstream "oval-as-source" foundation, which would collide with our PR #2096 foveated-DLSS divergence.
- **Mask:** `FoveatedShaderDetail.hlsli` + `FoveatedMask.hlsli` (superellipse, feathered or hard-cutoff) → a per-pixel 0..1 weight.
- **SSR shader:** in VR, the raymarch + binary-search iteration counts scale with the weight down to a floor (`minFoveatedIterations = 16` vs `64`), the SSR alpha is multiplied by the weight, and pixels outside the mask early-out. **Non-VR is behaviorally identical**: the non-VR branch sets `rayCount = iterations` / `binCount = binaryIterations` / `fovWeight = 1.0`, collapsing the (now VR-shared) loop body to the original constants and weight 1.0. The loop body is shared with the VR path rather than duplicated, so the source/bytecode is *not* byte-identical — equivalence is by construction + runtime A/B, not a bytecode diff.
- **Constants:** two `float4`s added to the shared `PerFrame` cbuffer (`VRFoveationData0` + `VRFoveationCenterOffsets`), with matching C++ layout under the existing `STATIC_ASSERT_ALIGNAS_16` size check.
- **Control:** VR-only "Foveated Effects" UI with `Foveate SSR Raymarching` + `Hard Cutoff` toggles, gated (with hints) on Foveated DLSS being active and SSR enabled.

## Scope decisions (per design discussion)

- **SSR only.** Water/wetterness/SSGI foveation and the compute-dispatch helpers from the upstream framework are intentionally not ported — nothing unused ships.
- **Adapter, not full model adoption.** Keeps divergence minimal and avoids the PR #2096 reconciliation; the rect→superellipse synthesis is approximate but sufficient for a per-pixel center/periphery weight.

## Validation

- `BuildRelease.bat ALL` (universal SE/AE/VR) — clean, exit 0, no warnings on the changed TUs.
- Targeted `hlslkit` compile of `ISReflectionsRayTracing.hlsl` — **0 errors / 0 warnings** on both the VR and Flatrim configs.
- **Runtime-tested in VR (Tracy GPU A/B).** Measured the `ISReflectionsRayTracing` GPU zone on an `ALL-TRACY` build, same scene and camera, Center 50% feathered foveation: the pass drops from ~88 µs to ~44 µs — a saving of **~44 µs, about 0.4% of the 90 fps frame budget** (11.1 ms). Small in absolute terms, but reclaimed entirely in the periphery where reflections aren't scrutinized, and it scales with how much SSR the scene actually draws (reflective interiors / water gain more). The rig was present-throttled with the HMD off, so per-pass GPU time is the signal here, not frame rate.

## Attribution

Foveation framework by ParticleTroned ([ParticleTroned/skyrim-community-shaders](https://github.com/ParticleTroned/skyrim-community-shaders)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VR foveation for screen-space reflections (SSR): per-pixel foveation weighting adjusts SSR detail/iteration counts and skips work outside the foveal center.
  * Engine exposes a foveation profile (coverage scale, horizontal scale, per-eye center offsets) for rendering.

* **UI**
  * New "Foveated Effects" settings section with enable toggle, hard-cutoff vs feathered option, and prerequisite warnings.

* **Settings**
  * Added persistent settings to enable SSR foveation and hard-cutoff behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


