### PR TITLE
ci: roll dev-latest tag to dev-HEAD on each publish

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -162,6 +162,23 @@ jobs:
                   } > "${FILE}"
                   echo "body-file=${FILE}" >> "$GITHUB_OUTPUT"
 
+            # Force-roll the rolling tag to the built commit BEFORE publishing.
+            # ncipollo honors `commit:` only when it *creates* a tag — on an
+            # update (allowUpdates) it leaves an existing tag pinned to its
+            # original commit. Without this, dev-latest froze at the commit where
+            # this workflow first published (the tag, release "target", and
+            # checkout source all stuck days behind dev while only the body/asset
+            # advanced). Move the ref ourselves so the release tracks dev-HEAD.
+            - name: Roll dev-latest tag to the built commit
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euo pipefail
+                  ref="repos/${{ github.repository }}/git/refs/tags/dev-latest"
+                  gh api -X PATCH "$ref" -f sha="${{ github.sha }}" -F force=true \
+                    || gh api -X POST "repos/${{ github.repository }}/git/refs" \
+                         -f ref="refs/tags/dev-latest" -f sha="${{ github.sha }}"
+
             - name: Refresh dev-latest prerelease
               uses: ./.github/actions/publish-release
               with:
@@ -169,7 +186,8 @@ jobs:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   # Non-semver tag: dodges maint-cleanup and the dev branch name.
                   tag: dev-latest
-                  # Point the rolling tag at the built commit (matches the body).
+                  # First-publish only (ncipollo ignores this on update); the
+                  # Roll step above keeps the existing tag tracking dev-HEAD.
                   commit: ${{ github.sha }}
                   name: "Open Shaders (dev) — latest build ${{ needs.build.outputs.version }}"
                   prerelease: "true"


### PR DESCRIPTION
## Problem

The dev nightly **is** running and succeeding daily — but the `dev-latest` rolling prerelease *looks* frozen. Three references that should be one commit had drifted:

| Reference | Commit | |
|---|---|---|
| `dev` HEAD | `dc88209` | Jun 2 |
| release **body** ("built at") | `cac323d9` (#79) | Jun 2 |
| `dev-latest` **tag** → | `1e8fda46` (#58) | **May 28** |

The tag was pinned to the commit where this workflow *first* published, ~6 days stale. So the release's target commit and `git checkout dev-latest` source were stale, and the page read as "nightlies stopped" even though the attached `.7z` was current.

## Root cause

[`publish-release`](.github/actions/publish-release/action.yaml) uses `ncipollo/release-action` with `allowUpdates: true` and passes `commit:`. ncipollo honors `commit` **only when creating** a tag — on update it never moves an existing ref. The tag pinned to its creation commit forever.

## Fix

Add a step in `release-dev.yaml`'s `prerelease` job that force-rolls the `dev-latest` ref to `github.sha` **before** the ncipollo publish (creating it on first run). The job already has `contents: write`.

Scoped to `release-dev` only — the shared `publish-release` action and its immutable semver release tags are untouched.

## Verification

YAML lints clean (pre-commit). Effect is observable on the next publish: `dev-latest` tag will equal dev-HEAD, matching the body/asset. No mod/runtime code touched (`ci:` → no release).