### PR TITLE
fix(upscaling): auto-disable foveated DLSS

### DIFF
--- a/src/Features/Upscaling/FoveatedRender.cpp
+++ b/src/Features/Upscaling/FoveatedRender.cpp
@@ -105,13 +105,10 @@ void FoveatedRender::ClampSettings()
 
 bool FoveatedRender::IsActive() const
 {
-	// Activity requires DLSS to be the *selected* upscaler, not merely available.
-	// IsRuntimeSupported() (availability) only gates the Enable checkbox; if we
-	// keyed activity off it too, foveation — and its SSR consumer — would run
-	// while the user has TAA/FSR/None selected. It also fails closed under
-	// RenderDoc, whose DX12-interop swapchain disables DLSS: GetUpscaleMethod()
-	// then returns a non-DLSS method, so the route stands down instead of
-	// dereferencing uninitialised DLSS resources.
+	// Gate on DLSS being the *selected* method, not just available
+	// (IsRuntimeSupported): otherwise foveation and its SSR consumer run under
+	// TAA/FSR/None and the route derefs unallocated DLSS resources — the crash
+	// seen under RenderDoc, whose DX12 swapchain disables DLSS.
 	return enabledAtBoot && IsRuntimeSupported() &&
 	       globals::features::upscaling.GetUpscaleMethod() == Upscaling::UpscaleMethod::kDLSS;
 }
@@ -199,9 +196,9 @@ void FoveatedRender::DrawEnable()
 
 	if (enabledAtBoot) {
 		if (globals::features::upscaling.GetUpscaleMethod() == Upscaling::UpscaleMethod::kDLSS)
-			Util::Text::WrappedInfo("Active: foveated subrect DLSS is running.");
+			Util::Text::WrappedInfo("Active: foveated subrect DLSS is enabled (skipped in menus / on preflight failure).");
 		else
-			Util::Text::Warning("Standing by: only runs while the Upscaling Method is DLSS. Inactive right now.");
+			Util::Text::Warning("Standing by: only active while the Upscaling Method is DLSS. Inactive right now.");
 	}
 
 	if (!globals::game::isVR) {

--- a/src/Features/Upscaling/FoveatedRender.cpp
+++ b/src/Features/Upscaling/FoveatedRender.cpp
@@ -105,7 +105,15 @@ void FoveatedRender::ClampSettings()
 
 bool FoveatedRender::IsActive() const
 {
-	return enabledAtBoot && IsRuntimeSupported();
+	// Activity requires DLSS to be the *selected* upscaler, not merely available.
+	// IsRuntimeSupported() (availability) only gates the Enable checkbox; if we
+	// keyed activity off it too, foveation — and its SSR consumer — would run
+	// while the user has TAA/FSR/None selected. It also fails closed under
+	// RenderDoc, whose DX12-interop swapchain disables DLSS: GetUpscaleMethod()
+	// then returns a non-DLSS method, so the route stands down instead of
+	// dereferencing uninitialised DLSS resources.
+	return enabledAtBoot && IsRuntimeSupported() &&
+	       globals::features::upscaling.GetUpscaleMethod() == Upscaling::UpscaleMethod::kDLSS;
 }
 
 bool FoveatedRender::IsRuntimeSupported() const
@@ -190,7 +198,10 @@ void FoveatedRender::DrawEnable()
 	}
 
 	if (enabledAtBoot) {
-		Util::Text::WrappedInfo("Active: upscaling is forced to DLSS while enabled.");
+		if (globals::features::upscaling.GetUpscaleMethod() == Upscaling::UpscaleMethod::kDLSS)
+			Util::Text::WrappedInfo("Active: foveated subrect DLSS is running.");
+		else
+			Util::Text::Warning("Standing by: only runs while the Upscaling Method is DLSS. Inactive right now.");
 	}
 
 	if (!globals::game::isVR) {

--- a/src/Features/Upscaling/FoveatedRender/Bridge.cpp
+++ b/src/Features/Upscaling/FoveatedRender/Bridge.cpp
@@ -6,9 +6,8 @@
 
 bool FoveatedRenderImpl::Bridge::IsRouteActive()
 {
-	// IsActive() already checks: globals::game::isVR
-	//                            && globals::features::upscaling.streamline.featureDLSS
-	//                            && enabledAtBoot
+	// IsActive() already checks: enabledAtBoot && isVR && featureDLSS
+	//                            && GetUpscaleMethod() == kDLSS (selected, not just available)
 	return globals::features::upscaling.foveatedRender.IsActive();
 }
 


### PR DESCRIPTION
## Problem

Disabling DLSS (selecting FSR/TAA/None) left **foveated DLSS still
active**, and using RenderDoc with FSR selected caused a crash in
`Upscaling::Upscale()` (null deref, `mov rax,[rax+0x30]`, `rax=0`).

## Root cause

Foveated subrect DLSS keyed its *activity* off DLSS **availability**, not
**selection**:

| Predicate | Before | Problem |
|---|---|---|
| `IsRuntimeSupported()` | `isVR && featureDLSS` | true whenever the DLSS runtime is loaded |
| `IsActive()` | `enabledAtBoot && IsRuntimeSupported()` | stayed active with TAA/FSR/None selected |

`IsActive()` feeds `Bridge::IsRouteActive()`, the motion-vector scaling,
and the SSR foveation consumer (`State.cpp`). So with the DLSS runtime
loaded but **FSR selected**:

- SSR foveation ran in foveated mode while the actual upscaler was FSR
  (the "foveated rendering still enabled" the report describes).
- The foveated DLSS route could execute under FSR and dereference
  `motionVectorCopyTexture`, which `CreateUpscalingTextureResources` only
  allocates for **DLSS** (never FSR) — null texture → crash. RenderDoc
  made it reliable because its DX12-interop swapchain disables DLSS.

## Fix

- `IsActive()` now additionally requires `GetUpscaleMethod() == kDLSS`, so
  foveation (and its SSR consumer) stands down whenever DLSS is not the
  live method, and fails closed under RenderDoc.
- `IsRuntimeSupported()` (availability) still gates only the Enable
  checkbox — unchanged.
- `DrawEnable()` status text no longer falsely claims upscaling is
  "forced to DLSS"; it now reports whether the route is actually running
  vs. standing by.

C++-only change; two files, +15/-5.

## Testing

- Builds clean (`BuildRelease.bat ALL-WITH-AUTO-DEPLOYMENT`); plugin DLL
  deployed to SE + VR `Data/SKSE/Plugins`.
- In-VR verification (FSR selected → foveation inactive; no RenderDoc
  crash) pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
