### PR TITLE
ci: incremental shader validation

### DIFF
--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -43,6 +43,10 @@ on:
                 description: "Optional suffix to invalidate the build cache"
                 type: string
                 default: ""
+            changed-files-json:
+                description: "JSON array of changed paths for incremental shader validation; empty => full validation"
+                type: string
+                default: ""
         outputs:
             version:
                 description: "CMake project version extracted from the build"
@@ -198,12 +202,25 @@ jobs:
             - name: Validate shader compilation (${{ matrix.config.name }})
               if: steps.check-hlsl.outputs.skip != 'true'
               shell: bash
+              env:
+                  CHANGED_FILES_JSON: ${{ inputs.changed-files-json }}
               run: |
                   if [ -z "${{ steps.find_fxc.outputs.fxc_path }}" ]; then
                     echo "fxc.exe not found - shader validation requires fxc.exe. Set --fxc to a valid path or ensure fxc.exe is in PATH." >&2
                     exit 1
                   fi
-                  hlslkit-compile --fxc "${{ steps.find_fxc.outputs.fxc_path }}" --shader-dir build/ALL/aio/Shaders --output-dir build/ShaderCache --config ${{ matrix.config.file }} --max-warnings 0 --suppress-warnings X1519
+                  # Materialize the changed-file list (one path per line). An empty
+                  # or absent JSON yields an empty file, which the wrapper treats
+                  # as "unknown change set" and validates everything (push/release).
+                  if [ -n "$CHANGED_FILES_JSON" ]; then
+                    echo "$CHANGED_FILES_JSON" | jq -r '.[]' > changed_files.txt
+                  else
+                    : > changed_files.txt
+                  fi
+                  echo "Changed files for incremental validation:"
+                  cat changed_files.txt || true
+                  python tools/validate_changed_shaders.py --changed-list-file changed_files.txt -- \
+                    hlslkit-compile --fxc "${{ steps.find_fxc.outputs.fxc_path }}" --shader-dir build/ALL/aio/Shaders --output-dir build/ShaderCache --config ${{ matrix.config.file }} --max-warnings 0 --suppress-warnings X1519
 
             - name: Upload shader validation logs
               if: failure() && steps.check-hlsl.outputs.skip != 'true'

--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -212,10 +212,14 @@ jobs:
                   # Materialize the changed-file list (one path per line). An empty
                   # or absent JSON yields an empty file, which the wrapper treats
                   # as "unknown change set" and validates everything (push/release).
+                  # If the JSON is malformed/truncated, fall back to an empty file
+                  # (=> full validation) rather than aborting the job.
+                  : > changed_files.txt
                   if [ -n "$CHANGED_FILES_JSON" ]; then
-                    echo "$CHANGED_FILES_JSON" | jq -r '.[]' > changed_files.txt
-                  else
-                    : > changed_files.txt
+                    if ! printf '%s' "$CHANGED_FILES_JSON" | jq -r '.[]' > changed_files.txt 2>/dev/null; then
+                      echo "WARNING: could not parse changed-files JSON; running FULL validation."
+                      : > changed_files.txt
+                    fi
                   fi
                   echo "Changed files for incremental validation:"
                   cat changed_files.txt || true

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -58,6 +58,10 @@ jobs:
             # so any cpp_any change is conservative-but-correct. cpp_tests_any catches changes to
             # the test sources themselves. cmake/build_ci cover CMake + CI plumbing.
             cpp-tests-should-build: ${{ steps.changed-files.outputs.cpp_tests_any_changed == 'true' || steps.changed-files.outputs.cpp_any_changed == 'true' || steps.changed-files.outputs.cmake_any_changed == 'true' || steps.changed-files.outputs.build_ci_any_changed == 'true' || steps.changed-files.outcome == 'failure' }}
+            # JSON array of every changed path, used to drive incremental shader
+            # validation. Empty (or absent on detection failure) => shader
+            # validation runs in full. JSON tolerates spaces in feature paths.
+            changed-files-json: ${{ steps.changed-files-json.outcome == 'success' && steps.changed-files-json.outputs.all_changed_files || '' }}
         steps:
             - uses: actions/checkout@v6
               with:
@@ -113,6 +117,20 @@ jobs:
                   base_sha: ${{ github.event.pull_request.base.sha }}
                   sha: ${{ github.event.pull_request.head.sha }}
 
+            # Separate JSON view of the full changed set for incremental shader
+            # validation. Kept distinct from the grouped step above so its
+            # carefully-tuned boolean outputs are untouched. JSON encoding
+            # preserves paths with spaces (e.g. "features/Light Limit Fix/...").
+            - name: Get changed files (JSON)
+              id: changed-files-json
+              uses: tj-actions/changed-files@v46
+              continue-on-error: true
+              with:
+                  json: true
+                  escape_json: false
+                  base_sha: ${{ github.event.pull_request.base.sha }}
+                  sha: ${{ github.event.pull_request.head.sha }}
+
     # Security: this job compiles untrusted fork code.
     # It uses _shared-build.yaml which enforces permissions: contents: read and receives NO secrets.
     # The absence of a `secrets:` block here is intentional — passing secrets to a reusable
@@ -135,6 +153,7 @@ jobs:
             hlsl-should-build: ${{ needs.check-changes.outputs.hlsl-should-build || 'true' }}
             shader-tests-should-build: ${{ needs.check-changes.outputs.shader-tests-should-build || 'true' }}
             cpp-tests-should-build: ${{ needs.check-changes.outputs.cpp-tests-should-build || 'true' }}
+            changed-files-json: ${{ needs.check-changes.outputs.changed-files-json }}
 
     # Security: this job has GITHUB_TOKEN write permissions but executes no fork
     # code. It sparse-checks-out the BASE branch (trusted) for the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -781,6 +781,29 @@ if(AUTO_PLUGIN_DEPLOYMENT OR AIO_ZIP_TO_DIST)
         DEPENDS copy_shaders.stamp
         COMMENT "Preparing shaders for validation"
     )
+
+    # Incremental local validation: compile only the shaders affected by the
+    # current working-tree diff (vs HEAD). Mirrors the CI incremental path but
+    # derives the change set from git instead of a precomputed list. Override
+    # the config with -DVALIDATE_CHANGED_CONFIG=... (defaults to Flatrim).
+    set(VALIDATE_CHANGED_CONFIG
+        "${CMAKE_SOURCE_DIR}/.github/configs/shader-validation.yaml"
+        CACHE FILEPATH
+        "hlslkit config used by the validate_changed target"
+    )
+    add_custom_target(
+        validate_changed
+        COMMAND
+            ${CMAKE_COMMAND} -E env python
+            "${CMAKE_SOURCE_DIR}/tools/validate_changed_shaders.py" --repo-root
+            "${CMAKE_SOURCE_DIR}" -- hlslkit-compile --shader-dir
+            "${AIO_DIR}/Shaders" --output-dir "${CMAKE_BINARY_DIR}/ShaderCache"
+            --config "${VALIDATE_CHANGED_CONFIG}" --max-warnings 0
+            --suppress-warnings X1519
+        DEPENDS prepare_shaders
+        USES_TERMINAL
+        COMMENT "Validating only shaders affected by working-tree changes"
+    )
 endif()
 
 # Automatic deployment to CommunityShaders output directory.

--- a/docs/development/shader-workflow.md
+++ b/docs/development/shader-workflow.md
@@ -86,3 +86,43 @@ You can configure VSCode to automatically deploy shaders when you save `.hlsl` o
 | `COPY_SHADERS`    | ❌         | ❌         | ✅             | Fast shader iteration |
 | `DEPLOY_ALL`      | ✅         | ✅         | ✅             | Full deployment       |
 | `prepare_shaders` | ❌         | ✅         | ✅ (AIO only)  | CI validation         |
+
+## Incremental shader validation
+
+Validating the full shader suite recompiles ~3,300 variants per config, which is
+slow for a one-line change. Incremental validation compiles **only the
+entry-point shaders that transitively `#include` a changed file**, derived from
+an `#include` dependency graph. A leaf shader used by one entry point validates
+in seconds; a shared `Common/*.hlsli` fans out to every shader that includes it.
+
+### Local
+
+```bash
+# Compile only shaders affected by your working-tree changes (vs HEAD)
+cmake --build ./build/ALL --target validate_changed
+
+# Override the config (defaults to Flatrim / shader-validation.yaml)
+cmake -DVALIDATE_CHANGED_CONFIG=.github/configs/shader-validation-vr.yaml -S . -B build/ALL
+cmake --build ./build/ALL --target validate_changed
+```
+
+The target depends on `prepare_shaders`, so the AIO shader tree is assembled
+first. Under the hood it runs `tools/validate_changed_shaders.py`, which maps
+your changed `package/Shaders/**` and `features/**/Shaders/**` paths into the
+AIO layout and passes them to `hlslkit-compile --changed-files`.
+
+### CI
+
+The PR shader-validation job feeds the PR's changed-file list (from
+`tj-actions/changed-files`) into the same wrapper. Validation is **only**
+narrowed when provably safe — any of these forces a full run:
+
+-   a change to a validation config (`.github/configs/**`), CMake, or a submodule
+    (these can redefine the entry-point/define set itself);
+-   a changed shader path outside the known shader roots;
+-   push/release builds (no PR change set), which always validate in full.
+
+`hlslkit` applies the same safety net independently: any changed path it can't
+find in the shader tree falls back to full validation. Preprocessor guards are
+ignored when scanning `#include`s, so the affected set is always a conservative
+superset — over-validating costs time, never correctness.

--- a/tools/validate_changed_shaders.py
+++ b/tools/validate_changed_shaders.py
@@ -20,9 +20,9 @@ Two ways to supply the change set:
 Safety: validation is only narrowed when it is provably safe. Any of the
 following forces a FULL run:
 
-* a validation config (``.github/configs/**``), CMake, or submodule change —
-  these can alter the entry-point/define set itself, so the graph is no longer
-  authoritative;
+* a validation config (``.github/configs/**``), CMake, or submodule change
+  (``.gitmodules`` or a gitlink bump under ``extern/``) — these can alter the
+  entry-point/define set itself, so the graph is no longer authoritative;
 * a changed shader path that doesn't map into the AIO shader tree (an
   unexpected location we can't reason about).
 
@@ -62,6 +62,9 @@ _FULL_TRIGGERS = (
     re.compile(r"^CMakePresets\.json$"),
     re.compile(r"^cmake/"),
     re.compile(r"^\.gitmodules$"),
+    # Submodule pointer bumps surface as a gitlink change under extern/ without
+    # touching .gitmodules; treat both as a full-validation trigger.
+    re.compile(r"^extern/"),
 )
 
 
@@ -241,7 +244,9 @@ def main(argv: list[str]) -> int:
     for f in aio_files:
         print(f"[validate-changed]   changed shader: {f}")
 
-    # Write the AIO-relative list and hand it to hlslkit via @file.
+    # Write the AIO-relative list and hand it to hlslkit via @file. The real run
+    # blocks until hlslkit has read the file, so it is safe to remove afterward;
+    # always clean up (including --dry-run) so no stray temp files accumulate.
     fd, list_path = tempfile.mkstemp(prefix="changed_shaders_", suffix=".txt", text=True)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
@@ -249,11 +254,10 @@ def main(argv: list[str]) -> int:
         full_command = [*command, "--changed-files", f"@{list_path}"]
         return _run(full_command, args.dry_run)
     finally:
-        if not args.dry_run:
-            try:
-                os.remove(list_path)
-            except OSError:
-                pass
+        try:
+            os.remove(list_path)
+        except OSError:
+            pass
 
 
 def _run(command: list[str], dry_run: bool) -> int:

--- a/tools/validate_changed_shaders.py
+++ b/tools/validate_changed_shaders.py
@@ -9,10 +9,10 @@ compiles only the entry-point shaders that transitively include a changed file.
 
 Two ways to supply the change set:
 
-* ``--changed-list-file FILE`` — a precomputed list (one path per line, or
-  whitespace/space separated). CI passes the list produced by
-  ``tj-actions/changed-files``. An *empty* file means "unknown change set" and
-  triggers FULL validation (used for push/release runs).
+* ``--changed-list-file FILE`` — a precomputed list, one path per line (not
+  whitespace-separated, so feature directory names with spaces survive). CI
+  passes the list produced by ``tj-actions/changed-files``. An *empty* file
+  means "unknown change set" and triggers FULL validation (push/release runs).
 * git diff (default when no list file is given) — compares the working tree
   against ``--base`` (default ``HEAD``). An empty diff means "nothing changed"
   and exits 0 without compiling. This is the local-dev path.
@@ -110,11 +110,21 @@ def find_full_trigger(changed: list[str]) -> str | None:
     return None
 
 
-def translate_to_aio(path: str) -> str | None:
-    """Map a repo-relative shader path to its AIO-relative form, or None.
+class _Unmappable:
+    """Sentinel type: a shader file outside the known AIO shader roots."""
 
-    Returns None for non-shader files. Raises nothing: an unmappable shader
-    path is reported via the sentinel below so the caller can fall back to full.
+
+# A shader file we can't map to the AIO layout (e.g. tests/shaders/**). Distinct
+# from None (not a shader at all) so the caller widens to full validation rather
+# than silently dropping it.
+UNMAPPABLE = _Unmappable()
+
+
+def translate_to_aio(path: str) -> "str | None | _Unmappable":
+    """Map a repo-relative shader path to its AIO-relative form.
+
+    Returns the AIO-relative path for a mappable shader, ``None`` for a
+    non-shader file, or :data:`UNMAPPABLE` for a shader outside the known roots.
     """
     norm = _normalize(path)
     if not norm.lower().endswith(SHADER_EXTENSIONS):
@@ -123,13 +133,7 @@ def translate_to_aio(path: str) -> str | None:
         m = pattern.match(norm)
         if m:
             return m.group(1)
-    # A shader file outside the known shader roots (e.g. tests/shaders/**) —
-    # signal "unmappable" so validation widens to full rather than silently
-    # dropping it.
-    return _UNMAPPABLE
-
-
-_UNMAPPABLE = object()
+    return UNMAPPABLE
 
 
 def classify_changes(changed: list[str]) -> tuple[list[str] | None, str]:
@@ -148,7 +152,7 @@ def classify_changes(changed: list[str]) -> tuple[list[str] | None, str]:
         mapped = translate_to_aio(path)
         if mapped is None:
             continue  # not a shader file
-        if mapped is _UNMAPPABLE:
+        if mapped is UNMAPPABLE:
             return None, f"full validation: shader path '{_normalize(path)}' is outside the AIO shader tree"
         aio_files.append(mapped)
 
@@ -208,7 +212,8 @@ def main(argv: list[str]) -> int:
     else:
         try:
             changed = git_changed_files(args.base, args.repo_root)
-        except subprocess.CalledProcessError as e:
+        except (subprocess.CalledProcessError, OSError) as e:
+            # CalledProcessError: not a git repo / bad ref. OSError: git not on PATH.
             print(f"[validate-changed] git diff failed ({e}); running FULL validation.", file=sys.stderr)
             changed = []
             empty_means_full = True

--- a/tools/validate_changed_shaders.py
+++ b/tools/validate_changed_shaders.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Run incremental HLSL validation: compile only shaders affected by a change.
+
+This is a thin wrapper around ``hlslkit-compile``. It figures out which shader
+files changed, translates their repo-relative paths into the assembled-AIO
+layout that the validation configs use, and passes them to hlslkit via
+``--changed-files``. hlslkit builds the ``#include`` dependency graph and
+compiles only the entry-point shaders that transitively include a changed file.
+
+Two ways to supply the change set:
+
+* ``--changed-list-file FILE`` — a precomputed list (one path per line, or
+  whitespace/space separated). CI passes the list produced by
+  ``tj-actions/changed-files``. An *empty* file means "unknown change set" and
+  triggers FULL validation (used for push/release runs).
+* git diff (default when no list file is given) — compares the working tree
+  against ``--base`` (default ``HEAD``). An empty diff means "nothing changed"
+  and exits 0 without compiling. This is the local-dev path.
+
+Safety: validation is only narrowed when it is provably safe. Any of the
+following forces a FULL run:
+
+* a validation config (``.github/configs/**``), CMake, or submodule change —
+  these can alter the entry-point/define set itself, so the graph is no longer
+  authoritative;
+* a changed shader path that doesn't map into the AIO shader tree (an
+  unexpected location we can't reason about).
+
+hlslkit applies a second layer of the same safety net: if any path we pass
+isn't found in the shader tree, it falls back to full validation on its own.
+
+Everything after ``--`` is the ``hlslkit-compile`` command to run; this script
+only appends ``--changed-files`` to it (or runs it unchanged for a full run).
+
+Example::
+
+    python tools/validate_changed_shaders.py --changed-list-file changed.txt -- \\
+        hlslkit-compile --fxc fxc.exe --shader-dir build/ALL/aio/Shaders \\
+        --output-dir build/ShaderCache --config .github/configs/shader-validation.yaml \\
+        --max-warnings 0 --suppress-warnings X1519
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+SHADER_EXTENSIONS = (".hlsl", ".hlsli")
+
+# Repo-relative prefixes that map onto the assembled AIO shader root.
+# package/Shaders/<rest>            -> <rest>
+# features/<Feature>/Shaders/<rest> -> <rest>
+_PACKAGE_PREFIX = re.compile(r"^package/Shaders/(.+)$")
+_FEATURE_PREFIX = re.compile(r"^features/[^/]+/Shaders/(.+)$")
+
+# Changes that invalidate the dependency-graph assumption and force a full run.
+_FULL_TRIGGERS = (
+    re.compile(r"^\.github/configs/"),  # validation configs define entries/defines
+    re.compile(r"^CMakeLists\.txt$"),
+    re.compile(r"^CMakePresets\.json$"),
+    re.compile(r"^cmake/"),
+    re.compile(r"^\.gitmodules$"),
+)
+
+
+def _normalize(path: str) -> str:
+    norm = path.replace("\\", "/").strip()
+    if norm.startswith("./"):
+        norm = norm[2:]
+    return norm
+
+
+def read_changed_list_file(path: str) -> list[str]:
+    """Read a precomputed changed-files list (one path per line).
+
+    Newline-separated, not whitespace-separated: feature directory names
+    contain spaces (e.g. ``features/Light Limit Fix/Shaders/...``).
+    """
+    with open(path, encoding="utf-8") as f:
+        return [line.strip() for line in f.read().splitlines() if line.strip()]
+
+
+def git_changed_files(base: str, repo_root: str) -> list[str]:
+    """Return working-tree changes vs ``base`` plus untracked files."""
+
+    def _run(args: list[str]) -> list[str]:
+        out = subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return [line for line in out.stdout.splitlines() if line.strip()]
+
+    tracked = _run(["diff", "--name-only", base])
+    untracked = _run(["ls-files", "--others", "--exclude-standard"])
+    return sorted(set(tracked) | set(untracked))
+
+
+def find_full_trigger(changed: list[str]) -> str | None:
+    """Return the first changed path that forces a full run, or None."""
+    for path in changed:
+        norm = _normalize(path)
+        for trigger in _FULL_TRIGGERS:
+            if trigger.search(norm):
+                return norm
+    return None
+
+
+def translate_to_aio(path: str) -> str | None:
+    """Map a repo-relative shader path to its AIO-relative form, or None.
+
+    Returns None for non-shader files. Raises nothing: an unmappable shader
+    path is reported via the sentinel below so the caller can fall back to full.
+    """
+    norm = _normalize(path)
+    if not norm.lower().endswith(SHADER_EXTENSIONS):
+        return None
+    for pattern in (_PACKAGE_PREFIX, _FEATURE_PREFIX):
+        m = pattern.match(norm)
+        if m:
+            return m.group(1)
+    # A shader file outside the known shader roots (e.g. tests/shaders/**) —
+    # signal "unmappable" so validation widens to full rather than silently
+    # dropping it.
+    return _UNMAPPABLE
+
+
+_UNMAPPABLE = object()
+
+
+def classify_changes(changed: list[str]) -> tuple[list[str] | None, str]:
+    """Decide full vs incremental from a changed-files list.
+
+    Returns ``(aio_files, reason)``. ``aio_files is None`` means run FULL
+    validation; otherwise it is the (possibly empty) list of AIO-relative
+    shader paths to validate incrementally.
+    """
+    trigger = find_full_trigger(changed)
+    if trigger is not None:
+        return None, f"full validation: '{trigger}' can change the entry-point/define set"
+
+    aio_files: list[str] = []
+    for path in changed:
+        mapped = translate_to_aio(path)
+        if mapped is None:
+            continue  # not a shader file
+        if mapped is _UNMAPPABLE:
+            return None, f"full validation: shader path '{_normalize(path)}' is outside the AIO shader tree"
+        aio_files.append(mapped)
+
+    # Deduplicate, preserve determinism.
+    aio_files = sorted(set(aio_files))
+    return aio_files, f"incremental: {len(aio_files)} changed shader file(s)"
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run hlslkit-compile incrementally for changed shaders.",
+        epilog="Pass the hlslkit-compile command after a '--' separator.",
+    )
+    parser.add_argument(
+        "--changed-list-file",
+        help="File with a precomputed list of changed repo-relative paths. "
+        "Empty file => full validation. Omit to derive the list from git diff.",
+    )
+    parser.add_argument(
+        "--base",
+        default="HEAD",
+        help="Git ref to diff against in local mode (default: HEAD).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=os.getcwd(),
+        help="Repository root for git operations (default: cwd).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the resolved hlslkit-compile command instead of running it.",
+    )
+    parser.add_argument(
+        "command",
+        nargs=argparse.REMAINDER,
+        help="The hlslkit-compile command, after a '--' separator.",
+    )
+    args = parser.parse_args(argv)
+
+    command = args.command
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        parser.error("missing hlslkit-compile command after '--'")
+
+    # --- Resolve the change set and decide full vs incremental ---
+    from_list = args.changed_list_file is not None
+    if from_list:
+        if not os.path.isfile(args.changed_list_file):
+            print(f"[validate-changed] list file '{args.changed_list_file}' not found; running FULL validation.")
+            changed = []
+            empty_means_full = True
+        else:
+            changed = read_changed_list_file(args.changed_list_file)
+            empty_means_full = True  # provided-but-empty => unknown => full
+    else:
+        try:
+            changed = git_changed_files(args.base, args.repo_root)
+        except subprocess.CalledProcessError as e:
+            print(f"[validate-changed] git diff failed ({e}); running FULL validation.", file=sys.stderr)
+            changed = []
+            empty_means_full = True
+        else:
+            empty_means_full = False  # clean empty diff => nothing to do
+
+    if not changed:
+        if empty_means_full:
+            print("[validate-changed] no change set provided; running FULL validation.")
+            return _run(command, args.dry_run)
+        print("[validate-changed] no changed files detected; nothing to validate.")
+        return 0
+
+    aio_files, reason = classify_changes(changed)
+    print(f"[validate-changed] {reason}")
+
+    if aio_files is None:
+        return _run(command, args.dry_run)
+
+    if not aio_files:
+        # Change set had no shader files and no full-trigger (e.g. only docs).
+        print("[validate-changed] no shader files in the change set; nothing to validate.")
+        return 0
+
+    for f in aio_files:
+        print(f"[validate-changed]   changed shader: {f}")
+
+    # Write the AIO-relative list and hand it to hlslkit via @file.
+    fd, list_path = tempfile.mkstemp(prefix="changed_shaders_", suffix=".txt", text=True)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write("\n".join(aio_files) + "\n")
+        full_command = [*command, "--changed-files", f"@{list_path}"]
+        return _run(full_command, args.dry_run)
+    finally:
+        if not args.dry_run:
+            try:
+                os.remove(list_path)
+            except OSError:
+                pass
+
+
+def _run(command: list[str], dry_run: bool) -> int:
+    printable = " ".join(command)
+    if dry_run:
+        print(f"[validate-changed] DRY RUN: {printable}")
+        return 0
+    print(f"[validate-changed] running: {printable}")
+    return subprocess.run(command).returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Make shader validation **intelligent**: validate only the shaders affected by a change instead of recompiling all ~3,300 variants per config on every HLSL edit. Backed by an `#include` dependency graph — a changed `.hlsl`/`.hlsli` triggers only the entry-point shaders that **transitively include it**.

## How it works

- **`tools/validate_changed_shaders.py`** wraps `hlslkit-compile`. It translates changed `package/Shaders/**` → `<rest>` and `features/*/Shaders/**` → `<rest>` into the assembled-AIO layout the configs use, then passes them to `hlslkit-compile --changed-files`. hlslkit builds the graph and compiles only the affected entry points.
- **CI** (`pr-checks.yaml` + `_shared-build.yaml`): the PR's changed-file list flows into the validation step as JSON (preserves spaces in feature dir names like `Light Limit Fix`).
- **Local**: `cmake --build ./build/ALL --target validate_changed` validates shaders affected by your working-tree diff. Override the config with `-DVALIDATE_CHANGED_CONFIG=…`.

## Safety (never under-validates)

Full validation is forced whenever narrowing isn't provably safe:
- validation config (`.github/configs/**`), CMake, or submodule changes (can redefine the entry/define set);
- a shader path outside the known roots;
- push/release builds (no PR change set).

Preprocessor guards are ignored when scanning includes → the affected set is always a **conservative superset**. hlslkit applies the same fallback independently (any path it can't locate → full).

## Validation (real tree + real config)

Validated against the assembled shader tree (202 files) and the real 24-shader / 3,324-variant config:

| Change | Variants validated |
|---|---|
| post-process IS shader (`ISHDR.hlsl`) | **0.6%** |
| single base shader (`Water.hlsl`) | 20% |
| isolated feature header (`ScreenSpaceShadows.hlsli`) | 18% |
| `LightLimitFix.hlsli` | 82% |
| foundational `Common/VR.hlsli` | 99.7% (≈full, correct) |

Real repo paths (incl. space-containing feature dirs) translate exactly to graph keys; feature-standalone compute shaders not in the config resolve to a clean no-op, matching current coverage (no regression).

## Dependency

Requires hlslkit with the `--changed-files` flag (**alandtse/hlslkit#18**). CI installs hlslkit from git `main`, so **merge that PR first** — until then incremental runs would pass an unrecognized flag. The wrapper's full-fallback paths keep working with the current hlslkit regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)