### PR TITLE
chore(tools): add RenderDoc verification harness

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -107,8 +107,11 @@ pwsh tools/verify-shader-refactor.ps1 package/Shaders/Foo.hlsl   # bash: tools/v
 
 When refactoring an existing shader (especially the decompile-transcription shaders like
 `ISTemporalAA.hlsl`), use `tools/verify-shader-refactor.ps1` to prove the change is
-behavior-preserving: identical compiled bytecode means a provable no-op. See
-`docs/development/shader-workflow.md` for details.
+behavior-preserving: identical compiled bytecode means a provable no-op. When the refactor
+legitimately reorders ops (bytecode differs but behavior shouldn't), validate it with the runtime
+A/B harness instead — capture one frame, swap just that shader, and diff the output against the
+shipping baseline (`tools/taa-renderdoc-ab.py`). See `docs/development/shader-workflow.md` and
+`docs/development/shader-runtime-ab.md` for details.
 
 ### Custom CMake Targets
 

--- a/docs/development/shader-runtime-ab.md
+++ b/docs/development/shader-runtime-ab.md
@@ -98,7 +98,7 @@ Load the harness, then run the A/B. (If a later call reports the functions undef
 uses a fresh namespace per `Eval` — see Lessons; `exec` and call in the same `Eval`.)
 
 ```python
-exec(open(r"f:/Worktrees/.../tools/taa-renderdoc-ab.py").read())
+exec(open(r"<repo>/tools/taa-renderdoc-ab.py").read())   # <repo> = your local checkout path
 taa_candidates()          # exhaustive forward scan — fine for menu / small captures
 # On a multi-GB in-game capture, scan from the end and stop at the first hit so the worker
 # doesn't time out (the TAA pass is post-process, near the end):

--- a/docs/development/shader-runtime-ab.md
+++ b/docs/development/shader-runtime-ab.md
@@ -23,9 +23,10 @@ op-reordering restructure produces.
 ## Prerequisites
 
 -   RenderDoc, reachable via the `renderdoc` MCP (`Eval`, `Get-Texture`, `Instance`).
--   SkyrimSE or SkyrimVR launchable with RenderDoc injected (`rd.ExecuteAndInject(skse64_loader.exe,
-…, hookIntoChildren=True)`, or launch from the RenderDoc GUI). The **main menu** already runs
-    the TAA pass, so it is a valid capture surface on either edition.
+-   SkyrimSE or SkyrimVR launchable with RenderDoc injected (`rd.ExecuteAndInject(<loader>, …,
+hookIntoChildren=True)`, or launch from the RenderDoc GUI) — `<loader>` is `skse64_loader.exe`
+    for SE/AE and `sksevr_loader.exe` for VR. The **main menu** already runs the TAA pass, so it is
+    a valid capture surface on either edition.
 -   The build must be in **TAA upscaling mode** (DLSS/FSR replace `ISTemporalAA`) and ideally with
     **HDR and frame-generation off** — otherwise Open Shaders presents through a DX12 interop
     swapchain and RenderDoc captures only the D3D12 present (Copy/Present, no draws), not the

--- a/docs/development/shader-runtime-ab.md
+++ b/docs/development/shader-runtime-ab.md
@@ -138,18 +138,23 @@ in the report.
 
 ## Generalizing to other shaders
 
-TAA is just the worked example — the harness is a template for validating **any** shader refactor
-or reverse-engineered transcription. The reusable core (freeze a real frame, swap one shader, diff
-its output against a baseline noise floor) is shader-agnostic. To point it at a different shader you
-change only three things:
+TAA is just the worked example — `grab_rt()`, `replace_ps_with_dxbc()`, `restore()`, `_diff()`, and
+`ab(eid, …)` are all **shader-agnostic** (give `ab()` an event ID and it validates any pass). The
+only TAA-specific piece is the fingerprint used to _find_ the pass, and that's a parameter:
 
--   **The pass fingerprint.** `taa_candidates()` locates the draw by its **bound-resource
-    signature** (the `t0..t5` SRV set), not by draw index. For another shader, match on its own
-    distinctive SRV/UAV/RT bindings.
--   **The permutation defines.** Compile A′/B with the exact `/D` set the running build used.
--   **The capture state.** Pick a frame that actually exercises the code path (see lessons).
+```python
+# Generic finder — match a pass by the SRV names its pixel shader binds (case-insensitive):
+cands = find_candidates({"mycolortex", "mydepthtex", "myhistorytex"}, reverse=True, stop_after=1)
+ab(cands[0]["eventId"], candidate_dxbc=..., baseline_dxbc=...)
+# taa_candidates() is just find_candidates(_TAA_TEX) — copy that one-liner for your own preset.
+```
 
-`ab()`, the baseline-floor verdict, the channel-aware decode, and restore-on-exit are unchanged.
+So to point it at a different shader you change only:
+
+-   **The pass fingerprint** — pass your shader's distinctive SRV names to `find_candidates()` (no
+    source edit needed). Match by bound resources, not draw index (indices shift frame to frame).
+-   **The permutation defines** — compile A′/B with the exact `/D` set the running build used.
+-   **The capture state** — pick a frame that actually exercises the code path (see lessons).
 
 ## Lessons (generalizable RE technique)
 

--- a/docs/development/shader-runtime-ab.md
+++ b/docs/development/shader-runtime-ab.md
@@ -1,9 +1,9 @@
-# TAA runtime A/B check (Tier-3)
+# Shader runtime A/B check
 
-A same-frame, GPU-level equivalence check for `ISTemporalAA.hlsl` refactors whose compiled
-bytecode legitimately diverges (the **Standard B** restructure of the bracket/flicker/blend
-core). For refactors that stay bytecode-identical, use `tools/verify-shader-refactor.ps1`
-instead — it is a hard offline proof and needs no game.
+A same-frame, GPU-level equivalence check for a shader refactor whose compiled bytecode
+legitimately diverges — an op-reordering / algebraic restructure (e.g. the TAA bracket/flicker/
+blend core). For refactors that stay **bytecode-identical**, use `tools/verify-shader-refactor.ps1`
+instead — a hard offline proof that needs no game.
 
 TAA is the worked example here, but the technique and the [Lessons](#lessons-generalizable-re-technique)
 generalize to any shader RE/refactor — see [Generalizing to other shaders](#generalizing-to-other-shaders).
@@ -17,8 +17,8 @@ TAA pixel shader on that captured frame. The inputs (history `t1`, velocity `t2`
 mask `t4`, alpha `t5`, cbuffer `b2`) are frozen, so A (shipping) and B (candidate) run on
 byte-identical inputs — a near-zero output diff means equivalent behavior on a real frame.
 
-This is the runtime analog of the offline verifier, tolerant of the bytecode divergence that
-defines Standard B.
+This is the runtime analog of the offline verifier, tolerant of the bytecode divergence an
+op-reordering restructure produces.
 
 ## Prerequisites
 
@@ -51,7 +51,7 @@ $defs = @("/D","PSHADER=1")            # add "/D","VR=1" and/or "/D","HDR_OUTPUT
 # Baseline A' = the DEPLOYED shader (extract the shipping ref to a temp file; UTF-8, not PS UTF-16)
 [IO.File]::WriteAllLines("$env:TEMP\taa_A.hlsl", (git show origin/dev:$sh))
 & $fxc /nologo /T ps_5_0 /E main @defs /I $inc "$env:TEMP\taa_A.hlsl" /Fo "$env:TEMP\taa_A.dxbc"
-# Candidate B = the Standard-B working tree
+# Candidate B = the refactored working tree
 & $fxc /nologo /T ps_5_0 /E main @defs /I $inc $sh /Fo "$env:TEMP\taa_B.dxbc"
 ```
 

--- a/docs/development/taa-runtime-ab.md
+++ b/docs/development/taa-runtime-ab.md
@@ -88,17 +88,24 @@ after capturing.
     corrupt/oversized `.rdc` needs a full RenderDoc relaunch, not an MCP reconnect.
 -   `TargetControl` sometimes returns a **stale** `NewCapture` path — verify the new `.rdc` by
     timestamp/size on disk, don't trust the returned string.
--   On a huge frame, find the TAA pass by scanning drawcalls **in reverse** (post-process is near
-    the end) — a full-frame `SetFrameEvent` sweep times out the eval worker.
+-   On a huge frame, a full-frame `SetFrameEvent` sweep times out the eval worker — use
+    `taa_candidates(reverse=True, stop_after=1)` (or `max_scan_drawcalls=N`) to scan from the end
+    (post-process is near there) and stop at the first match.
 
 ### 3. Load the harness and run the A/B (via the `renderdoc` MCP `Eval`)
 
-The embedded interpreter persists across `Eval` calls, so load the module once:
+Load the harness, then run the A/B. (If a later call reports the functions undefined, your MCP
+uses a fresh namespace per `Eval` — see Lessons; `exec` and call in the same `Eval`.)
 
 ```python
 exec(open(r"f:/Worktrees/.../tools/taa-renderdoc-ab.py").read())
-taa_candidates()          # find ISTemporalAA by its 6-SRV fingerprint (t0..t5: current/history/velocity/depth/mask/alpha)
+taa_candidates()          # exhaustive forward scan — fine for menu / small captures
+# On a multi-GB in-game capture, scan from the end and stop at the first hit so the worker
+# doesn't time out (the TAA pass is post-process, near the end):
+taa_candidates(reverse=True, stop_after=1)   # or max_scan_drawcalls=N to cap the probe
 ```
+
+(Finds ISTemporalAA by its 6-SRV fingerprint — `t0..t5`: current/history/velocity/depth/mask/alpha.)
 
 Pick the `eventId` of the TAA draw from the candidate list, then:
 

--- a/docs/development/taa-runtime-ab.md
+++ b/docs/development/taa-runtime-ab.md
@@ -20,26 +20,36 @@ defines Standard B.
 ## Prerequisites
 
 -   RenderDoc, reachable via the `renderdoc` MCP (`Eval`, `Get-Texture`, `Instance`).
--   SkyrimVR launchable with RenderDoc injected (devbench MCP when available, or launch+inject
-    from the RenderDoc GUI). The original VR TAA artifact is visible at the **main menu**, so the
-    menu is a valid capture surface.
+-   SkyrimSE or SkyrimVR launchable with RenderDoc injected (`rd.ExecuteAndInject(skse64_loader.exe,
+…, hookIntoChildren=True)`, or launch from the RenderDoc GUI). The **main menu** already runs
+    the TAA pass, so it is a valid capture surface on either edition.
+-   The build must be in **TAA upscaling mode** (DLSS/FSR replace `ISTemporalAA`) and ideally with
+    **HDR and frame-generation off** — otherwise Open Shaders presents through a DX12 interop
+    swapchain and RenderDoc captures only the D3D12 present (Copy/Present, no draws), not the
+    D3D11 TAA pass.
 -   `fxc.exe` (Windows SDK) — same compiler the offline verifier uses.
 
 ## Steps
 
 ### 1. Compile A' (current) and B (candidate) to DXBC — match the build's permutation
 
-Use the SAME defines as the running build (SkyrimVR ⇒ `VR`; add `HDR_OUTPUT` only if the user
-runs the HDR path) and `/I package/Shaders` so includes resolve. Feeding DXBC sidesteps
+Use the SAME defines as the running build (SkyrimSE ⇒ no `VR`; SkyrimVR ⇒ `VR`; add `HDR_OUTPUT`
+only if HDR is on) and `/I package/Shaders` so includes resolve. Feeding DXBC sidesteps
 RenderDoc's HLSL include/define handling.
+
+**A′ and B must come from different sources** — A′ from the **deployed/shipping** shader (so its
+diff vs the live RT establishes the noise floor), B from your **candidate**. Pull A′ from a git
+ref and B from the working tree so they can't accidentally be the same file:
 
 ```powershell
 $fxc = (Get-Command fxc.exe).Source
 $inc = "package/Shaders"; $sh = "package/Shaders/ISTemporalAA.hlsl"
-# Baseline A' = the shipping shader at this permutation (validates our define set)
-& $fxc /nologo /T ps_5_0 /E main /D PSHADER=1 /D VR=1 /I $inc $sh /Fo "$env:TEMP\taa_A.dxbc"
-# Candidate B = the Standard-B working tree (or a ref checked out first)
-& $fxc /nologo /T ps_5_0 /E main /D PSHADER=1 /D VR=1 /I $inc $sh /Fo "$env:TEMP\taa_B.dxbc"
+$defs = @("/D","PSHADER=1")            # add "/D","VR=1" and/or "/D","HDR_OUTPUT=1" to match the build
+# Baseline A' = the DEPLOYED shader (extract the shipping ref to a temp file; UTF-8, not PS UTF-16)
+[IO.File]::WriteAllLines("$env:TEMP\taa_A.hlsl", (git show origin/dev:$sh))
+& $fxc /nologo /T ps_5_0 /E main @defs /I $inc "$env:TEMP\taa_A.hlsl" /Fo "$env:TEMP\taa_A.dxbc"
+# Candidate B = the Standard-B working tree
+& $fxc /nologo /T ps_5_0 /E main @defs /I $inc $sh /Fo "$env:TEMP\taa_B.dxbc"
 ```
 
 ### 2. Capture a frame

--- a/docs/development/taa-runtime-ab.md
+++ b/docs/development/taa-runtime-ab.md
@@ -66,10 +66,17 @@ ab(<eventId>,
 
 ### 4. Interpret
 
--   `baseline_vs_live` should be `IDENTICAL`/`EQUIVALENT`. If not, the define set or permutation
-    is wrong (e.g. HDR mismatch) — fix step 1 before trusting the candidate.
--   `candidate_vs_live` is the result: `EQUIVALENT` (`max_abs < 1e-3`) ⇒ Standard B preserves
-    behavior on this frame. `DIFFERS` with a structured `max_abs` ⇒ a real regression.
+**Always pass `baseline_dxbc`** — the verdict is _relative to it_. The game compiles the live
+shader with slightly different optimization than offline fxc, so even an identical shader leaves
+a small **noise floor** (`baseline_vs_live.mean_abs`, e.g. ~2e-4 on a 10-bit RT). `ab()` reports:
+
+-   `noise_floor_mean` — the baseline residue.
+-   `verdict`: `EQUIVALENT` if `candidate_vs_live.mean_abs ≤ 3× the floor`, else `DIFFERS`.
+
+Validated on the SE main menu (TAA on, HDR/frame-gen off): the pre-rename `dev` shader read
+`EQUIVALENT` (mean = floor), a deliberately ×0.5 shader read `DIFFERS` (mean ≈ 83× floor, 61%
+of samples). If `baseline_vs_live.mean_abs` is _large_ (not a tiny floor), the permutation is
+wrong (e.g. `HDR_OUTPUT` mismatch) — fix step 1 before trusting the candidate.
 
 ### 5. (Optional) visual evidence
 

--- a/docs/development/taa-runtime-ab.md
+++ b/docs/development/taa-runtime-ab.md
@@ -1,0 +1,87 @@
+# TAA runtime A/B check (Tier-3)
+
+A same-frame, GPU-level equivalence check for `ISTemporalAA.hlsl` refactors whose compiled
+bytecode legitimately diverges (the **Standard B** restructure of the bracket/flicker/blend
+core). For refactors that stay bytecode-identical, use `tools/verify-shader-refactor.ps1`
+instead — it is a hard offline proof and needs no game.
+
+## Why same-frame swap (not two-launch screenshots)
+
+TAA is temporal: its output depends on accumulated history. Two separate game launches never
+align frame-for-frame (animated menu, HMD pose, timing/RNG), so a screenshot A/B only yields a
+noisy tolerance diff. Instead we capture **one** real frame in RenderDoc and replace just the
+TAA pixel shader on that captured frame. The inputs (history `t1`, velocity `t2`, depth `t3`,
+mask `t4`, alpha `t5`, cbuffer `b2`) are frozen, so A (shipping) and B (candidate) run on
+byte-identical inputs — a near-zero output diff means equivalent behavior on a real frame.
+
+This is the runtime analog of the offline verifier, tolerant of the bytecode divergence that
+defines Standard B.
+
+## Prerequisites
+
+-   RenderDoc, reachable via the `renderdoc` MCP (`Eval`, `Get-Texture`, `Instance`).
+-   SkyrimVR launchable with RenderDoc injected (devbench MCP when available, or launch+inject
+    from the RenderDoc GUI). The original VR TAA artifact is visible at the **main menu**, so the
+    menu is a valid capture surface.
+-   `fxc.exe` (Windows SDK) — same compiler the offline verifier uses.
+
+## Steps
+
+### 1. Compile A' (current) and B (candidate) to DXBC — match the build's permutation
+
+Use the SAME defines as the running build (SkyrimVR ⇒ `VR`; add `HDR_OUTPUT` only if the user
+runs the HDR path) and `/I package/Shaders` so includes resolve. Feeding DXBC sidesteps
+RenderDoc's HLSL include/define handling.
+
+```powershell
+$fxc = (Get-Command fxc.exe).Source
+$inc = "package/Shaders"; $sh = "package/Shaders/ISTemporalAA.hlsl"
+# Baseline A' = the shipping shader at this permutation (validates our define set)
+& $fxc /nologo /T ps_5_0 /E main /D PSHADER=1 /D VR=1 /I $inc $sh /Fo "$env:TEMP\taa_A.dxbc"
+# Candidate B = the Standard-B working tree (or a ref checked out first)
+& $fxc /nologo /T ps_5_0 /E main /D PSHADER=1 /D VR=1 /I $inc $sh /Fo "$env:TEMP\taa_B.dxbc"
+```
+
+### 2. Capture a frame
+
+Launch SkyrimVR to the main menu with RenderDoc attached and capture one frame. Confirm with
+`Instance list` (the `renderdoc` MCP) that an instance shows `capture_loaded: true`.
+
+### 3. Load the harness and run the A/B (via the `renderdoc` MCP `Eval`)
+
+The embedded interpreter persists across `Eval` calls, so load the module once:
+
+```python
+exec(open(r"f:/Worktrees/.../tools/taa-renderdoc-ab.py").read())
+taa_candidates()          # find the ISTemporalAA draw: 2 outputs (Color+Feedback), >=5 SRVs
+```
+
+Pick the `eventId` of the TAA draw from the candidate list, then:
+
+```python
+ab(<eventId>,
+   candidate_dxbc=r"%TEMP%/taa_B.dxbc",
+   baseline_dxbc=r"%TEMP%/taa_A.dxbc")
+```
+
+### 4. Interpret
+
+-   `baseline_vs_live` should be `IDENTICAL`/`EQUIVALENT`. If not, the define set or permutation
+    is wrong (e.g. HDR mismatch) — fix step 1 before trusting the candidate.
+-   `candidate_vs_live` is the result: `EQUIVALENT` (`max_abs < 1e-3`) ⇒ Standard B preserves
+    behavior on this frame. `DIFFERS` with a structured `max_abs` ⇒ a real regression.
+
+### 5. (Optional) visual evidence
+
+Use the `Get-Texture` MCP tool on the output RT before vs after replacement (and over the
+`x≈0.5` eye-seam region where the original VR bug showed) with `diff_amplify` for a diff image
+in the report.
+
+## Caveats
+
+-   One frame proves equivalence on that frame; loop over a few captured frames (different menu
+    animation phases) for confidence.
+-   The `HDR_OUTPUT` define must match the user's actual HDR setting, or `baseline_vs_live` will
+    flag it.
+-   This is a regression check against a known-good baseline, not a formal proof; pair it with
+    the offline verifier (which formally covers every part that stays bytecode-identical).

--- a/docs/development/taa-runtime-ab.md
+++ b/docs/development/taa-runtime-ab.md
@@ -5,6 +5,9 @@ bytecode legitimately diverges (the **Standard B** restructure of the bracket/fl
 core). For refactors that stay bytecode-identical, use `tools/verify-shader-refactor.ps1`
 instead — it is a hard offline proof and needs no game.
 
+TAA is the worked example here, but the technique and the [Lessons](#lessons-generalizable-re-technique)
+generalize to any shader RE/refactor — see [Generalizing to other shaders](#generalizing-to-other-shaders).
+
 ## Why same-frame swap (not two-launch screenshots)
 
 TAA is temporal: its output depends on accumulated history. Two separate game launches never
@@ -125,24 +128,60 @@ Use the `Get-Texture` MCP tool on the output RT before vs after replacement (and
 `x≈0.5` eye-seam region where the original VR bug showed) with `diff_amplify` for a diff image
 in the report.
 
-## Caveats & lessons learned
+## Generalizing to other shaders
 
--   **Reach for the offline verifier first.** Far more refactoring stays bytecode-identical than
-    you'd expect — even destructuring deeply-aliased decompile scratch (where one float4 component
-    means different things at different points) compiles **byte-identically**, because the compiler
-    already SSA's it. Go one small step at a time and run `verify-shader-refactor.ps1` (or a per-
-    permutation `fxc` byte-compare) after each. Byte-identity is a _stronger_ proof than this
-    runtime A/B and needs no game/RenderDoc. Reserve this harness for the genuine op-reordering
-    core (the bracket/flicker/blend restructure) where fxc legitimately emits different code.
--   One frame proves equivalence on that frame; loop over a few captured frames for confidence.
--   The `HDR_OUTPUT` define must match the user's actual HDR setting, or `baseline_vs_live` flags it.
--   **The HDR permutation can't be captured at all** — with HDR on, Open Shaders presents through a
-    DX12 interop swapchain and the D3D11 TAA pass isn't in the frame. Validate the `HDR_OUTPUT`
-    path by byte-identity + static analysis instead (the SDR path's runtime A/B covers the shared
-    math; HDR-only blocks are usually value-identical renames).
--   **MCP `Eval` quirks (vary by server/version):** (1) if `ab`/`taa_candidates` are undefined on a
-    later call, your server uses a **fresh namespace per `Eval`** — `exec` the harness _and_ call it
-    in the **same** `Eval` (`g = dict(globals()); exec(src, g); g["ab"](...)`). (2) Output can lag
-    **one call behind** (you get the _previous_ call's stdout); poll again to drain it.
--   This is a regression check against a known-good baseline, not a formal proof; pair it with the
-    offline verifier (which formally covers every part that stays bytecode-identical).
+TAA is just the worked example — the harness is a template for validating **any** shader refactor
+or reverse-engineered transcription. The reusable core (freeze a real frame, swap one shader, diff
+its output against a baseline noise floor) is shader-agnostic. To point it at a different shader you
+change only three things:
+
+-   **The pass fingerprint.** `taa_candidates()` locates the draw by its **bound-resource
+    signature** (the `t0..t5` SRV set), not by draw index. For another shader, match on its own
+    distinctive SRV/UAV/RT bindings.
+-   **The permutation defines.** Compile A′/B with the exact `/D` set the running build used.
+-   **The capture state.** Pick a frame that actually exercises the code path (see lessons).
+
+`ab()`, the baseline-floor verdict, the channel-aware decode, and restore-on-exit are unchanged.
+
+## Lessons (generalizable RE technique)
+
+These transfer to any GPU-shader RE/validation work, not just TAA:
+
+-   **Offline byte-identity beats any runtime check — try it first.** Far more refactoring stays
+    bytecode-identical than you'd expect (even destructuring deeply-aliased decompile scratch, since
+    the compiler already SSA's it). Prove those with an `fxc` byte-compare
+    (`verify-shader-refactor.ps1`), one small step at a time — no game needed. Reserve a runtime swap
+    for changes where the compiler legitimately emits different-but-equivalent code (op reordering,
+    algebraic rewrites).
+-   **Freeze inputs with a same-frame swap.** Any pass whose inputs are bound resources can be
+    validated by replacing only that shader on one captured frame: A and B then run on byte-identical
+    inputs, so the output diff is pure shader behaviour — no cross-launch timing/RNG/pose noise.
+-   **Judge against a baseline noise floor, not zero.** The runtime compiler differs from offline
+    `fxc` by a few LSBs, so even an identical shader isn't bit-exact vs the live RT. Always swap the
+    _shipping_ shader in too and measure the candidate relative to that floor.
+-   **Capture a state that exercises the path under test.** A degenerate frame (idle menu, static
+    camera, untaken branch) gives a false pass for any state-dependent code — temporal history,
+    motion vectors, conditionally-enabled features. Identify what state your code depends on and
+    capture a frame in it. _(TAA: a static menu read `EQUIVALENT` even with a real motion-path bug;
+    only an in-game motion frame exposed it.)_
+-   **Baseline against the change's true parent, not a distant branch.** If your work is stacked on
+    an unmerged fix, diffing against `dev` folds that fix into the "floor" → a huge bogus residue and
+    a meaningless verdict. Compile the baseline from the immediate parent commit.
+-   **Confirm which source you compiled.** A wrong-branch/ref compile silently validates the deployed
+    shader against itself and always reports `EQUIVALENT`. Check `git branch`/the ref first.
+-   **Find the pass by its resource fingerprint, and reverse-scan.** Match a draw by its bound
+    textures/buffers, not its index (indices shift frame to frame). Post-process sits near frame end,
+    so scan drawcalls in reverse — a full-frame state sweep can time out on a large capture.
+-   **Interop swapchains hide the inner API.** When an app presents D3D11 work through a DX12 interop
+    swapchain (here: HDR / frame-gen / upscaler paths), RenderDoc hooks the D3D12 present and the
+    D3D11 draws aren't in the frame at all. Disable the feature that triggers interop to capture the
+    inner API; if you can't, fall back to offline byte-identity for that permutation.
+-   **Captures scale with scene complexity.** A heavy scene (especially stereo/VR) can produce a
+    multi-GB capture that wedges the tools; shrink the scene (interior, lower res) to keep captures
+    loadable. Verify a new capture by file timestamp/size — capture APIs sometimes return a stale path.
+-   **Know your tooling's quirks.** (Here, the `renderdoc` MCP `Eval`: a fresh namespace per call can
+    drop your defs — `exec` the harness and call it in the _same_ `Eval`; and stdout may lag one call
+    behind, so poll again to drain it.)
+-   One frame proves equivalence on that frame; loop over a few representative frames for confidence.
+    This is a regression check against a known-good baseline, not a formal proof — pair it with the
+    offline verifier, which formally covers everything that stays bytecode-identical.

--- a/docs/development/taa-runtime-ab.md
+++ b/docs/development/taa-runtime-ab.md
@@ -63,7 +63,7 @@ The embedded interpreter persists across `Eval` calls, so load the module once:
 
 ```python
 exec(open(r"f:/Worktrees/.../tools/taa-renderdoc-ab.py").read())
-taa_candidates()          # find the ISTemporalAA draw: 2 outputs (Color+Feedback), >=5 SRVs
+taa_candidates()          # find ISTemporalAA by its 6-SRV fingerprint (t0..t5: current/history/velocity/depth/mask/alpha)
 ```
 
 Pick the `eventId` of the TAA draw from the candidate list, then:

--- a/docs/development/taa-runtime-ab.md
+++ b/docs/development/taa-runtime-ab.md
@@ -52,10 +52,41 @@ $defs = @("/D","PSHADER=1")            # add "/D","VR=1" and/or "/D","HDR_OUTPUT
 & $fxc /nologo /T ps_5_0 /E main @defs /I $inc $sh /Fo "$env:TEMP\taa_B.dxbc"
 ```
 
-### 2. Capture a frame
+**Baseline = the refactor's BASE, not blindly `origin/dev`.** If your refactor is _stacked_ on a
+fix/feature not yet on `dev` (e.g. a VR fix the restructure sits on top of), compiling A′ from
+`dev` makes `baseline_vs_live` measure _that fix's effect_, not the compiler noise floor — you'll
+see a huge "floor" (e.g. ~0.22 instead of ~0.001) and a meaningless `EQUIVALENT`. Use the
+refactor's **parent commit** (`git show <refactor-base>:$sh`) so A′ and B differ only by the
+restructure.
 
-Launch SkyrimSE or SkyrimVR to the main menu with RenderDoc attached and capture one frame.
-Confirm with `Instance list` (the `renderdoc` MCP) that an instance shows `capture_loaded: true`.
+**Confirm `git branch` before compiling B.** A wrong-branch compile silently builds the deployed
+shader as the "candidate" and reports a meaningless `EQUIVALENT`.
+
+### 2. Capture a frame — MOTION matters
+
+Confirm with `Instance list` (the `renderdoc` MCP) that an instance shows `capture_loaded: true`
+after capturing.
+
+-   The **main menu** runs the TAA pass, but its history rectification is near-passthrough on a
+    static image. **A menu frame does NOT validate any change that flows through the motion-
+    dependent path** (reject / history reproject / clip-to-AABB) — it reads a false `EQUIVALENT`.
+    Use a menu frame only for changes you already know are motion-independent. _(This is how a
+    gate-inversion bug once slipped through: byte-for-byte `EQUIVALENT` on the menu, ~4× off under
+    motion — caught only by re-running on an in-game motion frame and bisecting the commits.)_
+-   For anything touching the blend/reject core, capture an **in-game frame with real motion**.
+    Via `dev-bench` + `renderdoc`: load a light **interior** save, then `record replay` a movement
+    recording (continuous teleport along a path = sustained motion vectors) and fire
+    `TargetControl.TriggerCapture(1)` ~3 s into the replay from a **concurrent** `Eval` (the replay
+    call blocks for its whole duration, so the trigger must run in parallel). `camera setPov vanity`
+    gives orbiting motion on SE; in VR the HMD drives the camera, so **player translation is the
+    reliable VR motion source**.
+-   **Capture size is the gate.** SE in-game ≈ 1.5 GB; VR interior ≈ 0.5–5.5 GB (loads fine); VR
+    **exterior ≈ 14 GB and wedges/crashes RenderDoc** — stay indoors (e.g. Dragonsreach). A
+    corrupt/oversized `.rdc` needs a full RenderDoc relaunch, not an MCP reconnect.
+-   `TargetControl` sometimes returns a **stale** `NewCapture` path — verify the new `.rdc` by
+    timestamp/size on disk, don't trust the returned string.
+-   On a huge frame, find the TAA pass by scanning drawcalls **in reverse** (post-process is near
+    the end) — a full-frame `SetFrameEvent` sweep times out the eval worker.
 
 ### 3. Load the harness and run the A/B (via the `renderdoc` MCP `Eval`)
 
@@ -94,11 +125,24 @@ Use the `Get-Texture` MCP tool on the output RT before vs after replacement (and
 `x≈0.5` eye-seam region where the original VR bug showed) with `diff_amplify` for a diff image
 in the report.
 
-## Caveats
+## Caveats & lessons learned
 
--   One frame proves equivalence on that frame; loop over a few captured frames (different menu
-    animation phases) for confidence.
--   The `HDR_OUTPUT` define must match the user's actual HDR setting, or `baseline_vs_live` will
-    flag it.
--   This is a regression check against a known-good baseline, not a formal proof; pair it with
-    the offline verifier (which formally covers every part that stays bytecode-identical).
+-   **Reach for the offline verifier first.** Far more refactoring stays bytecode-identical than
+    you'd expect — even destructuring deeply-aliased decompile scratch (where one float4 component
+    means different things at different points) compiles **byte-identically**, because the compiler
+    already SSA's it. Go one small step at a time and run `verify-shader-refactor.ps1` (or a per-
+    permutation `fxc` byte-compare) after each. Byte-identity is a _stronger_ proof than this
+    runtime A/B and needs no game/RenderDoc. Reserve this harness for the genuine op-reordering
+    core (the bracket/flicker/blend restructure) where fxc legitimately emits different code.
+-   One frame proves equivalence on that frame; loop over a few captured frames for confidence.
+-   The `HDR_OUTPUT` define must match the user's actual HDR setting, or `baseline_vs_live` flags it.
+-   **The HDR permutation can't be captured at all** — with HDR on, Open Shaders presents through a
+    DX12 interop swapchain and the D3D11 TAA pass isn't in the frame. Validate the `HDR_OUTPUT`
+    path by byte-identity + static analysis instead (the SDR path's runtime A/B covers the shared
+    math; HDR-only blocks are usually value-identical renames).
+-   **MCP `Eval` quirks (vary by server/version):** (1) if `ab`/`taa_candidates` are undefined on a
+    later call, your server uses a **fresh namespace per `Eval`** — `exec` the harness _and_ call it
+    in the **same** `Eval` (`g = dict(globals()); exec(src, g); g["ab"](...)`). (2) Output can lag
+    **one call behind** (you get the _previous_ call's stdout); poll again to drain it.
+-   This is a regression check against a known-good baseline, not a formal proof; pair it with the
+    offline verifier (which formally covers every part that stays bytecode-identical).

--- a/docs/development/taa-runtime-ab.md
+++ b/docs/development/taa-runtime-ab.md
@@ -54,8 +54,8 @@ $defs = @("/D","PSHADER=1")            # add "/D","VR=1" and/or "/D","HDR_OUTPUT
 
 ### 2. Capture a frame
 
-Launch SkyrimVR to the main menu with RenderDoc attached and capture one frame. Confirm with
-`Instance list` (the `renderdoc` MCP) that an instance shows `capture_loaded: true`.
+Launch SkyrimSE or SkyrimVR to the main menu with RenderDoc attached and capture one frame.
+Confirm with `Instance list` (the `renderdoc` MCP) that an instance shows `capture_loaded: true`.
 
 ### 3. Load the harness and run the A/B (via the `renderdoc` MCP `Eval`)
 

--- a/tools/taa-renderdoc-ab.py
+++ b/tools/taa-renderdoc-ab.py
@@ -154,14 +154,22 @@ def restore(eid):
 def _diff(a, b, meta):
     """Byte-identity fast path + a SAMPLED float-magnitude estimate (no numpy in RenderDoc,
     and full-res TAA RTs are tens of MB — never materialize the whole thing)."""
-    out = {"size_a": len(a), "size_b": len(b), "format": meta[2], "dims": [meta[0], meta[1]]}
+    # Always populate mean_abs/max_abs so callers (ab) can read them unconditionally.
+    out = {"size_a": len(a), "size_b": len(b), "format": meta[2], "dims": [meta[0], meta[1]],
+           "mean_abs": None, "max_abs": None}
+    if not a or not b:  # fail-soft grab_rt returned empty bytes — not comparable
+        out["verdict"] = "NO-DATA"
+        return out
     if a == b:  # C-level compare — instant
         out["verdict"] = "IDENTICAL"
         out["bytes_differing"] = 0
+        out["mean_abs"] = 0.0
+        out["max_abs"] = 0.0
+        out["sample_frac_differing"] = 0.0
         return out
     if len(a) != len(b):
         out["verdict"] = "DIFFERS"
-        out["note"] = "size mismatch"
+        out["note"] = "size mismatch"  # mean_abs stays None -> ab() treats as not-comparable
         return out
 
     # Per-sample delta units by format: UNORM8 and packed R10G10B10A2 are normalized to [0,1]
@@ -255,8 +263,11 @@ def ab(eid, candidate_dxbc, baseline_dxbc=None, entry="main"):
     # compile residue). EQUIVALENT if within 3x the floor; DIFFERS otherwise.
     base = report.get("baseline_vs_live") or {}
     floor = base.get("mean_abs")
-    cand_mean = report["candidate_vs_live"]["mean_abs"]
-    if floor is not None:
+    cand_mean = report["candidate_vs_live"].get("mean_abs")
+    if cand_mean is None:
+        # candidate output not comparable (empty RT / size mismatch) — surface, don't crash.
+        report["verdict"] = "NOT-COMPARABLE"
+    elif floor is not None:
         report["noise_floor_mean"] = floor
         report["verdict"] = "EQUIVALENT" if cand_mean <= max(floor * 3.0, 1e-4) else "DIFFERS"
     elif baseline_dxbc:

--- a/tools/taa-renderdoc-ab.py
+++ b/tools/taa-renderdoc-ab.py
@@ -10,7 +10,7 @@
 #
 # HOW TO RUN: this is executed *inside RenderDoc's embedded Python* via the renderdoc MCP
 # `Eval` tool (the global `ctx` HandlerContext must be in scope). It is NOT a standalone
-# script. See docs/development/taa-runtime-ab.md for the full operator runbook.
+# script. See docs/development/shader-runtime-ab.md for the full operator runbook.
 #
 # Candidate B (and a baseline A') are supplied as pre-compiled DXBC built with fxc using the
 # SAME defines/permutation as the captured build (e.g. PSHADER VR [HDR_OUTPUT]) and with
@@ -22,8 +22,9 @@ import struct
 import os
 import math
 
-# eid -> (origPS ResourceId, replacement ResourceId). Persists across Eval calls so restore()
-# uses the real objects instead of round-tripping through strings.
+# eid -> (origPS ResourceId, replacement ResourceId), kept so restore() uses the real objects
+# instead of round-tripping through strings. Lives as long as this module's namespace does — if
+# your MCP gives a fresh namespace per Eval, do the replace and its restore in the SAME Eval.
 _replacements = {}
 
 

--- a/tools/taa-renderdoc-ab.py
+++ b/tools/taa-renderdoc-ab.py
@@ -58,15 +58,18 @@ def _as_resid(x):
 _TAA_TEX = {"currentframetex", "historytex", "velocitytex", "depthtex", "masktex", "alphatex"}
 
 
-def taa_candidates(reverse=False, max_scan_drawcalls=0, stop_after=0):
-    """Find ISTemporalAA draws by their pixel-shader SRV fingerprint (t0..t5). Returns
-    [{eventId, name}]; pass the eventId to ab().
+def find_candidates(srv_names, reverse=False, max_scan_drawcalls=0, stop_after=0):
+    """Find draws whose pixel shader binds ALL of `srv_names` — a resource-fingerprint match that
+    is robust across frames/versions (unlike a draw index, which shifts). `srv_names` is any
+    iterable of SRV names (case-insensitive). Returns [{eventId, name}]; pass an eventId to ab().
+    This is the shader-agnostic finder — `ab()`/`grab_rt()`/`replace_ps_with_dxbc()` are already
+    generic, so this plus your shader's fingerprint is all you need to validate a different pass.
 
     A full forward scan calls SetFrameEvent() once per drawcall, which can time out the replay
-    worker on a multi-GB capture. The TAA pass is post-process (near frame end), so on a huge
-    frame pass reverse=True to scan from the end and/or max_scan_drawcalls=N to cap how many
-    drawcalls are probed; stop_after=N returns as soon as N matches are found. Defaults keep the
-    exhaustive forward scan."""
+    worker on a multi-GB capture. Post-process passes sit near frame end, so pass reverse=True to
+    scan from the end and/or max_scan_drawcalls=N to cap how many drawcalls are probed; stop_after=N
+    returns as soon as N matches are found. Defaults keep the exhaustive forward scan."""
+    want = {s.lower() for s in srv_names}
     def work(ctrl):
         sdfile = ctrl.GetStructuredFile()
         draws = [a for a in _walk(ctrl.GetRootActions()) if (a.flags & rd.ActionFlags.Drawcall)]
@@ -81,12 +84,18 @@ def taa_candidates(reverse=False, max_scan_drawcalls=0, stop_after=0):
             if not refl:
                 continue
             names = {r.name.lower() for r in refl.readOnlyResources}
-            if _TAA_TEX.issubset(names):
+            if want.issubset(names):
                 res.append({"eventId": a.eventId, "name": a.GetName(sdfile)})
                 if stop_after > 0 and len(res) >= stop_after:
                     break
         return res
     return ctx.replay(work)
+
+
+def taa_candidates(reverse=False, max_scan_drawcalls=0, stop_after=0):
+    """TAA preset: find_candidates() with ISTemporalAA's t0..t5 SRV fingerprint (_TAA_TEX)."""
+    return find_candidates(_TAA_TEX, reverse=reverse,
+                           max_scan_drawcalls=max_scan_drawcalls, stop_after=stop_after)
 
 
 def _tex_desc(ctrl, rid):

--- a/tools/taa-renderdoc-ab.py
+++ b/tools/taa-renderdoc-ab.py
@@ -1,7 +1,7 @@
-# taa-renderdoc-ab.py — Tier-3 runtime A/B check for TAA shader refactors.
+# taa-renderdoc-ab.py — runtime A/B check for TAA shader refactors.
 #
-# Purpose: prove a behavior-preserving claim that bytecode-identity CANNOT (Standard B,
-# where fxc legitimately emits different-but-equivalent code). It swaps the ISTemporalAA
+# Purpose: prove a behavior-preserving claim that bytecode-identity CANNOT (an op-reordering
+# restructure, where fxc legitimately emits different-but-equivalent code). It swaps the ISTemporalAA
 # pixel shader on a SINGLE captured frame and diffs the output render target. Because the
 # inputs (history t1, velocity t2, depth t3, mask t4, alpha t5, cbuffer b2) are frozen from
 # that one frame, A (shipping shader) and B (candidate) run on byte-identical inputs — so a

--- a/tools/taa-renderdoc-ab.py
+++ b/tools/taa-renderdoc-ab.py
@@ -104,6 +104,11 @@ def replace_ps_with_dxbc(eid, dxbc_path, entry="main"):
     except OSError as e:
         return {"ok": False, "errors": "cannot read %s: %r" % (p, e)}
 
+    # Undo any prior replacement on this event first, so repeated swaps don't leak target
+    # resources or stack replacements (orig would otherwise capture an already-replaced shader).
+    if eid in _replacements:
+        restore(eid)
+
     def work(ctrl):
         ctrl.SetFrameEvent(eid, True)
         orig = _as_resid(ctrl.GetPipelineState().GetShader(rd.ShaderStage.Pixel))
@@ -231,15 +236,20 @@ def ab(eid, candidate_dxbc, baseline_dxbc=None, entry="main"):
     report["candidate_vs_live"] = _diff(a_real, b, meta)
 
     # Verdict: judge the candidate's mean_abs against the baseline noise floor (runtime-vs-fxc
-    # compile residue). EQUIVALENT if within 3x the floor; DIFFERS otherwise. Without a baseline
-    # we can only fall back to a small absolute mean tolerance.
+    # compile residue). EQUIVALENT if within 3x the floor; DIFFERS otherwise.
     base = report.get("baseline_vs_live") or {}
     floor = base.get("mean_abs")
     cand_mean = report["candidate_vs_live"]["mean_abs"]
     if floor is not None:
         report["noise_floor_mean"] = floor
         report["verdict"] = "EQUIVALENT" if cand_mean <= max(floor * 3.0, 1e-4) else "DIFFERS"
+    elif baseline_dxbc:
+        # A baseline was requested but did not yield a usable floor (build failed or size
+        # mismatch). Do NOT silently fall back to the absolute path — the floor is the whole
+        # point of passing a baseline, so the candidate is unjudged.
+        report["verdict"] = "UNVERIFIED-BASELINE"
     else:
+        # No baseline requested: best-effort absolute tolerance only.
         report["verdict"] = "EQUIVALENT" if cand_mean <= 1e-3 else "DIFFERS"
     restore(eid)
     return report

--- a/tools/taa-renderdoc-ab.py
+++ b/tools/taa-renderdoc-ab.py
@@ -6,7 +6,7 @@
 # inputs (history t1, velocity t2, depth t3, mask t4, alpha t5, cbuffer b2) are frozen from
 # that one frame, A (shipping shader) and B (candidate) run on byte-identical inputs — so a
 # near-zero output diff means equivalent behavior on a real frame, free of the cross-launch
-# and temporal-warmup noise that a two-launch screenshot A/B suffers from.
+# and temporal-warmup noise that a two-launch screenshot A/B suffers.
 #
 # HOW TO RUN: this is executed *inside RenderDoc's embedded Python* via the renderdoc MCP
 # `Eval` tool (the global `ctx` HandlerContext must be in scope). It is NOT a standalone
@@ -20,6 +20,10 @@
 import renderdoc as rd
 import struct
 
+# eid -> (origPS ResourceId, replacement ResourceId). Persists across Eval calls so restore()
+# uses the real objects instead of round-tripping through strings.
+_replacements = {}
+
 
 def _walk(actions):
     for a in actions:
@@ -29,11 +33,15 @@ def _walk(actions):
 
 
 def _desc_res(d):
-    # Descriptor.resource across RenderDoc versions.
     for attr in ("resource", "resourceId"):
         if hasattr(d, attr):
             return getattr(d, attr)
     return rd.ResourceId.Null
+
+
+def _as_resid(x):
+    # GetShader returns a ResourceId on current RenderDoc; guard older (id, reflection) tuples.
+    return x[0] if isinstance(x, tuple) else x
 
 
 def taa_candidates():
@@ -49,14 +57,11 @@ def taa_candidates():
             ps = ctrl.GetPipelineState()
             outs = [o for o in ps.GetOutputTargets() if _desc_res(o) != rd.ResourceId.Null]
             srvs = ps.GetReadOnlyResources(rd.ShaderStage.Pixel)
-            nsrv = sum(1 for s in srvs if _desc_res(s.descriptor if hasattr(s, "descriptor") else s) != rd.ResourceId.Null)
+            nsrv = sum(1 for s in srvs
+                       if _desc_res(s.descriptor if hasattr(s, "descriptor") else s) != rd.ResourceId.Null)
             if len(outs) == 2 and nsrv >= 5:
-                res.append({
-                    "eventId": a.eventId,
-                    "name": a.GetName(sdfile),
-                    "outputs": len(outs),
-                    "srvs": nsrv,
-                })
+                res.append({"eventId": a.eventId, "name": a.GetName(sdfile),
+                            "outputs": len(outs), "srvs": nsrv})
         return res
     return ctx.replay(work)
 
@@ -69,14 +74,11 @@ def _tex_desc(ctrl, rid):
 
 
 def grab_rt(eid, target_index=0):
-    """Return (resourceId, raw_bytes, (width,height,format_name)) for an output RT at an event."""
+    """Return (resourceId_str, raw_bytes, (width, height, format_name)) for an output RT."""
     def work(ctrl):
         ctrl.SetFrameEvent(eid, True)
-        ps = ctrl.GetPipelineState()
-        outs = ps.GetOutputTargets()
-        rid = _desc_res(outs[target_index])
-        sub = rd.Subresource(0, 0, 0)
-        data = bytes(ctrl.GetTextureData(rid, sub))
+        rid = _desc_res(ctrl.GetPipelineState().GetOutputTargets()[target_index])
+        data = bytes(ctrl.GetTextureData(rid, rd.Subresource(0, 0, 0)))
         td = _tex_desc(ctrl, rid)
         meta = (td.width, td.height, str(td.format.Name())) if td else (0, 0, "?")
         return (str(rid), data, meta)
@@ -85,67 +87,94 @@ def grab_rt(eid, target_index=0):
 
 def replace_ps_with_dxbc(eid, dxbc_path, entry="main"):
     """Build a replacement PS from a pre-compiled DXBC file and bind it at the event.
-    Returns (origPSId, newShaderId, errors). Keep origPSId to restore()."""
+    Returns {ok, errors}. On success the (orig, new) ResourceIds are stored for restore(eid)."""
     with open(dxbc_path, "rb") as f:
         blob = f.read()
 
     def work(ctrl):
         ctrl.SetFrameEvent(eid, True)
-        ps = ctrl.GetPipelineState()
-        orig = ps.GetShader(rd.ShaderStage.Pixel)
-        flags = rd.ShaderCompileFlags()
-        newid, errs = ctrl.BuildTargetShader(entry, rd.ShaderEncoding.DXBC, blob, flags, rd.ShaderStage.Pixel)
-        if newid != rd.ResourceId.Null:
+        orig = _as_resid(ctrl.GetPipelineState().GetShader(rd.ShaderStage.Pixel))
+        newid, errs = ctrl.BuildTargetShader(entry, rd.ShaderEncoding.DXBC, blob,
+                                             rd.ShaderCompileFlags(), rd.ShaderStage.Pixel)
+        ok = newid != rd.ResourceId.Null
+        if ok:
             ctrl.ReplaceResource(orig, newid)
             ctrl.SetFrameEvent(eid, True)  # re-replay with replacement bound
-        return (str(orig), str(newid), str(errs))
-    return ctx.replay(work)
+        return ok, orig, newid, str(errs)
+
+    ok, orig, newid, errs = ctx.replay(work)
+    if ok:
+        _replacements[eid] = (orig, newid)
+    return {"ok": ok, "errors": errs}
 
 
-def restore(orig_ps_id_str):
-    """Undo a replacement. Pass the origPSId string returned by replace_ps_with_dxbc.
-    (ResourceId can't round-trip from str, so we re-resolve by matching the current PS.)"""
-    def work(ctrl):
-        # RemoveReplacement needs the original ResourceId; re-resolve from the live shader list.
-        for rid in ctrl.GetResources():
-            if str(rid.resourceId) == orig_ps_id_str:
-                ctrl.RemoveReplacement(rid.resourceId)
-                return True
+def restore(eid):
+    """Undo a replacement made at eid, using the stored ResourceIds."""
+    pair = _replacements.pop(eid, None)
+    if not pair:
         return False
+    orig, newid = pair
+
+    def work(ctrl):
+        ctrl.RemoveReplacement(orig)
+        try:
+            ctrl.FreeTargetResource(newid)
+        except Exception:
+            pass
+        ctrl.SetFrameEvent(eid, True)
+        return True
     return ctx.replay(work)
 
 
 def _diff(a, b, meta):
-    """Byte diff (primary gate) plus float magnitude when the RT is a known float format."""
-    n = min(len(a), len(b))
-    nbytes = sum(1 for i in range(n) if a[i] != b[i]) + abs(len(a) - len(b))
-    out = {"size_a": len(a), "size_b": len(b), "bytes_differing": nbytes,
-           "format": meta[2], "dims": [meta[0], meta[1]]}
-    if nbytes == 0:
+    """Byte-identity fast path + a SAMPLED float-magnitude estimate (no numpy in RenderDoc,
+    and full-res TAA RTs are tens of MB — never materialize the whole thing)."""
+    out = {"size_a": len(a), "size_b": len(b), "format": meta[2], "dims": [meta[0], meta[1]]}
+    if a == b:  # C-level compare — instant
         out["verdict"] = "IDENTICAL"
+        out["bytes_differing"] = 0
         return out
+    if len(a) != len(b):
+        out["verdict"] = "DIFFERS"
+        out["note"] = "size mismatch"
+        return out
+
     fmt = meta[2].lower()
-    maxabs = meanabs = None
-    try:
-        if "16_float" in fmt or "16f" in fmt:  # RGBA16F etc.
-            va = struct.unpack("<%de" % (n // 2), a[:n // 2 * 2])
-            vb = struct.unpack("<%de" % (n // 2), b[:n // 2 * 2])
-            d = [abs(x - y) for x, y in zip(va, vb)]
-            maxabs, meanabs = max(d), sum(d) / len(d)
-        elif "32_float" in fmt or "32f" in fmt:
-            va = struct.unpack("<%df" % (n // 4), a[:n // 4 * 4])
-            vb = struct.unpack("<%df" % (n // 4), b[:n // 4 * 4])
-            d = [abs(x - y) for x, y in zip(va, vb)]
-            maxabs, meanabs = max(d), sum(d) / len(d)
-        else:  # 8-bit UNORM fallback
-            d = [abs(a[i] - b[i]) / 255.0 for i in range(n)]
-            maxabs, meanabs = max(d), sum(d) / len(d)
-    except Exception as e:
-        out["decode_error"] = str(e)
+    if "16_float" in fmt:
+        code, esz = "<e", 2
+    elif "32_float" in fmt:
+        code, esz = "<f", 4
+    else:
+        code, esz = None, 1  # 8-bit UNORM fallback
+
+    n = len(a)
+    total = n // esz
+    stride = max(1, total // 100000)  # cap ~100k samples across the whole image
+    maxabs = 0.0
+    sse = 0.0
+    cnt = 0
+    ndiff = 0
+    for i in range(0, total, stride):
+        off = i * esz
+        if code:
+            x = struct.unpack_from(code, a, off)[0]
+            y = struct.unpack_from(code, b, off)[0]
+            dlt = abs(x - y)
+        else:
+            dlt = abs(a[off] - b[off]) / 255.0
+        if dlt > 0:
+            ndiff += 1
+        if dlt > maxabs:
+            maxabs = dlt
+        sse += dlt
+        cnt += 1
+
+    out["sampled_elems"] = cnt
+    out["sample_frac_differing"] = (ndiff / cnt) if cnt else 0.0
     out["max_abs"] = maxabs
-    out["mean_abs"] = meanabs
-    # Tolerance: tiny residue from FP reassociation is OK; structured artifact is not.
-    out["verdict"] = "EQUIVALENT" if (maxabs is not None and maxabs < 1e-3) else "DIFFERS"
+    out["mean_abs"] = (sse / cnt) if cnt else 0.0
+    # Tiny residue from FP reassociation is OK; a structured artifact is not.
+    out["verdict"] = "EQUIVALENT" if maxabs < 1e-3 else "DIFFERS"
     return out
 
 
@@ -154,22 +183,26 @@ def ab(eid, candidate_dxbc, baseline_dxbc=None, entry="main"):
     - Captures the live output (A_real).
     - If baseline_dxbc given: swap it in and confirm it matches A_real (validates defines/
       permutation + the DXBC-replace path) before trusting the candidate result.
-    - Swaps candidate_dxbc and diffs against A_real. Restores afterward.
-    Returns a dict report."""
+    - Swaps candidate_dxbc and diffs against A_real. Restores after each swap.
+    A failed build is reported as BUILD-FAILED — never a false EQUIVALENT (which would happen
+    if we diffed with the original shader still bound)."""
     rid, a_real, meta = grab_rt(eid)
     report = {"eventId": eid, "rt": rid, "rt_meta": {"dims": [meta[0], meta[1]], "format": meta[2]}}
 
     if baseline_dxbc:
-        orig, newid, errs = replace_ps_with_dxbc(eid, baseline_dxbc, entry)
-        if newid == "ResourceId::0" or "0" == newid:
-            report["baseline_build_error"] = errs
-        _, a_prime, _ = grab_rt(eid)
-        report["baseline_vs_live"] = _diff(a_real, a_prime, meta)
-        restore(orig)
+        r = replace_ps_with_dxbc(eid, baseline_dxbc, entry)
+        if not r["ok"]:
+            report["baseline_vs_live"] = {"verdict": "BUILD-FAILED", "errors": r["errors"]}
+        else:
+            _, a_prime, _ = grab_rt(eid)
+            report["baseline_vs_live"] = _diff(a_real, a_prime, meta)
+            restore(eid)
 
-    orig, newid, errs = replace_ps_with_dxbc(eid, candidate_dxbc, entry)
-    report["candidate_build_errors"] = errs if errs and errs != "" else None
+    r = replace_ps_with_dxbc(eid, candidate_dxbc, entry)
+    if not r["ok"]:
+        report["candidate_vs_live"] = {"verdict": "BUILD-FAILED", "errors": r["errors"]}
+        return report
     _, b, _ = grab_rt(eid)
     report["candidate_vs_live"] = _diff(a_real, b, meta)
-    restore(orig)
+    restore(eid)
     return report

--- a/tools/taa-renderdoc-ab.py
+++ b/tools/taa-renderdoc-ab.py
@@ -19,6 +19,8 @@
 
 import renderdoc as rd
 import struct
+import os
+import math
 
 # eid -> (origPS ResourceId, replacement ResourceId). Persists across Eval calls so restore()
 # uses the real objects instead of round-tripping through strings.
@@ -88,8 +90,15 @@ def grab_rt(eid, target_index=0):
 def replace_ps_with_dxbc(eid, dxbc_path, entry="main"):
     """Build a replacement PS from a pre-compiled DXBC file and bind it at the event.
     Returns {ok, errors}. On success the (orig, new) ResourceIds are stored for restore(eid)."""
-    with open(dxbc_path, "rb") as f:
-        blob = f.read()
+    # Expand %TEMP%/~ and fail soft on a missing file — a raw open() would abort the whole Eval.
+    p = os.path.expandvars(os.path.expanduser(dxbc_path))
+    if not os.path.isfile(p):
+        return {"ok": False, "errors": "DXBC not found: " + p}
+    try:
+        with open(p, "rb") as f:
+            blob = f.read()
+    except OSError as e:
+        return {"ok": False, "errors": "cannot read %s: %r" % (p, e)}
 
     def work(ctrl):
         ctrl.SetFrameEvent(eid, True)
@@ -159,7 +168,14 @@ def _diff(a, b, meta):
         if code:
             x = struct.unpack_from(code, a, off)[0]
             y = struct.unpack_from(code, b, off)[0]
-            dlt = abs(x - y)
+            # NaN-safe: abs(NaN) is NaN and silently fails every comparison below, which would
+            # let a clearly-different output read as EQUIVALENT. Treat NaN-vs-number as a max
+            # difference; both-NaN as equal (identical bits already hit the a == b fast path).
+            xn, yn = math.isnan(x), math.isnan(y)
+            if xn or yn:
+                dlt = 0.0 if (xn and yn) else float("inf")
+            else:
+                dlt = abs(x - y)
         else:
             dlt = abs(a[off] - b[off]) / 255.0
         if dlt > 0:

--- a/tools/taa-renderdoc-ab.py
+++ b/tools/taa-renderdoc-ab.py
@@ -27,6 +27,11 @@ import math
 # your MCP gives a fresh namespace per Eval, do the replace and its restore in the SAME Eval.
 _replacements = {}
 
+# Above this baseline-vs-live mean_abs, the floor is implausible (an honest one is a few LSBs):
+# the baseline diverged from live, so ab() reports UNVERIFIED-BASELINE instead of judging against
+# it. Tune to the observed runtime-vs-fxc residue for your RT format.
+FLOOR_SANITY_LIMIT = 1e-2
+
 
 def _walk(actions):
     for a in actions:
@@ -199,8 +204,15 @@ def _diff(a, b, meta):
         esz, code = 2, "<e"
     elif "32_float" in fmt:
         esz, code = 4, "<f"
-    else:
+    elif "8_unorm" in fmt:
         esz, code = 1, None  # 8-bit UNORM per byte
+    else:
+        # Unknown RT format — refuse to guess. A byte-wise diff on an unhandled packed/sRGB/typeless
+        # format would be meaningless; leave mean_abs None so ab() reports NOT-COMPARABLE rather than
+        # a misleading EQUIVALENT/DIFFERS.
+        out["verdict"] = "NOT-COMPARABLE"
+        out["note"] = "unrecognized format: " + meta[2]
+        return out
 
     n = len(a)
     total = n // esz
@@ -285,7 +297,16 @@ def ab(eid, candidate_dxbc, baseline_dxbc=None, entry="main"):
         report["verdict"] = "NOT-COMPARABLE"
     elif floor is not None:
         report["noise_floor_mean"] = floor
-        report["verdict"] = "EQUIVALENT" if cand_mean <= max(floor * 3.0, 1e-4) else "DIFFERS"
+        if floor > FLOOR_SANITY_LIMIT:
+            # An honest floor is a few LSBs of runtime-vs-fxc residue. A large floor means the
+            # baseline diverged from live — wrong defines/permutation, or a baseline compiled from
+            # the wrong ref (e.g. dev when the refactor is stacked on an unmerged fix). Judging
+            # against it would rubber-stamp almost any candidate EQUIVALENT, so refuse to judge.
+            report["verdict"] = "UNVERIFIED-BASELINE"
+            report["note"] = ("baseline noise floor %.4g exceeds %.4g — verify defines/permutation "
+                              "and that the baseline is the refactor's parent" % (floor, FLOOR_SANITY_LIMIT))
+        else:
+            report["verdict"] = "EQUIVALENT" if cand_mean <= max(floor * 3.0, 1e-4) else "DIFFERS"
     elif baseline_dxbc:
         # A baseline was requested but did not yield a usable floor (build failed or size
         # mismatch). Do NOT silently fall back to the absolute path — the floor is the whole

--- a/tools/taa-renderdoc-ab.py
+++ b/tools/taa-renderdoc-ab.py
@@ -205,9 +205,12 @@ def _diff(a, b, meta):
         elif code:
             x = struct.unpack_from(code, a, off)[0]
             y = struct.unpack_from(code, b, off)[0]
-            # NaN-safe: abs(NaN) silently fails comparisons and could fake EQUIVALENT.
-            xn, yn = math.isnan(x), math.isnan(y)
-            dlt = (0.0 if (xn and yn) else float("inf")) if (xn or yn) else abs(x - y)
+            # NaN/inf-safe: abs(NaN) AND inf-inf both yield NaN, which silently fails every
+            # comparison below and could fake EQUIVALENT. Treat equal values (incl. both-NaN and
+            # both-inf) as 0; any NaN/inf-vs-finite mismatch as a max difference.
+            dlt = abs(x - y)
+            if math.isnan(dlt):
+                dlt = 0.0 if (x == y or (math.isnan(x) and math.isnan(y))) else float("inf")
         else:
             dlt = abs(a[off] - b[off]) / 255.0
         if dlt > 0:
@@ -221,6 +224,7 @@ def _diff(a, b, meta):
     out["sample_frac_differing"] = (ndiff / cnt) if cnt else 0.0
     out["max_abs"] = maxabs
     out["mean_abs"] = (sse / cnt) if cnt else 0.0
+    out["verdict"] = "COMPARED"  # metrics present; ab() assigns the final baseline-relative verdict
     return out
 
 

--- a/tools/taa-renderdoc-ab.py
+++ b/tools/taa-renderdoc-ab.py
@@ -52,15 +52,24 @@ def _as_resid(x):
 _TAA_TEX = {"currentframetex", "historytex", "velocitytex", "depthtex", "masktex", "alphatex"}
 
 
-def taa_candidates():
+def taa_candidates(reverse=False, max_scan_drawcalls=0, stop_after=0):
     """Find ISTemporalAA draws by their pixel-shader SRV fingerprint (t0..t5). Returns
-    [{eventId, name}]; pass the eventId to ab()."""
+    [{eventId, name}]; pass the eventId to ab().
+
+    A full forward scan calls SetFrameEvent() once per drawcall, which can time out the replay
+    worker on a multi-GB capture. The TAA pass is post-process (near frame end), so on a huge
+    frame pass reverse=True to scan from the end and/or max_scan_drawcalls=N to cap how many
+    drawcalls are probed; stop_after=N returns as soon as N matches are found. Defaults keep the
+    exhaustive forward scan."""
     def work(ctrl):
         sdfile = ctrl.GetStructuredFile()
+        draws = [a for a in _walk(ctrl.GetRootActions()) if (a.flags & rd.ActionFlags.Drawcall)]
+        if reverse:
+            draws = draws[::-1]
+        if max_scan_drawcalls > 0:
+            draws = draws[:max_scan_drawcalls]
         res = []
-        for a in _walk(ctrl.GetRootActions()):
-            if not (a.flags & rd.ActionFlags.Drawcall):
-                continue
+        for a in draws:
             ctrl.SetFrameEvent(a.eventId, True)
             refl = ctrl.GetPipelineState().GetShaderReflection(rd.ShaderStage.Pixel)
             if not refl:
@@ -68,6 +77,8 @@ def taa_candidates():
             names = {r.name.lower() for r in refl.readOnlyResources}
             if _TAA_TEX.issubset(names):
                 res.append({"eventId": a.eventId, "name": a.GetName(sdfile)})
+                if stop_after > 0 and len(res) >= stop_after:
+                    break
         return res
     return ctx.replay(work)
 

--- a/tools/taa-renderdoc-ab.py
+++ b/tools/taa-renderdoc-ab.py
@@ -1,0 +1,175 @@
+# taa-renderdoc-ab.py — Tier-3 runtime A/B check for TAA shader refactors.
+#
+# Purpose: prove a behavior-preserving claim that bytecode-identity CANNOT (Standard B,
+# where fxc legitimately emits different-but-equivalent code). It swaps the ISTemporalAA
+# pixel shader on a SINGLE captured frame and diffs the output render target. Because the
+# inputs (history t1, velocity t2, depth t3, mask t4, alpha t5, cbuffer b2) are frozen from
+# that one frame, A (shipping shader) and B (candidate) run on byte-identical inputs — so a
+# near-zero output diff means equivalent behavior on a real frame, free of the cross-launch
+# and temporal-warmup noise that a two-launch screenshot A/B suffers from.
+#
+# HOW TO RUN: this is executed *inside RenderDoc's embedded Python* via the renderdoc MCP
+# `Eval` tool (the global `ctx` HandlerContext must be in scope). It is NOT a standalone
+# script. See docs/development/taa-runtime-ab.md for the full operator runbook.
+#
+# Candidate B (and a baseline A') are supplied as pre-compiled DXBC built with fxc using the
+# SAME defines/permutation as the captured build (e.g. PSHADER VR [HDR_OUTPUT]) and with
+# /I package/Shaders so includes resolve — identical to tools/verify-shader-refactor.ps1.
+# Feeding DXBC (ShaderEncoding.DXBC) avoids RenderDoc's HLSL include/define handling.
+
+import renderdoc as rd
+import struct
+
+
+def _walk(actions):
+    for a in actions:
+        yield a
+        for c in _walk(a.children):
+            yield c
+
+
+def _desc_res(d):
+    # Descriptor.resource across RenderDoc versions.
+    for attr in ("resource", "resourceId"):
+        if hasattr(d, attr):
+            return getattr(d, attr)
+    return rd.ResourceId.Null
+
+
+def taa_candidates():
+    """List draws that look like ISTemporalAA: 2 colour outputs (Color+Feedback) and
+    >=5 pixel-stage SRVs (t0..t5). Operator confirms the eventId before swapping."""
+    def work(ctrl):
+        sdfile = ctrl.GetStructuredFile()
+        res = []
+        for a in _walk(ctrl.GetRootActions()):
+            if not (a.flags & rd.ActionFlags.Drawcall):
+                continue
+            ctrl.SetFrameEvent(a.eventId, True)
+            ps = ctrl.GetPipelineState()
+            outs = [o for o in ps.GetOutputTargets() if _desc_res(o) != rd.ResourceId.Null]
+            srvs = ps.GetReadOnlyResources(rd.ShaderStage.Pixel)
+            nsrv = sum(1 for s in srvs if _desc_res(s.descriptor if hasattr(s, "descriptor") else s) != rd.ResourceId.Null)
+            if len(outs) == 2 and nsrv >= 5:
+                res.append({
+                    "eventId": a.eventId,
+                    "name": a.GetName(sdfile),
+                    "outputs": len(outs),
+                    "srvs": nsrv,
+                })
+        return res
+    return ctx.replay(work)
+
+
+def _tex_desc(ctrl, rid):
+    for t in ctrl.GetTextures():
+        if t.resourceId == rid:
+            return t
+    return None
+
+
+def grab_rt(eid, target_index=0):
+    """Return (resourceId, raw_bytes, (width,height,format_name)) for an output RT at an event."""
+    def work(ctrl):
+        ctrl.SetFrameEvent(eid, True)
+        ps = ctrl.GetPipelineState()
+        outs = ps.GetOutputTargets()
+        rid = _desc_res(outs[target_index])
+        sub = rd.Subresource(0, 0, 0)
+        data = bytes(ctrl.GetTextureData(rid, sub))
+        td = _tex_desc(ctrl, rid)
+        meta = (td.width, td.height, str(td.format.Name())) if td else (0, 0, "?")
+        return (str(rid), data, meta)
+    return ctx.replay(work)
+
+
+def replace_ps_with_dxbc(eid, dxbc_path, entry="main"):
+    """Build a replacement PS from a pre-compiled DXBC file and bind it at the event.
+    Returns (origPSId, newShaderId, errors). Keep origPSId to restore()."""
+    with open(dxbc_path, "rb") as f:
+        blob = f.read()
+
+    def work(ctrl):
+        ctrl.SetFrameEvent(eid, True)
+        ps = ctrl.GetPipelineState()
+        orig = ps.GetShader(rd.ShaderStage.Pixel)
+        flags = rd.ShaderCompileFlags()
+        newid, errs = ctrl.BuildTargetShader(entry, rd.ShaderEncoding.DXBC, blob, flags, rd.ShaderStage.Pixel)
+        if newid != rd.ResourceId.Null:
+            ctrl.ReplaceResource(orig, newid)
+            ctrl.SetFrameEvent(eid, True)  # re-replay with replacement bound
+        return (str(orig), str(newid), str(errs))
+    return ctx.replay(work)
+
+
+def restore(orig_ps_id_str):
+    """Undo a replacement. Pass the origPSId string returned by replace_ps_with_dxbc.
+    (ResourceId can't round-trip from str, so we re-resolve by matching the current PS.)"""
+    def work(ctrl):
+        # RemoveReplacement needs the original ResourceId; re-resolve from the live shader list.
+        for rid in ctrl.GetResources():
+            if str(rid.resourceId) == orig_ps_id_str:
+                ctrl.RemoveReplacement(rid.resourceId)
+                return True
+        return False
+    return ctx.replay(work)
+
+
+def _diff(a, b, meta):
+    """Byte diff (primary gate) plus float magnitude when the RT is a known float format."""
+    n = min(len(a), len(b))
+    nbytes = sum(1 for i in range(n) if a[i] != b[i]) + abs(len(a) - len(b))
+    out = {"size_a": len(a), "size_b": len(b), "bytes_differing": nbytes,
+           "format": meta[2], "dims": [meta[0], meta[1]]}
+    if nbytes == 0:
+        out["verdict"] = "IDENTICAL"
+        return out
+    fmt = meta[2].lower()
+    maxabs = meanabs = None
+    try:
+        if "16_float" in fmt or "16f" in fmt:  # RGBA16F etc.
+            va = struct.unpack("<%de" % (n // 2), a[:n // 2 * 2])
+            vb = struct.unpack("<%de" % (n // 2), b[:n // 2 * 2])
+            d = [abs(x - y) for x, y in zip(va, vb)]
+            maxabs, meanabs = max(d), sum(d) / len(d)
+        elif "32_float" in fmt or "32f" in fmt:
+            va = struct.unpack("<%df" % (n // 4), a[:n // 4 * 4])
+            vb = struct.unpack("<%df" % (n // 4), b[:n // 4 * 4])
+            d = [abs(x - y) for x, y in zip(va, vb)]
+            maxabs, meanabs = max(d), sum(d) / len(d)
+        else:  # 8-bit UNORM fallback
+            d = [abs(a[i] - b[i]) / 255.0 for i in range(n)]
+            maxabs, meanabs = max(d), sum(d) / len(d)
+    except Exception as e:
+        out["decode_error"] = str(e)
+    out["max_abs"] = maxabs
+    out["mean_abs"] = meanabs
+    # Tolerance: tiny residue from FP reassociation is OK; structured artifact is not.
+    out["verdict"] = "EQUIVALENT" if (maxabs is not None and maxabs < 1e-3) else "DIFFERS"
+    return out
+
+
+def ab(eid, candidate_dxbc, baseline_dxbc=None, entry="main"):
+    """Full A/B on one event.
+    - Captures the live output (A_real).
+    - If baseline_dxbc given: swap it in and confirm it matches A_real (validates defines/
+      permutation + the DXBC-replace path) before trusting the candidate result.
+    - Swaps candidate_dxbc and diffs against A_real. Restores afterward.
+    Returns a dict report."""
+    rid, a_real, meta = grab_rt(eid)
+    report = {"eventId": eid, "rt": rid, "rt_meta": {"dims": [meta[0], meta[1]], "format": meta[2]}}
+
+    if baseline_dxbc:
+        orig, newid, errs = replace_ps_with_dxbc(eid, baseline_dxbc, entry)
+        if newid == "ResourceId::0" or "0" == newid:
+            report["baseline_build_error"] = errs
+        _, a_prime, _ = grab_rt(eid)
+        report["baseline_vs_live"] = _diff(a_real, a_prime, meta)
+        restore(orig)
+
+    orig, newid, errs = replace_ps_with_dxbc(eid, candidate_dxbc, entry)
+    report["candidate_build_errors"] = errs if errs and errs != "" else None
+    _, b, _ = grab_rt(eid)
+    report["candidate_vs_live"] = _diff(a_real, b, meta)
+    restore(orig)
+    return report

--- a/tools/taa-renderdoc-ab.py
+++ b/tools/taa-renderdoc-ab.py
@@ -46,9 +46,15 @@ def _as_resid(x):
     return x[0] if isinstance(x, tuple) else x
 
 
+# ISTemporalAA's pixel shader binds exactly these t0..t5 textures — a reliable fingerprint.
+# (Output-slot counting is unreliable: D3D11 returns 8 RTV slots and empty ones read as
+# "ResourceId::0", which does NOT compare equal to rd.ResourceId.Null.)
+_TAA_TEX = {"currentframetex", "historytex", "velocitytex", "depthtex", "masktex", "alphatex"}
+
+
 def taa_candidates():
-    """List draws that look like ISTemporalAA: 2 colour outputs (Color+Feedback) and
-    >=5 pixel-stage SRVs (t0..t5). Operator confirms the eventId before swapping."""
+    """Find ISTemporalAA draws by their pixel-shader SRV fingerprint (t0..t5). Returns
+    [{eventId, name}]; pass the eventId to ab()."""
     def work(ctrl):
         sdfile = ctrl.GetStructuredFile()
         res = []
@@ -56,14 +62,12 @@ def taa_candidates():
             if not (a.flags & rd.ActionFlags.Drawcall):
                 continue
             ctrl.SetFrameEvent(a.eventId, True)
-            ps = ctrl.GetPipelineState()
-            outs = [o for o in ps.GetOutputTargets() if _desc_res(o) != rd.ResourceId.Null]
-            srvs = ps.GetReadOnlyResources(rd.ShaderStage.Pixel)
-            nsrv = sum(1 for s in srvs
-                       if _desc_res(s.descriptor if hasattr(s, "descriptor") else s) != rd.ResourceId.Null)
-            if len(outs) == 2 and nsrv >= 5:
-                res.append({"eventId": a.eventId, "name": a.GetName(sdfile),
-                            "outputs": len(outs), "srvs": nsrv})
+            refl = ctrl.GetPipelineState().GetShaderReflection(rd.ShaderStage.Pixel)
+            if not refl:
+                continue
+            names = {r.name.lower() for r in refl.readOnlyResources}
+            if _TAA_TEX.issubset(names):
+                res.append({"eventId": a.eventId, "name": a.GetName(sdfile)})
         return res
     return ctx.replay(work)
 
@@ -148,34 +152,40 @@ def _diff(a, b, meta):
         out["note"] = "size mismatch"
         return out
 
+    # Decode to normalized [0,1] channel values. Packed formats (R10G10B10A2) MUST be unpacked
+    # by channel, not byte — a 1-LSB 10-bit delta spans byte boundaries and a byte-diff hugely
+    # overstates it. No verdict here: ab() judges relative to the baseline noise floor, because
+    # the game's runtime compile differs from offline fxc by a few LSBs even for an identical
+    # shader (that residue is the floor, not a behavior change).
     fmt = meta[2].lower()
-    if "16_float" in fmt:
-        code, esz = "<e", 2
+    packed = "10g10b10a2" in fmt
+    if packed:
+        esz, code = 4, None
+    elif "16_float" in fmt:
+        esz, code = 2, "<e"
     elif "32_float" in fmt:
-        code, esz = "<f", 4
+        esz, code = 4, "<f"
     else:
-        code, esz = None, 1  # 8-bit UNORM fallback
+        esz, code = 1, None  # 8-bit UNORM per byte
 
     n = len(a)
     total = n // esz
-    stride = max(1, total // 100000)  # cap ~100k samples across the whole image
-    maxabs = 0.0
-    sse = 0.0
-    cnt = 0
-    ndiff = 0
+    stride = max(1, total // 100000)  # cap ~100k samples across the image
+    maxabs = sse = 0.0
+    cnt = ndiff = 0
+    A2 = ((0, 1023, 1023.0), (10, 1023, 1023.0), (20, 1023, 1023.0), (30, 3, 3.0))
     for i in range(0, total, stride):
         off = i * esz
-        if code:
+        if packed:
+            px = struct.unpack_from("<I", a, off)[0]
+            py = struct.unpack_from("<I", b, off)[0]
+            dlt = max(abs(((px >> s) & m) / d - ((py >> s) & m) / d) for (s, m, d) in A2)
+        elif code:
             x = struct.unpack_from(code, a, off)[0]
             y = struct.unpack_from(code, b, off)[0]
-            # NaN-safe: abs(NaN) is NaN and silently fails every comparison below, which would
-            # let a clearly-different output read as EQUIVALENT. Treat NaN-vs-number as a max
-            # difference; both-NaN as equal (identical bits already hit the a == b fast path).
+            # NaN-safe: abs(NaN) silently fails comparisons and could fake EQUIVALENT.
             xn, yn = math.isnan(x), math.isnan(y)
-            if xn or yn:
-                dlt = 0.0 if (xn and yn) else float("inf")
-            else:
-                dlt = abs(x - y)
+            dlt = (0.0 if (xn and yn) else float("inf")) if (xn or yn) else abs(x - y)
         else:
             dlt = abs(a[off] - b[off]) / 255.0
         if dlt > 0:
@@ -189,8 +199,6 @@ def _diff(a, b, meta):
     out["sample_frac_differing"] = (ndiff / cnt) if cnt else 0.0
     out["max_abs"] = maxabs
     out["mean_abs"] = (sse / cnt) if cnt else 0.0
-    # Tiny residue from FP reassociation is OK; a structured artifact is not.
-    out["verdict"] = "EQUIVALENT" if maxabs < 1e-3 else "DIFFERS"
     return out
 
 
@@ -217,8 +225,21 @@ def ab(eid, candidate_dxbc, baseline_dxbc=None, entry="main"):
     r = replace_ps_with_dxbc(eid, candidate_dxbc, entry)
     if not r["ok"]:
         report["candidate_vs_live"] = {"verdict": "BUILD-FAILED", "errors": r["errors"]}
+        report["verdict"] = "BUILD-FAILED"
         return report
     _, b, _ = grab_rt(eid)
     report["candidate_vs_live"] = _diff(a_real, b, meta)
+
+    # Verdict: judge the candidate's mean_abs against the baseline noise floor (runtime-vs-fxc
+    # compile residue). EQUIVALENT if within 3x the floor; DIFFERS otherwise. Without a baseline
+    # we can only fall back to a small absolute mean tolerance.
+    base = report.get("baseline_vs_live") or {}
+    floor = base.get("mean_abs")
+    cand_mean = report["candidate_vs_live"]["mean_abs"]
+    if floor is not None:
+        report["noise_floor_mean"] = floor
+        report["verdict"] = "EQUIVALENT" if cand_mean <= max(floor * 3.0, 1e-4) else "DIFFERS"
+    else:
+        report["verdict"] = "EQUIVALENT" if cand_mean <= 1e-3 else "DIFFERS"
     restore(eid)
     return report

--- a/tools/taa-renderdoc-ab.py
+++ b/tools/taa-renderdoc-ab.py
@@ -83,7 +83,14 @@ def grab_rt(eid, target_index=0):
     """Return (resourceId_str, raw_bytes, (width, height, format_name)) for an output RT."""
     def work(ctrl):
         ctrl.SetFrameEvent(eid, True)
-        rid = _desc_res(ctrl.GetPipelineState().GetOutputTargets()[target_index])
+        outs = ctrl.GetPipelineState().GetOutputTargets()
+        # Fail soft on an out-of-range or empty (ResourceId::0) slot rather than letting
+        # GetTextureData raise and abort the whole Eval session.
+        if target_index >= len(outs):
+            return (None, b"", (0, 0, "none"))
+        rid = _desc_res(outs[target_index])
+        if str(rid) == "ResourceId::0":
+            return (str(rid), b"", (0, 0, "none"))
         data = bytes(ctrl.GetTextureData(rid, rd.Subresource(0, 0, 0)))
         td = _tex_desc(ctrl, rid)
         meta = (td.width, td.height, str(td.format.Name())) if td else (0, 0, "?")
@@ -157,11 +164,13 @@ def _diff(a, b, meta):
         out["note"] = "size mismatch"
         return out
 
-    # Decode to normalized [0,1] channel values. Packed formats (R10G10B10A2) MUST be unpacked
-    # by channel, not byte — a 1-LSB 10-bit delta spans byte boundaries and a byte-diff hugely
-    # overstates it. No verdict here: ab() judges relative to the baseline noise floor, because
-    # the game's runtime compile differs from offline fxc by a few LSBs even for an identical
-    # shader (that residue is the floor, not a behavior change).
+    # Per-sample delta units by format: UNORM8 and packed R10G10B10A2 are normalized to [0,1]
+    # (the packed format MUST be unpacked by channel, not byte — a 1-LSB 10-bit delta spans byte
+    # boundaries and a byte-diff hugely overstates it); float16/float32 are compared in their
+    # native units (abs(x-y)). mean_abs is therefore only comparable within one format, which is
+    # fine here since baseline and candidate always share the live RT's format. No verdict here:
+    # ab() judges relative to the baseline noise floor, because the game's runtime compile differs
+    # from offline fxc by a few LSBs even for an identical shader (that residue is the floor).
     fmt = meta[2].lower()
     packed = "10g10b10a2" in fmt
     if packed:
@@ -223,17 +232,24 @@ def ab(eid, candidate_dxbc, baseline_dxbc=None, entry="main"):
         if not r["ok"]:
             report["baseline_vs_live"] = {"verdict": "BUILD-FAILED", "errors": r["errors"]}
         else:
-            _, a_prime, _ = grab_rt(eid)
-            report["baseline_vs_live"] = _diff(a_real, a_prime, meta)
-            restore(eid)
+            # finally: guarantee the replacement is undone even if grab/diff raises, so a stale
+            # shader can't contaminate later replays.
+            try:
+                _, a_prime, _ = grab_rt(eid)
+                report["baseline_vs_live"] = _diff(a_real, a_prime, meta)
+            finally:
+                restore(eid)
 
     r = replace_ps_with_dxbc(eid, candidate_dxbc, entry)
     if not r["ok"]:
         report["candidate_vs_live"] = {"verdict": "BUILD-FAILED", "errors": r["errors"]}
         report["verdict"] = "BUILD-FAILED"
         return report
-    _, b, _ = grab_rt(eid)
-    report["candidate_vs_live"] = _diff(a_real, b, meta)
+    try:
+        _, b, _ = grab_rt(eid)
+        report["candidate_vs_live"] = _diff(a_real, b, meta)
+    finally:
+        restore(eid)
 
     # Verdict: judge the candidate's mean_abs against the baseline noise floor (runtime-vs-fxc
     # compile residue). EQUIVALENT if within 3x the floor; DIFFERS otherwise.
@@ -251,5 +267,4 @@ def ab(eid, candidate_dxbc, baseline_dxbc=None, entry="main"):
     else:
         # No baseline requested: best-effort absolute tolerance only.
         report["verdict"] = "EQUIVALENT" if cand_mean <= 1e-3 else "DIFFERS"
-    restore(eid)
     return report

--- a/tools/taa-renderdoc-ab.py
+++ b/tools/taa-renderdoc-ab.py
@@ -193,7 +193,7 @@ def _diff(a, b, meta):
     n = len(a)
     total = n // esz
     stride = max(1, total // 100000)  # cap ~100k samples across the image
-    maxabs = sse = 0.0
+    maxabs = absSum = 0.0  # absSum = sum of |Δ| (L1), not squared error — mean_abs = absSum/cnt
     cnt = ndiff = 0
     A2 = ((0, 1023, 1023.0), (10, 1023, 1023.0), (20, 1023, 1023.0), (30, 3, 3.0))
     for i in range(0, total, stride):
@@ -217,13 +217,13 @@ def _diff(a, b, meta):
             ndiff += 1
         if dlt > maxabs:
             maxabs = dlt
-        sse += dlt
+        absSum += dlt
         cnt += 1
 
     out["sampled_elems"] = cnt
     out["sample_frac_differing"] = (ndiff / cnt) if cnt else 0.0
     out["max_abs"] = maxabs
-    out["mean_abs"] = (sse / cnt) if cnt else 0.0
+    out["mean_abs"] = (absSum / cnt) if cnt else 0.0
     out["verdict"] = "COMPARED"  # metrics present; ab() assigns the final baseline-relative verdict
     return out
 


### PR DESCRIPTION
A same-frame, GPU-level equivalence check for TAA shader refactors whose **bytecode legitimately diverges** — i.e. the Standard B restructure of the bracket/flicker/blend core, where `tools/verify-shader-refactor.ps1` (byte-identity) no longer applies.

## How it works
Capture **one** real frame in RenderDoc, then replace just the `ISTemporalAA` pixel shader on that captured frame and diff the output RT. The TAA inputs (history `t1`, velocity `t2`, depth `t3`, mask `t4`, alpha `t5`, cbuffer `b2`) are frozen, so A (shipping) and B (candidate) run on **byte-identical inputs** — a near-zero output diff = equivalent behavior on a real frame. This is the runtime analog of the offline verifier, tolerant of the bytecode divergence Standard B implies, and free of the cross-launch / temporal-warmup noise a two-launch screenshot A/B suffers.

Candidate B (and a baseline A') are fed as **fxc-built DXBC** with the build's defines and `/I package/Shaders` (same compile path as the offline verifier), so RenderDoc's HLSL include/define handling is bypassed.

## Files
- `tools/taa-renderdoc-ab.py` — runs in RenderDoc's embedded Python via the `renderdoc` MCP `Eval`: finds the TAA draw (`taa_candidates()`), swaps the PS from a DXBC file (`BuildTargetShader`/`ReplaceResource`), reads the output RT before/after and reports a byte + float-magnitude diff, then restores.
- `docs/development/taa-runtime-ab.md` — operator runbook (compile → capture → run → interpret).

## Validation
Harness **compiles in RenderDoc's interpreter** and every API call it uses (`BuildTargetShader`, `ReplaceResource`, `GetTextureData`, `GetOutputTargets`, `Subresource`, `ShaderCompileFlags`, `ResourceFormat.Name`) is confirmed present in the live session. A full replay run is pending a game capture (devbench MCP / manual launch).

Complements #86 (offline byte-identity verifier): #86 formally covers the identical parts, this covers the diverging core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated shader refactor guidance with A/B validation workflow instructions.
  * Added comprehensive guide for runtime GPU shader equivalence validation, including prerequisites and step-by-step procedures.

* **New Features**
  * Added validation tool for single-frame shader A/B comparison with baseline establishment and diagnostic verdicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->