### PR TITLE
fix(TAA): restore VR per-eye reprojection and opaque alpha

### DIFF
--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -266,11 +266,8 @@ PS_OUTPUT main(PS_INPUT input)
 	history.xy = drMax;
 	motionReject.xy = velocityTex.Sample(velocitySampler, ClampScreenUV(motionReject.xy, history.xy)).xy;
 #	ifdef VR
-	// Both eyes share one render target in VR, so reprojection must stay within the current
-	// eye: Stereo::ApplyVelocityToUV converts to mono, applies velocity, clamps per-eye, and
-	// maps back. Plain texCoord+velocity (the SE path) lets a pixel near the x=0.5 seam sample
-	// the other eye's history (cross-eye ghosting). GetPreviousDynamicResolutionAdjustedScreen-
-	// Position keeps the DR history clamp per-eye too; prevUVOutOfBounds drives rejection below.
+	// Eyes share one RT in VR; reproject within the current eye (mono-space velocity, per-eye
+	// clamp) so a pixel near the x=0.5 seam never samples the other eye's history. OOB feeds reject.
 	bool prevUVOutOfBounds;
 	float2 prevUV = Stereo::ApplyVelocityToUV(texCoord.xy, motionReject.xy, prevUVOutOfBounds);
 	tapMin.xy = FrameBuffer::GetPreviousDynamicResolutionAdjustedScreenPosition(prevUV);
@@ -432,8 +429,7 @@ PS_OUTPUT main(PS_INPUT input)
 	// --- disocclusion / mask rejection ---
 	// motionReject.x = motion length (motionReject.zw held the reprojected UV on the SE path).
 #	ifdef VR
-	// Out-of-bounds was already resolved per-eye in mono space (Stereo::ApplyVelocityToUV); the
-	// stereo-space [0,1] test used on the SE path would miss the x=0.5 eye seam.
+	// VR resolves out-of-bounds per-eye in mono space; the SE stereo-space test misses the seam.
 	motionReject.z = prevUVOutOfBounds ? 1 : 0;
 #	else
 	sampleUV.w = min(motionReject.z, motionReject.w);

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -2,6 +2,7 @@
 #include "Common/DisplayMapping.hlsli"
 #include "Common/DummyVSTexCoord.hlsl"
 #include "Common/FrameBuffer.hlsli"
+#include "Common/VR.hlsli"
 
 typedef VS_OUTPUT PS_INPUT;
 
@@ -264,9 +265,20 @@ PS_OUTPUT main(PS_INPUT input)
 	// --- motion vector and history sample ---
 	history.xy = drMax;
 	motionReject.xy = velocityTex.Sample(velocitySampler, ClampScreenUV(motionReject.xy, history.xy)).xy;
+#	ifdef VR
+	// Both eyes share one render target in VR, so reprojection must stay within the current
+	// eye: Stereo::ApplyVelocityToUV converts to mono, applies velocity, clamps per-eye, and
+	// maps back. Plain texCoord+velocity (the SE path) lets a pixel near the x=0.5 seam sample
+	// the other eye's history (cross-eye ghosting). GetPreviousDynamicResolutionAdjustedScreen-
+	// Position keeps the DR history clamp per-eye too; prevUVOutOfBounds drives rejection below.
+	bool prevUVOutOfBounds;
+	float2 prevUV = Stereo::ApplyVelocityToUV(texCoord.xy, motionReject.xy, prevUVOutOfBounds);
+	tapMin.xy = FrameBuffer::GetPreviousDynamicResolutionAdjustedScreenPosition(prevUV);
+#	else
 	motionReject.zw = texCoord.xy + motionReject.xy;
-	motionReject.x = sqrt(dot(motionReject.xy, motionReject.xy));
 	tapMin.xy = ClampHistoryUV(motionReject.zw);
+#	endif
+	motionReject.x = sqrt(dot(motionReject.xy, motionReject.xy));
 	history.xyw = historyTex.Sample(historySampler, tapMin.xy).xyz;
 #	ifdef HDR_OUTPUT
 	// history.x is stored as game-gamma luma (see EncodeFeedbackLuma on write).
@@ -418,12 +430,18 @@ PS_OUTPUT main(PS_INPUT input)
 	corner.xyz = history.yyy * corner.xyz + tapMin.xyz;
 
 	// --- disocclusion / mask rejection ---
-	// motionReject.zw still holds reprojected UV from motion pass; motionReject.x = motion length
+	// motionReject.x = motion length (motionReject.zw held the reprojected UV on the SE path).
+#	ifdef VR
+	// Out-of-bounds was already resolved per-eye in mono space (Stereo::ApplyVelocityToUV); the
+	// stereo-space [0,1] test used on the SE path would miss the x=0.5 eye seam.
+	motionReject.z = prevUVOutOfBounds ? 1 : 0;
+#	else
 	sampleUV.w = min(motionReject.z, motionReject.w);
 	motionReject.zw = cmp(motionReject.zw >= float2(1, 1));
 	sampleUV.w = cmp(0 >= sampleUV.w);
 	motionReject.z = (int)motionReject.z | (int)sampleUV.w;
 	motionReject.z = (int)motionReject.w | (int)motionReject.z;
+#	endif
 	history.yz = maskTex.Sample(maskSampler, sampleUV.xy).xy;
 	motionReject.w = AlphaCoverageMask(sampleUV.xy);
 	sampleUV.x = cmp(ThresholdParams.w < history.z);
@@ -513,11 +531,8 @@ PS_OUTPUT main(PS_INPUT input)
 #	else
 	feedbackOut.x = saturate(sampleUV.x * motionReject.z);
 #	endif
-#	if defined(VR)
-	colorOut.w = motionReject.x ? 1 : 0;
-#	else
+	// Vanilla writes opaque alpha unconditionally on both SE and VR (decompile o0.w = 1).
 	colorOut.w = 1;
-#	endif
 	feedbackOut.w = 1;
 
 #	ifdef HDR_OUTPUT


### PR DESCRIPTION
## Problem

Upstream PR #2399 (`fix(TAA): banding and oversharpening`, commit `7cc80382`) replaced the high-level TAA implementation with a faithful **SE** decompile transcription. The unified math is correct (it matches the VR decompile too), but the rewrite dropped two VR-specific behaviors that Open Shaders' **combined-eye render target** depends on, breaking TAA in VR.

## Fixes (both `#ifdef VR`-only — SE path is byte-identical)

1. **Per-eye reprojection.** Vanilla VR renders eyes to *separate* targets, so plain `texCoord + velocity` is safe there. Open Shaders packs both eyes into one RT, so a pixel near the `x=0.5` seam sampled the **other eye's** history → cross-eye ghosting. Restored `Stereo::ApplyVelocityToUV` + the per-eye history clamp via `GetPreviousDynamicResolutionAdjustedScreenPosition`, and fed its mono-space out-of-bounds flag into the history reject (the stereo-space `[0,1]` test missed the seam).

2. **Output alpha.** The surviving VR branch wrote `colorOut.w = allTransparent ? 1 : 0`, so **opaque** pixels (nearly the whole frame) got alpha `0`. Restored the vanilla decompile behavior (`o0.w = 1`) on both editions.

## Notes
- This is fundamentally an **upstream** VR regression; the fix is self-contained and could be PR'd to community-shaders so the fork resyncs cleanly.
- The upstream HDR banding/oversharpen fix is untouched.

## Validation
- `fxc ps_5_0` clean (exit 0, no warnings) across flat / VR / HDR / VR+HDR permutations.
- Deployed via `COPY_SHADERS` to SE + VR Data dirs; in-game VR verification pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced temporal anti-aliasing stability for VR headsets with improved reprojection and out-of-bounds handling.
  * Refined alpha channel processing for more consistent visual quality across all rendering modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->