### PR TITLE
fix(llf): harden inputs across particle lights

### DIFF
--- a/src/Features/LightLimitFix/Particle.cpp
+++ b/src/Features/LightLimitFix/Particle.cpp
@@ -526,7 +526,9 @@ void LightLimitFix::AddCachedParticleLights(eastl::vector<LightData>& lightsData
 	float distance = CalculateLightDistance(light.positionWS[0].data, light.radius);
 
 	float dimmer = 0.0f;
-	if (distance < lightFadeStart || lightFadeEnd == 0.0f)
+	// lightFadeEnd <= lightFadeStart guards a zero/negative denominator below
+	// (equal engine globals would otherwise divide by zero → NaN into lighting).
+	if (distance < lightFadeStart || lightFadeEnd == 0.0f || lightFadeEnd <= lightFadeStart)
 		dimmer = 1.0f;
 	else if (distance <= lightFadeEnd)
 		dimmer = 1.0f - ((distance - lightFadeStart) / (lightFadeEnd - lightFadeStart));

--- a/src/Features/LightLimitFix/ParticleLights.cpp
+++ b/src/Features/LightLimitFix/ParticleLights.cpp
@@ -119,8 +119,10 @@ void ParticleLights::GetConfigs()
 
 				// Require exactly 6 (RRGGBB) or 8 (AARRGGBB) hex digits so malformed
 				// widths like "#1" / "#12345" fail closed instead of packing a garbage color.
+				// find_first_not_of is bounded to the view; strspn would rely on
+				// str.data() being NUL-terminated, which string_view doesn't guarantee.
 				bool matches = (str.size() == 6 || str.size() == 8) &&
-				               std::strspn(str.data(), cset.data()) == str.size();
+				               str.find_first_not_of(cset) == std::string_view::npos;
 
 				if (matches) {
 					try {

--- a/src/Features/LightLimitFix/ParticleLights.cpp
+++ b/src/Features/LightLimitFix/ParticleLights.cpp
@@ -31,6 +31,9 @@ void ParticleLights::GetConfigs()
 		logger::info("[LLF] Loading particle lights configs");
 
 		auto configs = clib_util::distribution::get_configs("Data\\ParticleLights", "", ".ini");
+		// get_configs order is filesystem-dependent; sort so the "first wins"
+		// duplicate policy below is deterministic across installs.
+		std::sort(configs.begin(), configs.end());
 
 		if (configs.empty()) {
 			logger::warn("[LLF] No .ini files were found within the Data\\ParticleLights folder, aborting...");
@@ -78,6 +81,8 @@ void ParticleLights::GetConfigs()
 		logger::info("[LLF] Loading particle lights gradients configs");
 
 		auto configs = clib_util::distribution::get_configs("Data\\ParticleLights\\Gradients", "", ".ini");
+		// Deterministic "first wins" across installs (see above).
+		std::sort(configs.begin(), configs.end());
 
 		if (configs.empty()) {
 			logger::warn("[LLF] No .ini files were found within the Data\\ParticleLights\\Gradients folder, aborting...");
@@ -112,7 +117,10 @@ void ParticleLights::GetConfigs()
 				if (str.starts_with(prefix2))
 					str.remove_prefix(prefix2.size());
 
-				bool matches = std::strspn(str.data(), cset.data()) == str.size();
+				// Require exactly 6 (RRGGBB) or 8 (AARRGGBB) hex digits so malformed
+				// widths like "#1" / "#12345" fail closed instead of packing a garbage color.
+				bool matches = (str.size() == 6 || str.size() == 8) &&
+				               std::strspn(str.data(), cset.data()) == str.size();
 
 				if (matches) {
 					try {

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -536,12 +536,8 @@ void Upscaling::DrawSettings()
 	if (ImGui::TreeNodeEx("Backend Diagnostics")) {
 		// Streamline log level selection
 		const char* logLevels[] = { "Off", "Default", "Verbose" };
-		// Clamp the stored value (not just the index): streamlineLogLevel is
-		// JSON-persisted and could be out of range on a stale/hand-edited config.
-		// Sanitizing only the local index would let the bad value persist through
-		// the save / restart-diff paths even if the user never opens this combo.
-		settings.streamlineLogLevel = std::min(settings.streamlineLogLevel,
-			static_cast<uint>(IM_ARRAYSIZE(logLevels) - 1));
+		// streamlineLogLevel is sanitized in LoadSettings (runs on every load,
+		// not gated on this node being expanded), so the stored value is in range.
 		int logLevelIdx = static_cast<int>(settings.streamlineLogLevel);
 		if (ImGui::Combo("Streamline Logging", &logLevelIdx, logLevels, IM_ARRAYSIZE(logLevels))) {
 			settings.streamlineLogLevel = static_cast<uint>(logLevelIdx);
@@ -703,6 +699,10 @@ void Upscaling::LoadSettings(json& o_json)
 	if (settings.presetDLSS > 4) {
 		logger::warn("[Upscaling] Loaded presetDLSS {} out of range, resetting to 0 (Default)", settings.presetDLSS);
 		settings.presetDLSS = 0;
+	}
+	if (settings.streamlineLogLevel > 2) {  // Off, Default, Verbose
+		logger::warn("[Upscaling] Loaded streamlineLogLevel {} out of range, clamping to 2", settings.streamlineLogLevel);
+		settings.streamlineLogLevel = 2;
 	}
 	// Re-apply FoveatedRender's cross-feature clamp now that the JSON
 	// re-assign above has overwritten anything it set during its own

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -536,11 +536,13 @@ void Upscaling::DrawSettings()
 	if (ImGui::TreeNodeEx("Backend Diagnostics")) {
 		// Streamline log level selection
 		const char* logLevels[] = { "Off", "Default", "Verbose" };
-		// Clamp before use: streamlineLogLevel is JSON-persisted and could be out
-		// of range (or a value that overflows the int cast) on a stale or
-		// hand-edited config; an unclamped value would index logLevels OOB.
-		int logLevelIdx = std::clamp(static_cast<int>(settings.streamlineLogLevel),
-			0, IM_ARRAYSIZE(logLevels) - 1);
+		// Clamp the stored value (not just the index): streamlineLogLevel is
+		// JSON-persisted and could be out of range on a stale/hand-edited config.
+		// Sanitizing only the local index would let the bad value persist through
+		// the save / restart-diff paths even if the user never opens this combo.
+		settings.streamlineLogLevel = std::min(settings.streamlineLogLevel,
+			static_cast<uint>(IM_ARRAYSIZE(logLevels) - 1));
+		int logLevelIdx = static_cast<int>(settings.streamlineLogLevel);
 		if (ImGui::Combo("Streamline Logging", &logLevelIdx, logLevels, IM_ARRAYSIZE(logLevels))) {
 			settings.streamlineLogLevel = static_cast<uint>(logLevelIdx);
 		}


### PR DESCRIPTION
## Summary

Addresses the four minor hardening items tracked in #87 — pre-existing issues surfaced by CodeRabbit during #56's review, in files outside that PR's scope, so split out here.

| Fix | File | Problem |
|---|---|---|
| Div-by-zero guard | `LightLimitFix/Particle.cpp` | `lightFadeEnd == lightFadeStart` (non-zero) made the dimmer interpolation divide by zero → NaN/Inf into lighting. Now `lightFadeEnd <= lightFadeStart` takes the full-brightness branch. |
| Deterministic dedupe | `LightLimitFix/ParticleLights.cpp` | `get_configs` order is filesystem-dependent; the "first wins" duplicate policy could pick different winners across installs. `std::sort` before both loops (ParticleLights + Gradients). |
| Hex-width validation | `LightLimitFix/ParticleLights.cpp` | Gradient color validated charset but not length, so `#1` / `#12345` packed as garbage 32-bit colors. Now requires exactly 6 (RRGGBB) or 8 (AARRGGBB) digits — fails closed. |
| Clamp stored value | `Upscaling.cpp` | Only the UI index was clamped; a stale/hand-edited `streamlineLogLevel` persisted unclamped through save/restart-diff. Now the stored value itself is clamped. |

All four verified present on `dev` before fixing; each is the change CodeRabbit suggested, kept minimal.

## Validation

⚠️ **Not built locally** — the local C: drive is full (~20 MB free), which blocks MSVC's temp compilation; the build drive (F:) is fine. The changes are minimal and self-contained (a conditional guard, two `std::sort` calls with `<algorithm>` already included, a `size()` check, and a `std::min` clamp on a `uint`), so I'm relying on CI's full build + `cpp_tests` + shader validation here.

Closes #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
