### PR TITLE
refactor(TAA): restructure ISTemporalAA into readable code

### DIFF
--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -380,18 +380,15 @@ PS_OUTPUT main(PS_INPUT input)
 	lowClamp = belowHistCentre ? lowClamp : kMinLumaCap.xxx;
 	tapC1.xyz = MergeMaxBracket(tapC1, lowClamp, belowHistC1);
 
-	// --- flicker contributions, one per neighbourhood tap ---
-	// Lifted out of the colour sort below: each reads a tap's ORIGINAL .w luma, and the sort only
-	// mutates .w/.yzw after that read, so hoisting them here is behavior-preserving. (In the vanilla
-	// decompile these were stashed into the taps' .x belowHist slots once those gates were spent.)
-	float fcC1 = FlickerLumaContribution(centerLuma, tapC1.w);
-	float fcC0 = FlickerLumaContribution(centerLuma, tapC0.w);
-	float fcB1 = FlickerLumaContribution(centerLuma, tapB1.w);
-	float fcB0 = FlickerLumaContribution(centerLuma, tapB0.w);
-	float fcA1 = FlickerLumaContribution(centerLuma, tapA1.w);
-	float fcA0 = FlickerLumaContribution(centerLuma, tapA0.w);
-	float fcMin = FlickerLumaContribution(centerLuma, tapMin.w);
-	float fcCorner = FlickerLumaContribution(centerLuma, corner.w);
+	// --- flicker score: 4 minus one integer contribution per neighbourhood tap ---
+	// Each contribution reads a tap's ORIGINAL .w luma; the colour sort below only mutates .w/.yzw
+	// after this, so computing them here is behaviour-preserving. The sum is order-independent (each
+	// contribution is a ceil() integer); tap order matches the original 8-term sum.
+	const float4 flickerTaps[8] = { corner, tapMin, tapA0, tapA1, tapB0, tapB1, tapC0, tapC1 };
+	float flickerScore = 4;
+	[unroll] for (int flick = 0; flick < 8; flick++)
+		flickerScore -= FlickerLumaContribution(centerLuma, flickerTaps[flick].w);
+	flickerScore = saturate(flickerScore);
 
 	// --- neighbourhood MAX-luma colour bracket (complement to the min bracket above) ---
 	// Same six folds as the min bracket (foldTaps/foldGates), but the max rule commits a tap when its
@@ -406,10 +403,6 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 maxWithCorner = MergeMaxBracket(corner, maxBracket, 1);
 	float3 maxBoundSel = cornerBelowHist.xxx ? maxWithCorner : maxBracket;             // (R, B, luma)
 	float3 minBoundSel = cornerBelowHist.xxx ? minBoundNoCorner : minBoundWithCorner;  // (R, B, luma)
-
-	// Flicker score = saturate(4 - sum of the 8 integer flicker contributions). Exact regardless
-	// of grouping (each is a ceil() integer).
-	float flickerScore = saturate(4 - fcCorner - fcMin - fcA0 - fcA1 - fcB0 - fcB1 - fcC0 - fcC1);
 
 	// --- temporal blend, clamp, and sharpen (history rectification toward the neighbourhood AABB) ---
 	// Build two clip candidates (min/max bound, RCAS-sharpened), clamp history luma into their range,

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -374,12 +374,11 @@ PS_OUTPUT main(PS_INPUT input)
 	mergeScratch.yzw = MergeLumaBracket(tapMin, minBracket, uvMinBelowHist);
 	// Final fold: corner tap, ungated (gate 0 → always take the lower-luma colour).
 	bracketMinReg.yzw = MergeLumaBracket(corner, mergeScratch.yzw, 0);
-	tapB1.x = cmp(kMinLumaCap < centerLuma);
-	bracketMax.yzw = tapB1.xxx ? centerMeta.yzx : kMinLumaCap.xxx;
-	bracketMax.xyz = bracketMax.xxx ? bracketMax.yzw : kMinLumaCap.xxx;
-	tapB1.x = cmp(bracketMax.z < tapC1.w);
-	tapC1.xyz = tapB1.xxx ? tapC1.yzw : bracketMax.xyz;
-	tapC1.xyz = center.xxx ? tapC1.xyz : bracketMax.xyz;
+	// Low-clamp the (max-bracketed) tapC1 to the kMinLumaCap floor: build the centre-vs-floor bound
+	// (gated by belowHistCentre), then fold tapC1 toward it (MergeMaxBracket, gated by tapC1's belowHist).
+	float3 lowClamp = cmp(kMinLumaCap < centerLuma) ? centerMeta.yzx : kMinLumaCap.xxx;
+	lowClamp = bracketMax.x ? lowClamp : kMinLumaCap.xxx;
+	tapC1.xyz = MergeMaxBracket(tapC1, lowClamp, center.x);
 
 	// --- flicker contributions, one per neighbourhood tap ---
 	// Lifted out of the colour sort below: each reads a tap's ORIGINAL .w luma, and the sort only

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -151,13 +151,6 @@ float4 PackNeighborTap(ISTAA_NeighborTap tap)
 	return float4(tap.grb, tap.luma);
 }
 
-void AssignPackedNeighbor(float2 uv, float historyLuma, out float4 packed, out float belowHist)
-{
-	ISTAA_NeighborTap tap = SampleNeighborGRB(uv, historyLuma);
-	packed = PackNeighborTap(tap);
-	belowHist = tap.belowHist;
-}
-
 // Centre tap: .xyz sample into .yzw layout; luma via dot(.zwy, kLumaWeights).
 float3 SampleCenterRGB(float2 uv)
 {

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -404,13 +404,15 @@ PS_OUTPUT main(PS_INPUT input)
 	maxBracket = MergeMaxBracket(tapA1, maxBracket, tapMin.x);
 	maxBracket = MergeMaxBracket(tapA0, maxBracket, corner.x);
 	maxBracket = MergeMaxBracket(tapMin, maxBracket, uvMinBelowHist);
-	tapA0.yzw = maxBracket;
-	bracketMinReg.x = tapA0.z;
-	// Final ungated corner fold completes the max bracket (gate 1 -> always take the brighter pick).
-	tapMin.yzw = MergeMaxBracket(corner, maxBracket, 1);
-	tapC0.xw = motionReject.yy ? tapMin.yw : tapA0.yw;
-	mergeScratch.x = tapMin.z;
-	tapC1.xyzw = motionReject.yyyy ? mergeScratch.xyzw : bracketMinReg.xyzw;
+	// Complete the max bracket (ungated corner fold), then select the neighbourhood AABB bounds for
+	// history clamping. motionReject.y toggles whether the corner tap is included: when set, max uses
+	// the with-corner bracket and min the without-corner one (opposite when clear). Packed into
+	// tapC0 (max bound) and tapC1 (max.y, then min bound) in the layout the blend below reads.
+	float3 maxWithCorner = MergeMaxBracket(corner, maxBracket, 1);
+	float3 maxBoundSel = motionReject.yyy ? maxWithCorner : maxBracket;
+	float3 minBoundSel = motionReject.yyy ? mergeScratch.yzw : bracketMinReg.yzw;
+	tapC0.xw = maxBoundSel.xz;
+	tapC1.xyzw = float4(maxBoundSel.y, minBoundSel);
 
 	// Flicker score = saturate(4 - sum of the 8 integer flicker contributions). Exact regardless
 	// of grouping (each is a ceil() integer).

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -490,21 +490,21 @@ PS_OUTPUT main(PS_INPUT input)
 	similarity = max(float2(0, 0), similarity);
 	tapMin.yzw = similarity.xxx * tapMin.xyz + corner.xyz;
 	sampleUV.xyw = -tapMin.yzw + sampleUV.xyw;
-	motionReject.x = BlendParams.x + -BlendParams.y;
-	motionReject.x = motionConfidence * motionReject.x + BlendParams.y;
-	motionReject.x = min(motionReject.x, similarity.x);
-	tapA0.y = similarity.y * historyBlend;
-	motionReject.y = kFeedbackBlendMax + -motionReject.x;
-	motionReject.x = tapA0.y * motionReject.y + motionReject.x;
-	feedbackOut.yz = float2(tapA0.y, motionConfidence);
+	float blendWeight = BlendParams.x + -BlendParams.y;
+	blendWeight = motionConfidence * blendWeight + BlendParams.y;
+	blendWeight = min(blendWeight, similarity.x);
+	float historyFeedback = similarity.y * historyBlend;
+	float feedbackComplement = kFeedbackBlendMax + -blendWeight;
+	blendWeight = historyFeedback * feedbackComplement + blendWeight;
+	feedbackOut.yz = float2(historyFeedback, motionConfidence);
 #	ifdef HDR_OUTPUT
 	tapMin.yzw = max(tapMin.yzw, 0);
-	sampleUV.xyw = saturate(motionReject.xxx * sampleUV.xyw + tapMin.yzw);
+	sampleUV.xyw = saturate(blendWeight.xxx * sampleUV.xyw + tapMin.yzw);
 	// Skip vanilla BlendParams.z/w detail recovery — neighbourhood delta blows up in linear HDR
 	// and causes dark bezels / halos on the alpha-aware corner.yzw output path.
 	corner.yzw = sampleUV.xyw;
 #	else
-	sampleUV.xyw = saturate(motionReject.xxx * sampleUV.xyw + tapMin.yzw);
+	sampleUV.xyw = saturate(blendWeight.xxx * sampleUV.xyw + tapMin.yzw);
 
 	tapA0.xyz = sampleUV.xyw + -corner.xyz;
 	sampleUV.xyw = saturate(tapA0.xyz * BlendParams.zzz + sampleUV.xyw);
@@ -513,10 +513,11 @@ PS_OUTPUT main(PS_INPUT input)
 	corner.yzw = saturate(BlendParams.www * corner.xyz + sampleUV.xyw);
 #	endif
 
-	motionReject.y = motionReject.x * lumaDiff + centerLuma;
-	motionReject.x = motionReject.x * lumaDiff;
-	motionReject.x = cmp(abs(motionReject.x) < kLumaEpsilon);
-	corner.x = motionReject.x ? centerLuma : motionReject.y;
+	// Feedback luma: nudge centre luma by the blend-weighted luma diff, unless that nudge is negligible.
+	float feedbackLuma = blendWeight * lumaDiff + centerLuma;
+	float lumaNudge = blendWeight * lumaDiff;
+	float lumaNudgeTiny = cmp(abs(lumaNudge) < kLumaEpsilon);
+	corner.x = lumaNudgeTiny ? centerLuma : feedbackLuma;
 	float outputLuma = dot(tapMin.zwy, kLumaWeights);
 
 	// --- alpha-aware output ---

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -393,15 +393,10 @@ PS_OUTPUT main(PS_INPUT input)
 	tapC0.xw = motionReject.yy ? tapMin.yw : tapA0.yw;
 	mergeScratch.x = tapMin.z;
 	tapC1.xyzw = motionReject.yyyy ? mergeScratch.xyzw : bracketMinReg.xyzw;
-	float flickerScore = FlickerLumaContribution(centerLuma, corner.w);
-	flickerScore = 4 + -flickerScore;
-	flickerScore = flickerScore + -sampleUV.w;
-	flickerScore = flickerScore + -corner.x;
-	flickerScore = flickerScore + -tapMin.x;
-	flickerScore = flickerScore + -tapA0.x;
-	flickerScore = flickerScore + -tapA1.x;
-	flickerScore = flickerScore + -tapB0.x;
-	flickerScore = saturate(flickerScore + -tapB1.x);
+	// Flicker score = saturate(4 - sum of the 9 neighbourhood FlickerLumaContributions).
+	// Each contribution is an integer ceil() result, so the sum is exact regardless of grouping.
+	float flickerScore = saturate(4 - FlickerLumaContribution(centerLuma, corner.w) - sampleUV.w -
+								  corner.x - tapMin.x - tapA0.x - tapA1.x - tapB0.x - tapB1.x);
 
 	// --- temporal blend, clamp, and sharpen ---
 	sampleUV.w = cmp(1 < tapC1.w);

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -184,6 +184,14 @@ float3 MergeLumaBracket(float4 tap, float3 bracket, float gate)
 	return gate ? bracket : cand;
 }
 
+// RCAS-style sharpen delta: 2 * (center - 0.25*a - 0.25*b), in the decompile's exact op order.
+float SharpenDelta(float center, float a, float b)
+{
+	float d = -a * 0.25 + center;
+	d = -b * 0.25 + d;
+	return d + d;
+}
+
 // shallowestDepth must already include depth before calling.
 float2 PickIfShallowestUV(float2 selectedUV, float shallowestDepth, float depth, float2 uvIfMatch)
 {
@@ -407,14 +415,11 @@ PS_OUTPUT main(PS_INPUT input)
 
 	// --- temporal blend, clamp, and sharpen ---
 	sampleUV.w = cmp(1 < tapC1.w);
-	corner.x = -tapC1.y * 0.25 + tapC1.w;
-	corner.x = -tapC1.z * 0.25 + corner.x;
-	corner.y = corner.x + corner.x;
+	// Sharpen deltas for the two blend candidates (centre minus quarter-weighted neighbour pair).
+	corner.y = SharpenDelta(tapC1.w, tapC1.y, tapC1.z);
 	tapC0.z = tapC1.x;
 	corner.xzw = tapC1.yzw;
-	tapMin.x = -tapC0.x * 0.25 + tapC0.w;
-	tapMin.x = -tapC1.x * 0.25 + tapMin.x;
-	tapC0.y = tapMin.x + tapMin.x;
+	tapC0.y = SharpenDelta(tapC0.w, tapC0.x, tapC1.x);
 	tapMin.x = cmp(tapC0.w < 0);
 	tapMin.xyzw = tapMin.xxxx ? corner.xyzw : tapC0.xyzw;
 	tapA0.xyzw = sampleUV.wwww ? tapMin.xyzw : corner.xyzw;

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -361,42 +361,49 @@ PS_OUTPUT main(PS_INPUT input)
 	tapC1.xyz = tapB1.xxx ? tapC1.yzw : bracketMax.xyz;
 	tapC1.xyz = center.xxx ? tapC1.xyz : bracketMax.xyz;
 
-	// --- flicker score from neighbor luma spread ---
-	tapB1.x = FlickerLumaContribution(centerLuma, tapC1.w);
+	// --- flicker contributions, one per neighbourhood tap ---
+	// Lifted out of the colour sort below: each reads a tap's ORIGINAL .w luma, and the sort only
+	// mutates .w/.yzw after that read, so hoisting them here is behavior-preserving. (In the vanilla
+	// decompile these were stashed into the taps' .x belowHist slots once those gates were spent.)
+	float fcC1 = FlickerLumaContribution(centerLuma, tapC1.w);
+	float fcC0 = FlickerLumaContribution(centerLuma, tapC0.w);
+	float fcB1 = FlickerLumaContribution(centerLuma, tapB1.w);
+	float fcB0 = FlickerLumaContribution(centerLuma, tapB0.w);
+	float fcA1 = FlickerLumaContribution(centerLuma, tapA1.w);
+	float fcA0 = FlickerLumaContribution(centerLuma, tapA0.w);
+	float fcMin = FlickerLumaContribution(centerLuma, tapMin.w);
+	float fcCorner = FlickerLumaContribution(centerLuma, corner.w);
+
+	// --- min-luma colour sort: bubble the lowest-luma neighbour colour through the tap chain,
+	// gated per step by the belowHist masks (.x slots). Irreducible decompile packing — left as-is.
 	tapC0.x = cmp(tapC1.z < tapC0.w);
 	tapC0.xyz = tapC0.xxx ? tapC0.yzw : tapC1.xyz;
 	tapC0.xyz = tapB0.xxx ? tapC0.xyz : tapC1.xyz;
-	tapB0.x = FlickerLumaContribution(centerLuma, tapC0.w);
 	tapC0.w = cmp(tapC0.z < tapB1.w);
 	tapC1.xyz = tapC0.www ? tapB1.yzw : tapC0.xyz;
 	tapC0.xyz = tapA1.xxx ? tapC1.xyz : tapC0.xyz;
-	tapA1.x = FlickerLumaContribution(centerLuma, tapB1.w);
 	tapB1.y = cmp(tapC0.z < tapB0.w);
 	tapB1.yzw = tapB1.yyy ? tapB0.yzw : tapC0.xyz;
 	tapB1.yzw = tapA0.xxx ? tapB1.yzw : tapC0.xyz;
-	tapA0.x = FlickerLumaContribution(centerLuma, tapB0.w);
 	tapB0.y = cmp(tapB1.w < tapA1.w);
 	tapB0.yzw = tapB0.yyy ? tapA1.yzw : tapB1.yzw;
 	tapB0.yzw = tapMin.xxx ? tapB0.yzw : tapB1.yzw;
-	tapMin.x = FlickerLumaContribution(centerLuma, tapA1.w);
 	tapA1.y = cmp(tapB0.w < tapA0.w);
 	tapA1.yzw = tapA1.yyy ? tapA0.yzw : tapB0.yzw;
 	tapA1.yzw = corner.xxx ? tapA1.yzw : tapB0.yzw;
-	corner.x = FlickerLumaContribution(centerLuma, tapA0.w);
 	tapA0.y = cmp(tapA1.w < tapMin.w);
 	tapA0.yzw = tapA0.yyy ? tapMin.yzw : tapA1.yzw;
 	tapA0.yzw = uvMinBelowHist.xxx ? tapA0.yzw : tapA1.yzw;
-	sampleUV.w = FlickerLumaContribution(centerLuma, tapMin.w);
 	bracketMinReg.x = tapA0.z;
 	tapMin.y = cmp(tapA0.w < corner.w);
 	tapMin.yzw = tapMin.yyy ? corner.yzw : tapA0.yzw;
 	tapC0.xw = motionReject.yy ? tapMin.yw : tapA0.yw;
 	mergeScratch.x = tapMin.z;
 	tapC1.xyzw = motionReject.yyyy ? mergeScratch.xyzw : bracketMinReg.xyzw;
-	// Flicker score = saturate(4 - sum of the 9 neighbourhood FlickerLumaContributions).
-	// Each contribution is an integer ceil() result, so the sum is exact regardless of grouping.
-	float flickerScore = saturate(4 - FlickerLumaContribution(centerLuma, corner.w) - sampleUV.w -
-								  corner.x - tapMin.x - tapA0.x - tapA1.x - tapB0.x - tapB1.x);
+
+	// Flicker score = saturate(4 - sum of the 8 integer flicker contributions). Exact regardless
+	// of grouping (each is a ceil() integer).
+	float flickerScore = saturate(4 - fcCorner - fcMin - fcA0 - fcA1 - fcB0 - fcB1 - fcC0 - fcC1);
 
 	// --- temporal blend, clamp, and sharpen ---
 	sampleUV.w = cmp(1 < tapC1.w);

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -459,9 +459,9 @@ PS_OUTPUT main(PS_INPUT input)
 	reject = (int)uvHigh.x | (int)uvLow;
 	reject = (int)uvHigh.y | (int)reject;
 #	endif
-	history.yz = maskTex.Sample(maskSampler, sampleUV.xy).xy;
+	float2 maskValues = maskTex.Sample(maskSampler, sampleUV.xy).xy;  // .x depth-mask, .y coverage
 	float centerCoverage = AlphaCoverageMask(sampleUV.xy);
-	float maskReject = cmp(ThresholdParams.w < history.z);
+	float maskReject = cmp(ThresholdParams.w < maskValues.y);
 	reject = (int)reject | (int)maskReject;
 	// Two colour candidates: the rectified history colour and the neighbourhood-weighted colour
 	// (both collapse to the centre tap when the pixel is rejected).
@@ -499,27 +499,29 @@ PS_OUTPUT main(PS_INPUT input)
 	float feedbackComplement = kFeedbackBlendMax + -blendWeight;
 	blendWeight = historyFeedback * feedbackComplement + blendWeight;
 	feedbackOut.yz = float2(historyFeedback, motionConfidence);
+	// outPacked.yzw = resolved colour; .x = feedback luma (set just below).
+	float4 outPacked;
 #	ifdef HDR_OUTPUT
 	targetColor = max(targetColor, 0);
 	workColor = saturate(blendWeight.xxx * workColor + targetColor);
 	// Skip vanilla BlendParams.z/w detail recovery — neighbourhood delta blows up in linear HDR
-	// and causes dark bezels / halos on the alpha-aware corner.yzw output path.
-	corner.yzw = workColor;
+	// and causes dark bezels / halos on the alpha-aware outPacked.yzw output path.
+	outPacked.yzw = workColor;
 #	else
 	workColor = saturate(blendWeight.xxx * workColor + targetColor);
 
 	float3 detailDelta = workColor + -neighborBlend;
 	workColor = saturate(detailDelta * BlendParams.zzz + workColor);
 
-	corner.xyz = neighborBlend + -workColor;
-	corner.yzw = saturate(BlendParams.www * corner.xyz + workColor);
+	outPacked.xyz = neighborBlend + -workColor;
+	outPacked.yzw = saturate(BlendParams.www * outPacked.xyz + workColor);
 #	endif
 
 	// Feedback luma: nudge centre luma by the blend-weighted luma diff, unless that nudge is negligible.
 	float feedbackLuma = blendWeight * lumaDiff + centerLuma;
 	float lumaNudge = blendWeight * lumaDiff;
 	float lumaNudgeTiny = cmp(abs(lumaNudge) < kLumaEpsilon);
-	corner.x = lumaNudgeTiny ? centerLuma : feedbackLuma;
+	outPacked.x = lumaNudgeTiny ? centerLuma : feedbackLuma;
 	float outputLuma = dot(targetColor.yzx, kLumaWeights);
 
 	// --- alpha-aware output ---
@@ -533,11 +535,11 @@ PS_OUTPUT main(PS_INPUT input)
 	[unroll] for (int alphaTap = 0; alphaTap < 7; alphaTap++)
 		allTransparent = AlphaCoverageMask(alphaUVs[alphaTap]) ? allTransparent : 0;
 	allTransparent = centerCoverage ? allTransparent : 0;
-	float depthMaskPass = cmp(ThresholdParams.w >= history.y);
-	float feedbackWeight = 1 + -history.z;
+	float depthMaskPass = cmp(ThresholdParams.w >= maskValues.x);
+	float feedbackWeight = 1 + -maskValues.y;
 	allTransparent = depthMaskPass ? allTransparent : 0;
 	// .x = feedback luma, .yzw = resolved colour
-	float4 resolved = allTransparent.xxxx ? float4(outputLuma, targetColor) : corner.xyzw;
+	float4 resolved = allTransparent.xxxx ? float4(outputLuma, targetColor) : outPacked.xyzw;
 	colorOut.xyz = resolved.yzw;
 #	ifdef HDR_OUTPUT
 	// Encode PQ luma to game-gamma for feedback RT storage.

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -93,8 +93,8 @@ static const float kFlickerThreshold = 0.200000003;       // luma-spread below t
  * - Bracket colours (float3): (R, B, luma) with .z = luma — see MergeLumaBracket/MergeMaxBracket.
  * - Output colour lives in .yzw (vanilla r3.yzw after blend; resolved/outPacked .yzw), not .xyz.
  *
- * The few remaining float4 packs (motionReject, history, corner, taps) are semantic but reuse
- * components like the decompile; the blend-math packs have been split into named locals.
+ * The few remaining float4 packs (motionReject, corner, the neighbour taps) are semantic but reuse
+ * components like the decompile; the blend-math and history packs have been split into named locals.
  */
 
 float2 ClampScreenUV(float2 screenUV, float2 drMax)
@@ -295,7 +295,7 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 colorOut, feedbackOut;
 
 	// float4 packs — component reuse matches vanilla decompile (see header comment).
-	float4 motionReject, history, corner;  // decompile r0–r4
+	float4 motionReject, corner;  // decompile r0–r4 (corner = depth-guided tap; motionReject = velocity/UV)
 
 	float2 drMax = GetDynamicResolutionMax(), drUVMin, drUVMax, drCenter;
 	float4 drNeighborsA, drNeighborsB, drNeighborsC;
@@ -318,15 +318,19 @@ PS_OUTPUT main(PS_INPUT input)
 	bool prevUVOutOfBounds;
 	float2 historyUV = ReprojectHistoryUV(texCoord.xy, motionReject.xy, prevUVOutOfBounds, motionReject.zw);
 	float motionLength = sqrt(dot(motionReject.xy, motionReject.xy));
-	history.xyw = historyTex.Sample(historySampler, historyUV).xyz;
+	// Feedback RT round-trip: .x = prev feedback luma, .y = prev historyFeedback weight, .z = prev
+	// motionConfidence (see feedbackOut writes at the end). The two weights are NOT colour/luma.
+	float3 historySample = historyTex.Sample(historySampler, historyUV).xyz;
+	float historyLuma = historySample.x;
+	float historyFeedbackPrev = historySample.y;
+	float prevMotionConfidence = historySample.z;
 #	ifdef HDR_OUTPUT
-	// history.x is stored as game-gamma luma (see EncodeFeedbackLuma on write).
-	// Decode to PQ luma to match the working space of all neighbour taps.
-	// history.y and history.w are motion scalars — do NOT convert them.
-	history.x = DecodeFeedbackLuma(history.x);
+	// historyLuma is stored as game-gamma (see EncodeFeedbackLuma on write); decode to PQ to match
+	// the working space of all neighbour taps. The two weights are not luma — do NOT convert them.
+	historyLuma = DecodeFeedbackLuma(historyLuma);
 #	endif
 	corner.w = dot(corner.xzy, kLumaWeights);
-	float cornerBelowHist = cmp(corner.w < history.x);  // toggles corner-tap inclusion in the AABB
+	float cornerBelowHist = cmp(corner.w < historyLuma);  // toggles corner-tap inclusion in the AABB
 
 	// --- neighbour colour / luma samples ---
 	// Sample the 9-tap neighbourhood (packed GRB.xyz + luma.w) plus each tap's below-history mask,
@@ -339,14 +343,14 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 neighbors[7];
 	float neighborBelowHist[7];
 	{
-		ISTAA_NeighborTap tap = SampleNeighborGRB(drUVMin, history.x);
+		ISTAA_NeighborTap tap = SampleNeighborGRB(drUVMin, historyLuma);
 		neighbors[0] = PackNeighborTap(tap);
 		neighborBelowHist[0] = tap.belowHist;
 	}
 	float uvMinCoverage = AlphaCoverageMask(drUVMin);  // seeds the allTransparent test far below
 	[unroll] for (int n = 1; n < 7; n++)
 	{
-		ISTAA_NeighborTap tap = SampleNeighborGRB(neighborUVs[n], history.x);
+		ISTAA_NeighborTap tap = SampleNeighborGRB(neighborUVs[n], historyLuma);
 		neighbors[n] = PackNeighborTap(tap);
 		neighborBelowHist[n] = tap.belowHist;
 	}
@@ -354,7 +358,7 @@ PS_OUTPUT main(PS_INPUT input)
 
 	// --- centre bracket seed, neighbourhood bracket, flicker, temporal blend ---
 	float centerLuma = dot(centerColor.yzx, kLumaWeights);
-	float belowHistCentre = cmp(centerLuma < history.x);
+	float belowHistCentre = cmp(centerLuma < historyLuma);
 	// Centre colour packed as (R, B, luma) — the bracket seeds clamp this against the luma caps.
 	float3 centerRBL = float3(centerColor.x, centerColor.z, centerLuma);
 	// Bracket ceiling: 1.001 is just above the maximum PQ value (1.0 = 10000 nits).
@@ -424,20 +428,20 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 clipPick = cmp(clipHi.w < 0) ? clipLo : clipHi;
 	float4 clipFinal = minOverbright ? clipPick : clipLo;
 	// Clamp history luma into the candidates' luma range: (clamped, lo, hi).
-	float3 clampedHistory = float3(clamp(history.x, clipPick.w, clipFinal.w), clipPick.w, clipFinal.w);
-	float3 historyLumaPack = float3(history.x, clipHi.w, clipLo.w);  // (history luma, max luma, min luma)
-	float historyMotionDecay = kHistoryLumaDecay * history.y;
+	float3 clampedHistory = float3(clamp(historyLuma, clipPick.w, clipFinal.w), clipPick.w, clipFinal.w);
+	float3 historyLumaPack = float3(historyLuma, clipHi.w, clipLo.w);  // (history luma, max luma, min luma)
+	float historyMotionDecay = kHistoryLumaDecay * historyFeedbackPrev;
 	float historyBlend = saturate(flickerScore * 0.25 + historyMotionDecay);
 	float clampToNeighborhood = cmp(historyBlend < kHistoryBlendThreshold);
-	history.xyz = clampToNeighborhood.xxx ? clampedHistory : historyLumaPack;
-	// Clip ratio: where the selected candidate's luma sits within its [lo, hi] range
-	// (history = (luma, lo, hi)); 0.5 fallback when the range is negligible.
-	float clipRange = history.z - history.y;
-	history.y = cmp(kLumaEpsilon < clipRange) ? (history.x - history.y) / clipRange : 0.5;
+	// clipState = (selected luma, lo, hi) — the candidate whose colour we'll rectify toward.
+	float3 clipState = clampToNeighborhood.xxx ? clampedHistory : historyLumaPack;
+	// Clip ratio: where the selected luma sits within its [lo, hi] range; 0.5 fallback when negligible.
+	float clipRange = clipState.z - clipState.y;
+	float clipRatio = cmp(kLumaEpsilon < clipRange) ? (clipState.x - clipState.y) / clipRange : 0.5;
 	float3 rectifyLo = clampToNeighborhood.xxx ? clipPick.xyz : clipHi.xyz;
 	float3 rectifyHi = clampToNeighborhood.xxx ? clipFinal.xyz : clipLo.xyz;
-	// Rectified colour: lerp from the low candidate toward the high one by the clip ratio (history.y).
-	float3 rectifiedColor = lerp(rectifyLo, rectifyHi, history.yyy);
+	// Rectified colour: lerp from the low candidate toward the high one by the clip ratio.
+	float3 rectifiedColor = lerp(rectifyLo, rectifyHi, clipRatio.xxx);
 
 	// --- disocclusion / mask rejection ---
 	float reject;  // disocclusion / OOB / mask rejection flag
@@ -458,19 +462,21 @@ PS_OUTPUT main(PS_INPUT input)
 	// Two colour candidates: the rectified history colour and the neighbourhood-weighted colour
 	// (both collapse to the centre tap when the pixel is rejected).
 	float3 workColor = reject.xxx ? centerColor : rectifiedColor;  // history/rectified colour, evolves below
-	history.xw = reject.xx ? float2(centerLuma, 0) : history.xw;
+	// On reject the history luma/motion collapse to the current frame (centre luma, zero motion).
+	// Kept as one float2 select (.x luma, .y motion) to match the decompile's single movc.
+	float2 blendLumaMotion = reject.xx ? float2(centerLuma, 0) : float2(clipState.x, prevMotionConfidence);
 	float3 neighborBlend = reject.xxx ? centerColor : neighborColor;
 	float3 centerVsNeighbor = centerColor + -neighborBlend;
 	float motionNormScale = 128 * TexelSizeParams.x;  // 128-texel span used to normalize motion length
 	float motionConfidence = saturate(motionLength / motionNormScale);
-	float motionVsHistory = motionConfidence + -history.w;
+	float motionVsHistory = motionConfidence + -blendLumaMotion.y;
 	// Luma convergence decay: the *20 and *100 constants were tuned for gamma-space luma.
 	// PQ is perceptually uniform — a single linear rescale of the PQ diff is accurate
 	// across all luminance levels (unlike converting through gamma, which has a varying
 	// derivative and overcorrects at bright and dark extremes).
 	// Scale factor: 0.05 gamma ≈ 0.020 PQ at mid-scene luminance → factor ≈ 2.5.
 	// luma diff drives the history similarity weights (and the final luma fixup at blend end).
-	float lumaDiff = history.x + -centerLuma;
+	float lumaDiff = blendLumaMotion.x + -centerLuma;
 	// similarity = (1 - scale*diff) per channel, clamped >= 0: .x weights colour, .y the feedback luma.
 #	ifdef HDR_OUTPUT
 	float2 similarity;

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -282,9 +282,9 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 colorOut, feedbackOut;
 
 	// float4 packs — component reuse matches vanilla decompile (see header comment).
-	float4 motionReject, sampleUV, history, corner, tapMin;                 // was r0–r4
-	float4 tapA0, tapA1, tapB0, tapB1, tapC0, tapC1;                        // was r6–r13
-	float4 center, centerMeta, weightedColor, mergeScratch, bracketMinReg;  // was r14–r19
+	float4 motionReject, sampleUV, history, corner, tapMin;  // was r0–r4
+	float4 tapA0, tapA1, tapB0, tapB1, tapC0, tapC1;         // was r6–r13
+	float4 center, centerMeta, mergeScratch, bracketMinReg;  // was r14–r19
 
 	float2 drMax = GetDynamicResolutionMax(), drUVMin, drUVMax, drCenter;
 	float4 drNeighborsA, drNeighborsB, drNeighborsC;

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -422,33 +422,29 @@ PS_OUTPUT main(PS_INPUT input)
 	// compute the clip ratio, and lerp the colour toward the rectified value by it. historyBlend sets
 	// how much history to keep; when low, clampToNeighborhood pulls the result toward the bracket.
 	// Two history-clip candidates from the min/max AABB bounds, each packed (R, sharpenDelta, B, luma)
-	// — the decompile stashes the RCAS sharpen in the G slot. corner = min bound, tapC0 = max bound.
+	// — the decompile stashes the RCAS sharpen in the G slot.
 	float minOverbright = cmp(1 < tapC1.w);
-	corner = float4(tapC1.y, SharpenDelta(tapC1.w, tapC1.y, tapC1.z), tapC1.z, tapC1.w);
-	tapC0 = float4(tapC0.x, SharpenDelta(tapC0.w, tapC0.x, tapC1.x), tapC1.x, tapC0.w);
+	float4 clipLo = float4(tapC1.y, SharpenDelta(tapC1.w, tapC1.y, tapC1.z), tapC1.z, tapC1.w);  // min bound
+	float4 clipHi = float4(tapC0.x, SharpenDelta(tapC0.w, tapC0.x, tapC1.x), tapC1.x, tapC0.w);  // max bound
 	// Prefer the max bound; fall back to the min bound when the max luma is degenerate (<0), then to
 	// that result vs the min bound when the min luma is overbright (>1).
-	tapMin.xyzw = cmp(tapC0.w < 0) ? corner : tapC0;
-	tapA0.xyzw = minOverbright ? tapMin.xyzw : corner;
-	// Clamp history luma into the two sharpened candidates' luma range; tapA1 = (clamped, lo, hi).
-	tapA1.x = clamp(history.x, tapMin.w, tapA0.w);
-	tapA1.y = tapMin.w;
-	tapA1.z = tapA0.w;
-	tapB0.z = corner.w;
-	tapB0.x = history.x;
-	tapB0.y = tapC0.w;
+	float4 clipPick = cmp(clipHi.w < 0) ? clipLo : clipHi;
+	float4 clipFinal = minOverbright ? clipPick : clipLo;
+	// Clamp history luma into the candidates' luma range: (clamped, lo, hi).
+	float3 clampedHistory = float3(clamp(history.x, clipPick.w, clipFinal.w), clipPick.w, clipFinal.w);
+	float3 historyLumaPack = float3(history.x, clipHi.w, clipLo.w);  // (history luma, max luma, min luma)
 	sampleUV.w = kHistoryLumaDecay * history.y;
 	float historyBlend = saturate(flickerScore * 0.25 + sampleUV.w);
 	float clampToNeighborhood = cmp(historyBlend < kHistoryBlendThreshold);
-	history.xyz = clampToNeighborhood.xxx ? tapA1.xyz : tapB0.xyz;
+	history.xyz = clampToNeighborhood.xxx ? clampedHistory : historyLumaPack;
 	// Clip ratio: where the selected candidate's luma sits within its [lo, hi] range
 	// (history = (luma, lo, hi)); 0.5 fallback when the range is negligible.
 	float clipRange = history.z - history.y;
 	history.y = cmp(kLumaEpsilon < clipRange) ? (history.x - history.y) / clipRange : 0.5;
-	tapMin.xyz = clampToNeighborhood.xxx ? tapMin.xyz : tapC0.xyz;
-	corner.xyz = clampToNeighborhood.xxx ? tapA0.xyz : corner.xyz;
+	float3 rectifyLo = clampToNeighborhood.xxx ? clipPick.xyz : clipHi.xyz;
+	float3 rectifyHi = clampToNeighborhood.xxx ? clipFinal.xyz : clipLo.xyz;
 	// Rectified colour: lerp from the low candidate toward the high one by the clip ratio (history.y).
-	corner.xyz = lerp(tapMin.xyz, corner.xyz, history.yyy);
+	corner.xyz = lerp(rectifyLo, rectifyHi, history.yyy);
 
 	// --- disocclusion / mask rejection ---
 	// motionLength holds the motion length (motionReject.zw held the reprojected UV on the SE path).

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -87,7 +87,7 @@ static const float kFlickerThreshold = 0.200000003;       // luma-spread below t
 /*
  * Channel layout (vanilla decompile — swizzles are load-bearing):
  * - Neighbour taps: .yxz sample; luma via dot(.xzy, kLumaWeights); stored as float4(.xyz=GRB, .w=luma).
- * - center: float4 .x=belowHistC1, .yzw=centre RGB; luma via dot(center.zwy, kLumaWeights).
+ * - centre: centerColor float3 = RGB; belowHistC1 scalar = C1 mask; luma via dot(centerColor.yzx, kLumaWeights).
  * - corner: float4 .xyz=corner GRB, .w=corner luma (depth-guided); .x reused for belowHistA0 mask.
  * - Bracket colours: .yzw holds (R, B, G); .w = luma.
  * - Output colour lives in .yzw (vanilla r3.yzw after blend; colorOut = sampleUV.yzw), not .xyz.
@@ -284,7 +284,7 @@ PS_OUTPUT main(PS_INPUT input)
 	// float4 packs — component reuse matches vanilla decompile (see header comment).
 	float4 motionReject, sampleUV, history, corner, tapMin;  // was r0–r4
 	float4 tapA0, tapA1, tapB0, tapB1, tapC0, tapC1;         // was r6–r13
-	float4 center;                                           // belowHistC1 mask carrier (was r14)
+	float belowHistC1;                                       // C1 tap below-history mask (was center.x, r14)
 
 	float2 drMax = GetDynamicResolutionMax(), drUVMin, drUVMax, drCenter;
 	float4 drNeighborsA, drNeighborsB, drNeighborsC;
@@ -341,8 +341,8 @@ PS_OUTPUT main(PS_INPUT input)
 	AssignPackedNeighbor(drNeighborsB.xy, history.x, tapB0, tapA0.x);
 	AssignPackedNeighbor(drNeighborsB.zw, history.x, tapB1, tapA1.x);
 	AssignPackedNeighbor(drNeighborsC.xy, history.x, tapC0, tapB0.x);
-	AssignPackedNeighbor(drNeighborsC.zw, history.x, tapC1, center.x);
-	float3 centerColor = SampleCenterRGB(sampleUV.xy);  // centre RGB; center.x stays the belowHist mask
+	AssignPackedNeighbor(drNeighborsC.zw, history.x, tapC1, belowHistC1);
+	float3 centerColor = SampleCenterRGB(sampleUV.xy);  // centre RGB (belowHistC1 holds the C1 mask)
 
 	// --- centre bracket seed, neighbourhood bracket, flicker, temporal blend (verbatim math) ---
 	float centerLuma = dot(centerColor.yzx, kLumaWeights);
@@ -356,7 +356,7 @@ PS_OUTPUT main(PS_INPUT input)
 	// below history (belowHistCentre), start at the ceiling. Then fold tapC1 (its belowHist).
 	float3 minBracket = cmp(centerLuma < kMaxLumaCap) ? centerRBL : kMaxLumaCap.xxx;
 	minBracket = belowHistCentre ? kMaxLumaCap.xxx : minBracket;
-	minBracket = MergeLumaBracket(tapC1, minBracket, center.x);
+	minBracket = MergeLumaBracket(tapC1, minBracket, belowHistC1);
 
 	// --- neighborhood min/max color bracket ---
 	// 4-tap weighted neighbour colour (C + D + L + LD); consumed by the non-reject output path.
@@ -380,7 +380,7 @@ PS_OUTPUT main(PS_INPUT input)
 	// (gated by belowHistCentre), then fold tapC1 toward it (MergeMaxBracket, gated by tapC1's belowHist).
 	float3 lowClamp = cmp(kMinLumaCap < centerLuma) ? centerRBL : kMinLumaCap.xxx;
 	lowClamp = belowHistCentre ? lowClamp : kMinLumaCap.xxx;
-	tapC1.xyz = MergeMaxBracket(tapC1, lowClamp, center.x);
+	tapC1.xyz = MergeMaxBracket(tapC1, lowClamp, belowHistC1);
 
 	// --- flicker contributions, one per neighbourhood tap ---
 	// Lifted out of the colour sort below: each reads a tap's ORIGINAL .w luma, and the sort only

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -445,10 +445,10 @@ PS_OUTPUT main(PS_INPUT input)
 	float historyBlend = saturate(flickerScore * 0.25 + sampleUV.w);
 	float clampToNeighborhood = cmp(historyBlend < kHistoryBlendThreshold);
 	history.xyz = clampToNeighborhood.xxx ? tapA1.xyz : tapB0.xyz;
-	history.yz = history.zx + -history.yy;
-	corner.w = cmp(kLumaEpsilon < history.y);
-	history.y = history.z / history.y;
-	history.y = corner.w ? history.y : 0.5;
+	// Clip ratio: where the selected candidate's luma sits within its [lo, hi] range
+	// (history = (luma, lo, hi)); 0.5 fallback when the range is negligible.
+	float clipRange = history.z - history.y;
+	history.y = cmp(kLumaEpsilon < clipRange) ? (history.x - history.y) / clipRange : 0.5;
 	tapMin.xyz = clampToNeighborhood.xxx ? tapMin.xyz : tapC0.xyz;
 	corner.xyz = clampToNeighborhood.xxx ? tapA0.xyz : corner.xyz;
 	// Rectified colour: lerp from the low candidate toward the high one by the clip ratio (history.y).

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -403,13 +403,10 @@ PS_OUTPUT main(PS_INPUT input)
 		maxBracket = MergeMaxBracket(foldTaps[maxFold], maxBracket, foldGates[maxFold]);
 	// Complete the max bracket (ungated corner fold), then select the neighbourhood AABB bounds for
 	// history clamping. cornerBelowHist toggles whether the corner tap is included: when set, max uses
-	// the with-corner bracket and min the without-corner one (opposite when clear). Packed into
-	// tapC0 (max bound) and tapC1 (max.y, then min bound) in the layout the blend below reads.
+	// the with-corner bracket and min the without-corner one (opposite when clear).
 	float3 maxWithCorner = MergeMaxBracket(corner, maxBracket, 1);
-	float3 maxBoundSel = cornerBelowHist.xxx ? maxWithCorner : maxBracket;
-	float3 minBoundSel = cornerBelowHist.xxx ? minBoundNoCorner : minBoundWithCorner;
-	tapC0.xw = maxBoundSel.xz;
-	tapC1.xyzw = float4(maxBoundSel.y, minBoundSel);
+	float3 maxBoundSel = cornerBelowHist.xxx ? maxWithCorner : maxBracket;             // (R, B, luma)
+	float3 minBoundSel = cornerBelowHist.xxx ? minBoundNoCorner : minBoundWithCorner;  // (R, B, luma)
 
 	// Flicker score = saturate(4 - sum of the 8 integer flicker contributions). Exact regardless
 	// of grouping (each is a ceil() integer).
@@ -421,9 +418,9 @@ PS_OUTPUT main(PS_INPUT input)
 	// how much history to keep; when low, clampToNeighborhood pulls the result toward the bracket.
 	// Two history-clip candidates from the min/max AABB bounds, each packed (R, sharpenDelta, B, luma)
 	// — the decompile stashes the RCAS sharpen in the G slot.
-	float minOverbright = cmp(1 < tapC1.w);
-	float4 clipLo = float4(tapC1.y, SharpenDelta(tapC1.w, tapC1.y, tapC1.z), tapC1.z, tapC1.w);  // min bound
-	float4 clipHi = float4(tapC0.x, SharpenDelta(tapC0.w, tapC0.x, tapC1.x), tapC1.x, tapC0.w);  // max bound
+	float minOverbright = cmp(1 < minBoundSel.z);
+	float4 clipLo = float4(minBoundSel.x, SharpenDelta(minBoundSel.z, minBoundSel.x, minBoundSel.y), minBoundSel.y, minBoundSel.z);  // min bound
+	float4 clipHi = float4(maxBoundSel.x, SharpenDelta(maxBoundSel.z, maxBoundSel.x, maxBoundSel.y), maxBoundSel.y, maxBoundSel.z);  // max bound
 	// Prefer the max bound; fall back to the min bound when the max luma is degenerate (<0), then to
 	// that result vs the min bound when the min luma is overbright (>1).
 	float4 clipPick = cmp(clipHi.w < 0) ? clipLo : clipHi;

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -82,6 +82,7 @@ static const float2 kSimilarityScale = float2(20, 100);   // motion-diff converg
 static const float kHistoryLumaDecay = 0.949999988;       // 0.95 decay applied to history motion luma
 static const float kHistoryBlendThreshold = 0.902499974;  // below this blend weight, clamp to neighbourhood
 static const float kFeedbackBlendMax = 0.99000001;        // ~1.0 ceiling for the feedback blend weight
+static const float kFlickerThreshold = 0.200000003;       // luma-spread below this counts as flicker
 
 /*
  * Channel layout (vanilla decompile — swizzles are load-bearing):
@@ -173,7 +174,7 @@ float AlphaCoverageMask(float2 uv)
 float FlickerLumaContribution(float centerLuma, float neighborLuma)
 {
 	float d = centerLuma + -neighborLuma;
-	d = 0.200000003 + -abs(d);
+	d = kFlickerThreshold + -abs(d);
 	return ceil(d);
 }
 

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -74,6 +74,12 @@ float DecodeFeedbackLuma(float gammaLuma)
 
 static const float3 kLumaWeights = float3(0.5, 0.25, 0.25);
 
+// Named magic constants from the vanilla decompile (values unchanged).
+static const float kMaxLumaCap = 1.00100005;             // bracket ceiling (just above 1.0 PQ)
+static const float kMinLumaCap = -0.00100000005;         // bracket floor (just below 0)
+static const float kLumaEpsilon = 0.00999999978;         // negligible-luma threshold
+static const float2 kSimilarityScale = float2(20, 100);  // motion-diff convergence decay (x), strict (y)
+
 /*
  * Channel layout (vanilla decompile — swizzles are load-bearing):
  * - Neighbour taps: .yxz sample; luma via dot(.xzy, kLumaWeights); stored as float4(.xyz=GRB, .w=luma).
@@ -275,7 +281,7 @@ PS_OUTPUT main(PS_INPUT input)
 	motionReject.zw = texCoord.xy + motionReject.xy;
 	tapMin.xy = ClampHistoryUV(motionReject.zw);
 #	endif
-	motionReject.x = sqrt(dot(motionReject.xy, motionReject.xy));
+	float motionLength = sqrt(dot(motionReject.xy, motionReject.xy));
 	history.xyw = historyTex.Sample(historySampler, tapMin.xy).xyz;
 #	ifdef HDR_OUTPUT
 	// history.x is stored as game-gamma luma (see EncodeFeedbackLuma on write).
@@ -289,12 +295,14 @@ PS_OUTPUT main(PS_INPUT input)
 	// --- neighbour colour / luma samples ---
 	sampleUV.zw = drUVMin;
 	sampleUV.xy = drCenter;
+	float uvMinCoverage;   // uvMin alpha coverage; seeds the allTransparent test far below
+	float uvMinBelowHist;  // uvMin tap below-history mask; consumed in the bracket/flicker cascade
 	{
 		ISTAA_NeighborTap tap = SampleNeighborGRB(sampleUV.zw, history.x);
 		tapMin.xyz = tap.grb;
-		sampleUV.z = AlphaCoverageMask(sampleUV.zw);
+		uvMinCoverage = AlphaCoverageMask(sampleUV.zw);
 		tapMin.w = tap.luma;
-		sampleUV.w = tap.belowHist;
+		uvMinBelowHist = tap.belowHist;
 	}
 	AssignPackedNeighbor(drNeighborsA.xy, history.x, tapA0, corner.x);
 	AssignPackedNeighbor(drNeighborsA.zw, history.x, tapA1, tapMin.x);
@@ -302,28 +310,30 @@ PS_OUTPUT main(PS_INPUT input)
 	AssignPackedNeighbor(drNeighborsB.zw, history.x, tapB1, tapA1.x);
 	AssignPackedNeighbor(drNeighborsC.xy, history.x, tapC0, tapB0.x);
 	AssignPackedNeighbor(drNeighborsC.zw, history.x, tapC1, center.x);
-	center.yzw = SampleCenterRGB(sampleUV.xy);
+	float3 centerColor = SampleCenterRGB(sampleUV.xy);  // centre RGB; center.x stays the belowHist mask
 
 	// --- centre bracket seed, neighbourhood bracket, flicker, temporal blend (verbatim math) ---
-	centerMeta.x = dot(center.zwy, kLumaWeights);
-	bracketMax.x = cmp(centerMeta.x < history.x);
-	centerMeta.yz = center.yw;
+	float centerLuma = dot(centerColor.yzx, kLumaWeights);
+	centerMeta.x = centerLuma;  // .yzx swizzle in the bracket cascade still reads this slot
+	bracketMax.x = cmp(centerLuma < history.x);
+	centerMeta.yz = centerColor.xz;
 	// Bracket ceiling: 1.001 is just above the maximum PQ value (1.0 = 10000 nits).
 	// Nothing in the scene exceeds this, so the ceiling works correctly in PQ working space.
 	// (In linear BT2020 this would be wrong — sky/specular exceed 1.0 linear — but PQ is bounded.)
-	bracketMax.y = cmp(centerMeta.x < 1.00100005);
-	bracketMax.yzw = bracketMax.yyy ? centerMeta.yzx : float3(1.00100005, 1.00100005, 1.00100005);
-	bracketMax.yzw = bracketMax.xxx ? float3(1.00100005, 1.00100005, 1.00100005) : bracketMax.yzw;
+	bracketMax.y = cmp(centerLuma < kMaxLumaCap);
+	bracketMax.yzw = bracketMax.yyy ? centerMeta.yzx : kMaxLumaCap.xxx;
+	bracketMax.yzw = bracketMax.xxx ? kMaxLumaCap.xxx : bracketMax.yzw;
 
 	weightedColor.x = cmp(tapC1.w < bracketMax.w);
 	weightedColor.xyz = weightedColor.xxx ? tapC1.yzw : bracketMax.yzw;
 	bracketMax.yzw = center.xxx ? bracketMax.yzw : weightedColor.xyz;
 
 	// --- neighborhood min/max color bracket ---
-	weightedColor.xyz = NeighborWeights.zzz * tapC0.yxz;
-	weightedColor.xyz = tapB1.yxz * NeighborWeights.www + weightedColor.xyz;
-	weightedColor.xyz = tapC1.yxz * NeighborWeights.yyy + weightedColor.xyz;
-	weightedColor.xyz = center.yzw * NeighborWeights.xxx + weightedColor.xyz;
+	// 4-tap weighted neighbour colour (C + D + L + LD); consumed by the non-reject output path.
+	float3 neighborColor = NeighborWeights.zzz * tapC0.yxz;
+	neighborColor = tapB1.yxz * NeighborWeights.www + neighborColor;
+	neighborColor = tapC1.yxz * NeighborWeights.yyy + neighborColor;
+	neighborColor = centerColor * NeighborWeights.xxx + neighborColor;
 	tapB1.x = cmp(tapC0.w < bracketMax.w);
 	mergeScratch.xyz = tapB1.xxx ? tapC0.yzw : bracketMax.yzw;
 	bracketMax.yzw = tapB0.xxx ? bracketMax.yzw : mergeScratch.xyz;
@@ -341,57 +351,57 @@ PS_OUTPUT main(PS_INPUT input)
 	bracketMax.yzw = corner.xxx ? bracketMax.yzw : mergeScratch.xyz;
 	tapB1.x = cmp(tapMin.w < bracketMax.w);
 	mergeScratch.xyz = tapB1.xxx ? tapMin.yzw : bracketMax.yzw;
-	mergeScratch.yzw = sampleUV.www ? bracketMax.yzw : mergeScratch.xyz;
+	mergeScratch.yzw = uvMinBelowHist.xxx ? bracketMax.yzw : mergeScratch.xyz;
 	tapB1.x = cmp(corner.w < mergeScratch.w);
 	bracketMinReg.yzw = tapB1.xxx ? corner.yzw : mergeScratch.yzw;
-	tapB1.x = cmp(-0.00100000005 < centerMeta.x);
-	bracketMax.yzw = tapB1.xxx ? centerMeta.yzx : float3(-0.00100000005, -0.00100000005, -0.00100000005);
-	bracketMax.xyz = bracketMax.xxx ? bracketMax.yzw : float3(-0.00100000005, -0.00100000005, -0.00100000005);
+	tapB1.x = cmp(kMinLumaCap < centerLuma);
+	bracketMax.yzw = tapB1.xxx ? centerMeta.yzx : kMinLumaCap.xxx;
+	bracketMax.xyz = bracketMax.xxx ? bracketMax.yzw : kMinLumaCap.xxx;
 	tapB1.x = cmp(bracketMax.z < tapC1.w);
 	tapC1.xyz = tapB1.xxx ? tapC1.yzw : bracketMax.xyz;
 	tapC1.xyz = center.xxx ? tapC1.xyz : bracketMax.xyz;
 
 	// --- flicker score from neighbor luma spread ---
-	tapB1.x = FlickerLumaContribution(centerMeta.x, tapC1.w);
+	tapB1.x = FlickerLumaContribution(centerLuma, tapC1.w);
 	tapC0.x = cmp(tapC1.z < tapC0.w);
 	tapC0.xyz = tapC0.xxx ? tapC0.yzw : tapC1.xyz;
 	tapC0.xyz = tapB0.xxx ? tapC0.xyz : tapC1.xyz;
-	tapB0.x = FlickerLumaContribution(centerMeta.x, tapC0.w);
+	tapB0.x = FlickerLumaContribution(centerLuma, tapC0.w);
 	tapC0.w = cmp(tapC0.z < tapB1.w);
 	tapC1.xyz = tapC0.www ? tapB1.yzw : tapC0.xyz;
 	tapC0.xyz = tapA1.xxx ? tapC1.xyz : tapC0.xyz;
-	tapA1.x = FlickerLumaContribution(centerMeta.x, tapB1.w);
+	tapA1.x = FlickerLumaContribution(centerLuma, tapB1.w);
 	tapB1.y = cmp(tapC0.z < tapB0.w);
 	tapB1.yzw = tapB1.yyy ? tapB0.yzw : tapC0.xyz;
 	tapB1.yzw = tapA0.xxx ? tapB1.yzw : tapC0.xyz;
-	tapA0.x = FlickerLumaContribution(centerMeta.x, tapB0.w);
+	tapA0.x = FlickerLumaContribution(centerLuma, tapB0.w);
 	tapB0.y = cmp(tapB1.w < tapA1.w);
 	tapB0.yzw = tapB0.yyy ? tapA1.yzw : tapB1.yzw;
 	tapB0.yzw = tapMin.xxx ? tapB0.yzw : tapB1.yzw;
-	tapMin.x = FlickerLumaContribution(centerMeta.x, tapA1.w);
+	tapMin.x = FlickerLumaContribution(centerLuma, tapA1.w);
 	tapA1.y = cmp(tapB0.w < tapA0.w);
 	tapA1.yzw = tapA1.yyy ? tapA0.yzw : tapB0.yzw;
 	tapA1.yzw = corner.xxx ? tapA1.yzw : tapB0.yzw;
-	corner.x = FlickerLumaContribution(centerMeta.x, tapA0.w);
+	corner.x = FlickerLumaContribution(centerLuma, tapA0.w);
 	tapA0.y = cmp(tapA1.w < tapMin.w);
 	tapA0.yzw = tapA0.yyy ? tapMin.yzw : tapA1.yzw;
-	tapA0.yzw = sampleUV.www ? tapA0.yzw : tapA1.yzw;
-	sampleUV.w = FlickerLumaContribution(centerMeta.x, tapMin.w);
+	tapA0.yzw = uvMinBelowHist.xxx ? tapA0.yzw : tapA1.yzw;
+	sampleUV.w = FlickerLumaContribution(centerLuma, tapMin.w);
 	bracketMinReg.x = tapA0.z;
 	tapMin.y = cmp(tapA0.w < corner.w);
 	tapMin.yzw = tapMin.yyy ? corner.yzw : tapA0.yzw;
 	tapC0.xw = motionReject.yy ? tapMin.yw : tapA0.yw;
 	mergeScratch.x = tapMin.z;
 	tapC1.xyzw = motionReject.yyyy ? mergeScratch.xyzw : bracketMinReg.xyzw;
-	motionReject.y = FlickerLumaContribution(centerMeta.x, corner.w);
-	motionReject.y = 4 + -motionReject.y;
-	motionReject.y = motionReject.y + -sampleUV.w;
-	motionReject.y = motionReject.y + -corner.x;
-	motionReject.y = motionReject.y + -tapMin.x;
-	motionReject.y = motionReject.y + -tapA0.x;
-	motionReject.y = motionReject.y + -tapA1.x;
-	motionReject.y = motionReject.y + -tapB0.x;
-	motionReject.y = saturate(motionReject.y + -tapB1.x);
+	float flickerScore = FlickerLumaContribution(centerLuma, corner.w);
+	flickerScore = 4 + -flickerScore;
+	flickerScore = flickerScore + -sampleUV.w;
+	flickerScore = flickerScore + -corner.x;
+	flickerScore = flickerScore + -tapMin.x;
+	flickerScore = flickerScore + -tapA0.x;
+	flickerScore = flickerScore + -tapA1.x;
+	flickerScore = flickerScore + -tapB0.x;
+	flickerScore = saturate(flickerScore + -tapB1.x);
 
 	// --- temporal blend, clamp, and sharpen ---
 	sampleUV.w = cmp(1 < tapC1.w);
@@ -414,20 +424,20 @@ PS_OUTPUT main(PS_INPUT input)
 	tapB0.x = history.x;
 	tapB0.y = tapC0.w;
 	sampleUV.w = 0.949999988 * history.y;
-	motionReject.y = saturate(motionReject.y * 0.25 + sampleUV.w);
-	sampleUV.w = cmp(motionReject.y < 0.902499974);
-	history.xyz = sampleUV.www ? tapA1.xyz : tapB0.xyz;
+	float historyBlend = saturate(flickerScore * 0.25 + sampleUV.w);
+	float clampToNeighborhood = cmp(historyBlend < 0.902499974);
+	history.xyz = clampToNeighborhood.xxx ? tapA1.xyz : tapB0.xyz;
 	history.yz = history.zx + -history.yy;
-	corner.w = cmp(0.00999999978 < history.y);
+	corner.w = cmp(kLumaEpsilon < history.y);
 	history.y = history.z / history.y;
 	history.y = corner.w ? history.y : 0.5;
-	tapMin.xyz = sampleUV.www ? tapMin.xyz : tapC0.xyz;
-	corner.xyz = sampleUV.www ? tapA0.xyz : corner.xyz;
+	tapMin.xyz = clampToNeighborhood.xxx ? tapMin.xyz : tapC0.xyz;
+	corner.xyz = clampToNeighborhood.xxx ? tapA0.xyz : corner.xyz;
 	corner.xyz = corner.xyz + -tapMin.xyz;
 	corner.xyz = history.yyy * corner.xyz + tapMin.xyz;
 
 	// --- disocclusion / mask rejection ---
-	// motionReject.x = motion length (motionReject.zw held the reprojected UV on the SE path).
+	// motionLength holds the motion length (motionReject.zw held the reprojected UV on the SE path).
 #	ifdef VR
 	// VR resolves out-of-bounds per-eye in mono space; the SE stereo-space test misses the seam.
 	motionReject.z = prevUVOutOfBounds ? 1 : 0;
@@ -439,42 +449,43 @@ PS_OUTPUT main(PS_INPUT input)
 	motionReject.z = (int)motionReject.w | (int)motionReject.z;
 #	endif
 	history.yz = maskTex.Sample(maskSampler, sampleUV.xy).xy;
-	motionReject.w = AlphaCoverageMask(sampleUV.xy);
+	float centerCoverage = AlphaCoverageMask(sampleUV.xy);
 	sampleUV.x = cmp(ThresholdParams.w < history.z);
 	motionReject.z = (int)motionReject.z | (int)sampleUV.x;
-	sampleUV.xyw = motionReject.zzz ? center.yzw : corner.xyz;
+	float reject = motionReject.z;  // disocclusion / OOB / mask rejection flag
+	sampleUV.xyw = reject.xxx ? centerColor : corner.xyz;
 	centerMeta.w = 0;
-	history.xw = motionReject.zz ? centerMeta.xw : history.xw;
-	corner.xyz = motionReject.zzz ? center.yzw : weightedColor.xyz;
-	tapMin.xyz = center.yzw + -corner.xyz;
-	motionReject.z = 128 * TexelSizeParams.x;
-	tapA0.z = saturate(motionReject.x / motionReject.z);
-	motionReject.x = tapA0.z + -history.w;
+	history.xw = reject.xx ? centerMeta.xw : history.xw;
+	corner.xyz = reject.xxx ? centerColor : neighborColor;
+	tapMin.xyz = centerColor + -corner.xyz;
+	float motionNormScale = 128 * TexelSizeParams.x;  // 128-texel span used to normalize motion length
+	float motionConfidence = saturate(motionLength / motionNormScale);
+	motionReject.x = motionConfidence + -history.w;
 	// Luma convergence decay: the *20 and *100 constants were tuned for gamma-space luma.
 	// PQ is perceptually uniform — a single linear rescale of the PQ diff is accurate
 	// across all luminance levels (unlike converting through gamma, which has a varying
 	// derivative and overcorrects at bright and dark extremes).
 	// Scale factor: 0.05 gamma ≈ 0.020 PQ at mid-scene luminance → factor ≈ 2.5.
 #	ifdef HDR_OUTPUT
-	motionReject.z = history.x + -centerMeta.x;
+	motionReject.z = history.x + -centerLuma;
 	{
 		float lumaDiffScaled = abs(motionReject.z) * 0.05;
-		history.xw = -lumaDiffScaled.xx * float2(20, 100) + float2(1, 1);
+		history.xw = -lumaDiffScaled.xx * kSimilarityScale + float2(1, 1);
 	}
 #	else
-	motionReject.z = history.x + -centerMeta.x;
-	history.xw = -abs(motionReject.xx) * float2(20, 100) + float2(1, 1);
+	motionReject.z = history.x + -centerLuma;
+	history.xw = -abs(motionReject.xx) * kSimilarityScale + float2(1, 1);
 #	endif
 	history.xw = max(float2(0, 0), history.xw);
 	tapMin.yzw = history.xxx * tapMin.xyz + corner.xyz;
 	sampleUV.xyw = -tapMin.yzw + sampleUV.xyw;
 	motionReject.x = BlendParams.x + -BlendParams.y;
-	motionReject.x = tapA0.z * motionReject.x + BlendParams.y;
+	motionReject.x = motionConfidence * motionReject.x + BlendParams.y;
 	motionReject.x = min(motionReject.x, history.x);
-	tapA0.y = history.w * motionReject.y;
+	tapA0.y = history.w * historyBlend;
 	motionReject.y = 0.99000001 + -motionReject.x;
 	motionReject.x = tapA0.y * motionReject.y + motionReject.x;
-	feedbackOut.yz = tapA0.yz;
+	feedbackOut.yz = float2(tapA0.y, motionConfidence);
 #	ifdef HDR_OUTPUT
 	tapMin.yzw = max(tapMin.yzw, 0);
 	sampleUV.xyw = saturate(motionReject.xxx * sampleUV.xyw + tapMin.yzw);
@@ -491,41 +502,37 @@ PS_OUTPUT main(PS_INPUT input)
 	corner.yzw = saturate(BlendParams.www * corner.xyz + sampleUV.xyw);
 #	endif
 
-	motionReject.y = motionReject.x * motionReject.z + centerMeta.x;
+	motionReject.y = motionReject.x * motionReject.z + centerLuma;
 	motionReject.x = motionReject.x * motionReject.z;
-	motionReject.x = cmp(abs(motionReject.x) < 0.00999999978);
-	corner.x = motionReject.x ? centerMeta.x : motionReject.y;
-	tapMin.x = dot(tapMin.zwy, kLumaWeights);
+	motionReject.x = cmp(abs(motionReject.x) < kLumaEpsilon);
+	corner.x = motionReject.x ? centerLuma : motionReject.y;
+	float outputLuma = dot(tapMin.zwy, kLumaWeights);
 
 	// --- alpha-aware output ---
-	motionReject.x = AlphaCoverageMask(drNeighborsA.xy);
-	motionReject.y = AlphaCoverageMask(drNeighborsA.zw);
-	motionReject.x = motionReject.x ? sampleUV.z : 0;
-	motionReject.x = motionReject.y ? motionReject.x : 0;
-	motionReject.y = AlphaCoverageMask(drNeighborsB.xy);
-	motionReject.z = AlphaCoverageMask(drNeighborsB.zw);
-	motionReject.x = motionReject.y ? motionReject.x : 0;
-	motionReject.x = motionReject.z ? motionReject.x : 0;
-	motionReject.y = AlphaCoverageMask(drNeighborsC.xy);
-	motionReject.z = AlphaCoverageMask(drNeighborsC.zw);
-	motionReject.x = motionReject.y ? motionReject.x : 0;
-	motionReject.x = motionReject.z ? motionReject.x : 0;
-	motionReject.y = AlphaCoverageMask(drUVMax);
-	motionReject.x = motionReject.y ? motionReject.x : 0;
-	motionReject.x = motionReject.w ? motionReject.x : 0;
-	motionReject.y = cmp(ThresholdParams.w >= history.y);
-	motionReject.z = 1 + -history.z;
-	motionReject.x = motionReject.y ? motionReject.x : 0;
-	sampleUV.xyzw = motionReject.xxxx ? tapMin.xyzw : corner.xyzw;
-	colorOut.xyz = sampleUV.yzw;
+	// allTransparent: every 3x3 tap covered by alpha. Seed = uvMin coverage (uvMinCoverage),
+	// gated by the 8 remaining taps (centerCoverage already holds the centre tap's coverage).
+	const float2 alphaUVs[7] = {
+		drNeighborsA.xy, drNeighborsA.zw, drNeighborsB.xy, drNeighborsB.zw,
+		drNeighborsC.xy, drNeighborsC.zw, drUVMax
+	};
+	float allTransparent = uvMinCoverage;
+	[unroll] for (int alphaTap = 0; alphaTap < 7; alphaTap++)
+		allTransparent = AlphaCoverageMask(alphaUVs[alphaTap]) ? allTransparent : 0;
+	allTransparent = centerCoverage ? allTransparent : 0;
+	float depthMaskPass = cmp(ThresholdParams.w >= history.y);
+	float feedbackWeight = 1 + -history.z;
+	allTransparent = depthMaskPass ? allTransparent : 0;
+	// .x = feedback luma, .yzw = resolved colour
+	float4 resolved = allTransparent.xxxx ? float4(outputLuma, tapMin.yzw) : corner.xyzw;
+	colorOut.xyz = resolved.yzw;
 #	ifdef HDR_OUTPUT
 	// Encode PQ luma to game-gamma for feedback RT storage.
 	// Storing raw PQ [0,1] in a low-precision RT causes highlight banding because
 	// PQ packs high-nit values into the upper range where RT quantization is visible.
 	// Game-gamma encoding spreads precision evenly — symmetric with DecodeFeedbackLuma on read.
-	feedbackOut.x = EncodeFeedbackLuma(saturate(sampleUV.x * motionReject.z));
+	feedbackOut.x = EncodeFeedbackLuma(saturate(resolved.x * feedbackWeight));
 #	else
-	feedbackOut.x = saturate(sampleUV.x * motionReject.z);
+	feedbackOut.x = saturate(resolved.x * feedbackWeight);
 #	endif
 	// Vanilla writes opaque alpha unconditionally on both SE and VR (decompile o0.w = 1).
 	colorOut.w = 1;

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -477,17 +477,15 @@ PS_OUTPUT main(PS_INPUT input)
 	// Scale factor: 0.05 gamma ≈ 0.020 PQ at mid-scene luminance → factor ≈ 2.5.
 	// luma diff drives the history similarity weights (and the final luma fixup at blend end).
 	float lumaDiff = blendLumaMotion.x + -centerLuma;
-	// similarity = (1 - scale*diff) per channel, clamped >= 0: .x weights colour, .y the feedback luma.
+	// similarity = max(0, 1 - scale*diff) per channel: .x weights colour, .y the feedback luma.
+	// Only the diff term differs by permutation: HDR keys off the luma diff (scaled to PQ), SDR off
+	// the motion-vs-history delta.
 #	ifdef HDR_OUTPUT
-	float2 similarity;
-	{
-		float lumaDiffScaled = abs(lumaDiff) * 0.05;
-		similarity = -lumaDiffScaled.xx * kSimilarityScale + float2(1, 1);
-	}
+	float similarityDiff = abs(lumaDiff) * 0.05;
 #	else
-	float2 similarity = -abs(motionVsHistory.xx) * kSimilarityScale + float2(1, 1);
+	float similarityDiff = abs(motionVsHistory);
 #	endif
-	similarity = max(float2(0, 0), similarity);
+	float2 similarity = max(float2(0, 0), -similarityDiff.xx * kSimilarityScale + float2(1, 1));
 	float3 targetColor = similarity.xxx * centerVsNeighbor + neighborBlend;
 	workColor = -targetColor + workColor;
 	float blendWeight = BlendParams.x + -BlendParams.y;
@@ -539,15 +537,14 @@ PS_OUTPUT main(PS_INPUT input)
 	// .x = feedback luma, .yzw = resolved colour
 	float4 resolved = allTransparent.xxxx ? float4(outputLuma, targetColor) : outPacked.xyzw;
 	colorOut.xyz = resolved.yzw;
+	float feedbackLumaOut = saturate(resolved.x * feedbackWeight);
 #	ifdef HDR_OUTPUT
-	// Encode PQ luma to game-gamma for feedback RT storage.
-	// Storing raw PQ [0,1] in a low-precision RT causes highlight banding because
-	// PQ packs high-nit values into the upper range where RT quantization is visible.
-	// Game-gamma encoding spreads precision evenly — symmetric with DecodeFeedbackLuma on read.
-	feedbackOut.x = EncodeFeedbackLuma(saturate(resolved.x * feedbackWeight));
-#	else
-	feedbackOut.x = saturate(resolved.x * feedbackWeight);
+	// Encode PQ luma to game-gamma for feedback RT storage: raw PQ in a low-precision RT bands in
+	// highlights (PQ packs high-nit values where quantization shows); game-gamma spreads precision
+	// evenly — symmetric with DecodeFeedbackLuma on read.
+	feedbackLumaOut = EncodeFeedbackLuma(feedbackLumaOut);
 #	endif
+	feedbackOut.x = feedbackLumaOut;
 	// Vanilla writes opaque alpha unconditionally on both SE and VR (decompile o0.w = 1).
 	colorOut.w = 1;
 	feedbackOut.w = 1;

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -352,12 +352,11 @@ PS_OUTPUT main(PS_INPUT input)
 	// Bracket ceiling: 1.001 is just above the maximum PQ value (1.0 = 10000 nits).
 	// Nothing in the scene exceeds this, so the ceiling works correctly in PQ working space.
 	// (In linear BT2020 this would be wrong — sky/specular exceed 1.0 linear — but PQ is bounded.)
-	bracketMax.y = cmp(centerLuma < kMaxLumaCap);
-	bracketMax.yzw = bracketMax.yyy ? centerMeta.yzx : kMaxLumaCap.xxx;
-	bracketMax.yzw = bracketMax.xxx ? kMaxLumaCap.xxx : bracketMax.yzw;
-
-	// First (tapC1) fold into the max bracket — same merge as the cascade below, gated by belowHistC1.
-	bracketMax.yzw = MergeLumaBracket(tapC1, bracketMax.yzw, center.x);
+	// Seed the min bracket: centre colour (as R,B,luma) clamped to the 1.001 ceiling; if the centre is
+	// below history (bracketMax.x = belowHistCentre), start at the ceiling. Then fold tapC1 (its belowHist).
+	float3 minBracket = cmp(centerLuma < kMaxLumaCap) ? centerMeta.yzx : kMaxLumaCap.xxx;
+	minBracket = bracketMax.x ? kMaxLumaCap.xxx : minBracket;
+	minBracket = MergeLumaBracket(tapC1, minBracket, center.x);
 
 	// --- neighborhood min/max color bracket ---
 	// 4-tap weighted neighbour colour (C + D + L + LD); consumed by the non-reject output path.
@@ -367,12 +366,12 @@ PS_OUTPUT main(PS_INPUT input)
 	neighborColor = centerColor * NeighborWeights.xxx + neighborColor;
 	// Running min-luma colour bracket folded over the neighbourhood taps, each committed unless its
 	// belowHist gate is set (see MergeLumaBracket). The final tap lands in mergeScratch.yzw.
-	bracketMax.yzw = MergeLumaBracket(tapC0, bracketMax.yzw, tapB0.x);
-	bracketMax.yzw = MergeLumaBracket(tapB1, bracketMax.yzw, tapA1.x);
-	bracketMax.yzw = MergeLumaBracket(tapB0, bracketMax.yzw, tapA0.x);
-	bracketMax.yzw = MergeLumaBracket(tapA1, bracketMax.yzw, tapMin.x);
-	bracketMax.yzw = MergeLumaBracket(tapA0, bracketMax.yzw, corner.x);
-	mergeScratch.yzw = MergeLumaBracket(tapMin, bracketMax.yzw, uvMinBelowHist);
+	minBracket = MergeLumaBracket(tapC0, minBracket, tapB0.x);
+	minBracket = MergeLumaBracket(tapB1, minBracket, tapA1.x);
+	minBracket = MergeLumaBracket(tapB0, minBracket, tapA0.x);
+	minBracket = MergeLumaBracket(tapA1, minBracket, tapMin.x);
+	minBracket = MergeLumaBracket(tapA0, minBracket, corner.x);
+	mergeScratch.yzw = MergeLumaBracket(tapMin, minBracket, uvMinBelowHist);
 	// Final fold: corner tap, ungated (gate 0 → always take the lower-luma colour).
 	bracketMinReg.yzw = MergeLumaBracket(corner, mergeScratch.yzw, 0);
 	tapB1.x = cmp(kMinLumaCap < centerLuma);

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -469,29 +469,31 @@ PS_OUTPUT main(PS_INPUT input)
 	tapMin.xyz = centerColor + -corner.xyz;
 	float motionNormScale = 128 * TexelSizeParams.x;  // 128-texel span used to normalize motion length
 	float motionConfidence = saturate(motionLength / motionNormScale);
-	motionReject.x = motionConfidence + -history.w;
+	float motionVsHistory = motionConfidence + -history.w;
 	// Luma convergence decay: the *20 and *100 constants were tuned for gamma-space luma.
 	// PQ is perceptually uniform — a single linear rescale of the PQ diff is accurate
 	// across all luminance levels (unlike converting through gamma, which has a varying
 	// derivative and overcorrects at bright and dark extremes).
 	// Scale factor: 0.05 gamma ≈ 0.020 PQ at mid-scene luminance → factor ≈ 2.5.
+	// luma diff drives the history similarity weights (and the final luma fixup at blend end).
+	float lumaDiff = history.x + -centerLuma;
+	// similarity = (1 - scale*diff) per channel, clamped >= 0: .x weights colour, .y the feedback luma.
 #	ifdef HDR_OUTPUT
-	motionReject.z = history.x + -centerLuma;
+	float2 similarity;
 	{
-		float lumaDiffScaled = abs(motionReject.z) * 0.05;
-		history.xw = -lumaDiffScaled.xx * kSimilarityScale + float2(1, 1);
+		float lumaDiffScaled = abs(lumaDiff) * 0.05;
+		similarity = -lumaDiffScaled.xx * kSimilarityScale + float2(1, 1);
 	}
 #	else
-	motionReject.z = history.x + -centerLuma;
-	history.xw = -abs(motionReject.xx) * kSimilarityScale + float2(1, 1);
+	float2 similarity = -abs(motionVsHistory.xx) * kSimilarityScale + float2(1, 1);
 #	endif
-	history.xw = max(float2(0, 0), history.xw);
-	tapMin.yzw = history.xxx * tapMin.xyz + corner.xyz;
+	similarity = max(float2(0, 0), similarity);
+	tapMin.yzw = similarity.xxx * tapMin.xyz + corner.xyz;
 	sampleUV.xyw = -tapMin.yzw + sampleUV.xyw;
 	motionReject.x = BlendParams.x + -BlendParams.y;
 	motionReject.x = motionConfidence * motionReject.x + BlendParams.y;
-	motionReject.x = min(motionReject.x, history.x);
-	tapA0.y = history.w * historyBlend;
+	motionReject.x = min(motionReject.x, similarity.x);
+	tapA0.y = similarity.y * historyBlend;
 	motionReject.y = kFeedbackBlendMax + -motionReject.x;
 	motionReject.x = tapA0.y * motionReject.y + motionReject.x;
 	feedbackOut.yz = float2(tapA0.y, motionConfidence);
@@ -511,8 +513,8 @@ PS_OUTPUT main(PS_INPUT input)
 	corner.yzw = saturate(BlendParams.www * corner.xyz + sampleUV.xyw);
 #	endif
 
-	motionReject.y = motionReject.x * motionReject.z + centerLuma;
-	motionReject.x = motionReject.x * motionReject.z;
+	motionReject.y = motionReject.x * lumaDiff + centerLuma;
+	motionReject.x = motionReject.x * lumaDiff;
 	motionReject.x = cmp(abs(motionReject.x) < kLumaEpsilon);
 	corner.x = motionReject.x ? centerLuma : motionReject.y;
 	float outputLuma = dot(tapMin.zwy, kLumaWeights);

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -448,21 +448,21 @@ PS_OUTPUT main(PS_INPUT input)
 
 	// --- disocclusion / mask rejection ---
 	// motionLength holds the motion length (motionReject.zw held the reprojected UV on the SE path).
+	float reject;  // disocclusion / OOB / mask rejection flag
 #	ifdef VR
 	// VR resolves out-of-bounds per-eye in mono space; the SE stereo-space test misses the seam.
-	motionReject.z = prevUVOutOfBounds ? 1 : 0;
+	reject = prevUVOutOfBounds ? 1 : 0;
 #	else
-	sampleUV.w = min(motionReject.z, motionReject.w);
-	motionReject.zw = cmp(motionReject.zw >= float2(1, 1));
-	sampleUV.w = cmp(0 >= sampleUV.w);
-	motionReject.z = (int)motionReject.z | (int)sampleUV.w;
-	motionReject.z = (int)motionReject.w | (int)motionReject.z;
+	float2 prevUV = motionReject.zw;  // reprojected UV from the SE path
+	float uvLow = cmp(0 >= min(prevUV.x, prevUV.y));
+	float2 uvHigh = cmp(prevUV >= float2(1, 1));
+	reject = (int)uvHigh.x | (int)uvLow;
+	reject = (int)uvHigh.y | (int)reject;
 #	endif
 	history.yz = maskTex.Sample(maskSampler, sampleUV.xy).xy;
 	float centerCoverage = AlphaCoverageMask(sampleUV.xy);
-	sampleUV.x = cmp(ThresholdParams.w < history.z);
-	motionReject.z = (int)motionReject.z | (int)sampleUV.x;
-	float reject = motionReject.z;  // disocclusion / OOB / mask rejection flag
+	float maskReject = cmp(ThresholdParams.w < history.z);
+	reject = (int)reject | (int)maskReject;
 	sampleUV.xyw = reject.xxx ? centerColor : corner.xyz;
 	history.xw = reject.xx ? float2(centerLuma, 0) : history.xw;
 	corner.xyz = reject.xxx ? centerColor : neighborColor;

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -364,14 +364,16 @@ PS_OUTPUT main(PS_INPUT input)
 	neighborColor = tapB1.yxz * NeighborWeights.www + neighborColor;
 	neighborColor = tapC1.yxz * NeighborWeights.yyy + neighborColor;
 	neighborColor = centerColor * NeighborWeights.xxx + neighborColor;
+	// Shared neighbourhood fold sequence (tap + its belowHist gate), in vanilla tap order. The min and
+	// max colour brackets fold the same six taps with the same gates — only the merge rule (lower- vs
+	// higher-luma) and seed differ.
+	const float4 foldTaps[6] = { tapC0, tapB1, tapB0, tapA1, tapA0, tapMin };
+	const float foldGates[6] = { tapB0.x, tapA1.x, tapA0.x, tapMin.x, corner.x, uvMinBelowHist };
 	// Running min-luma colour bracket folded over the neighbourhood taps, each committed unless its
-	// belowHist gate is set (see MergeLumaBracket). The final tap lands in mergeScratch.yzw.
-	minBracket = MergeLumaBracket(tapC0, minBracket, tapB0.x);
-	minBracket = MergeLumaBracket(tapB1, minBracket, tapA1.x);
-	minBracket = MergeLumaBracket(tapB0, minBracket, tapA0.x);
-	minBracket = MergeLumaBracket(tapA1, minBracket, tapMin.x);
-	minBracket = MergeLumaBracket(tapA0, minBracket, corner.x);
-	mergeScratch.yzw = MergeLumaBracket(tapMin, minBracket, uvMinBelowHist);
+	// belowHist gate is set (see MergeLumaBracket). Result is the without-corner min bound.
+	[unroll] for (int fold = 0; fold < 6; fold++)
+		minBracket = MergeLumaBracket(foldTaps[fold], minBracket, foldGates[fold]);
+	mergeScratch.yzw = minBracket;
 	// Final fold: corner tap, ungated (gate 0 → always take the lower-luma colour).
 	bracketMinReg.yzw = MergeLumaBracket(corner, mergeScratch.yzw, 0);
 	// Low-clamp the (max-bracketed) tapC1 to the kMinLumaCap floor: build the centre-vs-floor bound
@@ -397,13 +399,10 @@ PS_OUTPUT main(PS_INPUT input)
 	// Running max folded over the taps, each committed when its belowHist gate is set (see
 	// MergeMaxBracket — gate is inverted vs the min fold). Seed = the clamped centre/C1 colour;
 	// result handed back to tapA0.yzw for the bespoke min/max-select tail below.
+	// Same six folds as the min bracket (foldTaps/foldGates), max rule, seeded from the low-clamped C1.
 	float3 maxBracket = tapC1.xyz;
-	maxBracket = MergeMaxBracket(tapC0, maxBracket, tapB0.x);
-	maxBracket = MergeMaxBracket(tapB1, maxBracket, tapA1.x);
-	maxBracket = MergeMaxBracket(tapB0, maxBracket, tapA0.x);
-	maxBracket = MergeMaxBracket(tapA1, maxBracket, tapMin.x);
-	maxBracket = MergeMaxBracket(tapA0, maxBracket, corner.x);
-	maxBracket = MergeMaxBracket(tapMin, maxBracket, uvMinBelowHist);
+	[unroll] for (int maxFold = 0; maxFold < 6; maxFold++)
+		maxBracket = MergeMaxBracket(foldTaps[maxFold], maxBracket, foldGates[maxFold]);
 	// Complete the max bracket (ungated corner fold), then select the neighbourhood AABB bounds for
 	// history clamping. motionReject.y toggles whether the corner tap is included: when set, max uses
 	// the with-corner bracket and min the without-corner one (opposite when clear). Packed into

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -283,9 +283,9 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 colorOut, feedbackOut;
 
 	// float4 packs — component reuse matches vanilla decompile (see header comment).
-	float4 motionReject, history, corner, tapMin;     // was r0–r4
-	float4 tapA0, tapA1, tapB0, tapB1, tapC0, tapC1;  // was r6–r13
-	float belowHistC1;                                // C1 tap below-history mask (was center.x, r14)
+	float4 motionReject, history, corner, tapMin;     // decompile r0–r4
+	float4 tapA0, tapA1, tapB0, tapB1, tapC0, tapC1;  // decompile r6–r13
+	float belowHistC1;                                // C1 tap below-history mask (decompile r14.x)
 
 	float2 drMax = GetDynamicResolutionMax(), drUVMin, drUVMax, drCenter;
 	float4 drNeighborsA, drNeighborsB, drNeighborsC;
@@ -342,7 +342,7 @@ PS_OUTPUT main(PS_INPUT input)
 	AssignPackedNeighbor(drNeighborsC.zw, history.x, tapC1, belowHistC1);
 	float3 centerColor = SampleCenterRGB(drCenter);  // centre RGB (belowHistC1 holds the C1 mask)
 
-	// --- centre bracket seed, neighbourhood bracket, flicker, temporal blend (verbatim math) ---
+	// --- centre bracket seed, neighbourhood bracket, flicker, temporal blend ---
 	float centerLuma = dot(centerColor.yzx, kLumaWeights);
 	float belowHistCentre = cmp(centerLuma < history.x);
 	// Centre colour packed as (R, B, luma) — the bracket seeds clamp this against the luma caps.
@@ -394,10 +394,9 @@ PS_OUTPUT main(PS_INPUT input)
 	float fcCorner = FlickerLumaContribution(centerLuma, corner.w);
 
 	// --- neighbourhood MAX-luma colour bracket (complement to the min bracket above) ---
-	// Running max folded over the taps, each committed when its belowHist gate is set (see
-	// MergeMaxBracket — gate is inverted vs the min fold). Seed = the clamped centre/C1 colour;
-	// result handed back to tapA0.yzw for the bespoke min/max-select tail below.
-	// Same six folds as the min bracket (foldTaps/foldGates), max rule, seeded from the low-clamped C1.
+	// Same six folds as the min bracket (foldTaps/foldGates), but the max rule commits a tap when its
+	// belowHist gate is SET — inverted vs the min fold (see MergeMaxBracket). Seeded from the
+	// low-clamped C1 colour.
 	float3 maxBracket = tapC1.xyz;
 	[unroll] for (int maxFold = 0; maxFold < 6; maxFold++)
 		maxBracket = MergeMaxBracket(foldTaps[maxFold], maxBracket, foldGates[maxFold]);
@@ -442,7 +441,6 @@ PS_OUTPUT main(PS_INPUT input)
 	corner.xyz = lerp(rectifyLo, rectifyHi, history.yyy);
 
 	// --- disocclusion / mask rejection ---
-	// motionLength holds the motion length (motionReject.zw held the reprojected UV on the SE path).
 	float reject;  // disocclusion / OOB / mask rejection flag
 #	ifdef VR
 	// VR resolves out-of-bounds per-eye in mono space; the SE stereo-space test misses the seam.

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -295,7 +295,7 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 colorOut, feedbackOut;
 
 	// float4 packs — component reuse matches vanilla decompile (see header comment).
-	float4 motionReject, history, corner, tapMin;  // decompile r0–r4 (tapMin = history UV here)
+	float4 motionReject, history, corner;  // decompile r0–r4
 
 	float2 drMax = GetDynamicResolutionMax(), drUVMin, drUVMax, drCenter;
 	float4 drNeighborsA, drNeighborsB, drNeighborsC;
@@ -316,9 +316,9 @@ PS_OUTPUT main(PS_INPUT input)
 	// Reproject history: VR sets prevUVOutOfBounds (feeds reject); SE writes the raw reprojected UV
 	// into motionReject.zw (the SE disocclusion test reads it later).
 	bool prevUVOutOfBounds;
-	tapMin.xy = ReprojectHistoryUV(texCoord.xy, motionReject.xy, prevUVOutOfBounds, motionReject.zw);
+	float2 historyUV = ReprojectHistoryUV(texCoord.xy, motionReject.xy, prevUVOutOfBounds, motionReject.zw);
 	float motionLength = sqrt(dot(motionReject.xy, motionReject.xy));
-	history.xyw = historyTex.Sample(historySampler, tapMin.xy).xyz;
+	history.xyw = historyTex.Sample(historySampler, historyUV).xyz;
 #	ifdef HDR_OUTPUT
 	// history.x is stored as game-gamma luma (see EncodeFeedbackLuma on write).
 	// Decode to PQ luma to match the working space of all neighbour taps.
@@ -437,7 +437,7 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 rectifyLo = clampToNeighborhood.xxx ? clipPick.xyz : clipHi.xyz;
 	float3 rectifyHi = clampToNeighborhood.xxx ? clipFinal.xyz : clipLo.xyz;
 	// Rectified colour: lerp from the low candidate toward the high one by the clip ratio (history.y).
-	corner.xyz = lerp(rectifyLo, rectifyHi, history.yyy);
+	float3 rectifiedColor = lerp(rectifyLo, rectifyHi, history.yyy);
 
 	// --- disocclusion / mask rejection ---
 	float reject;  // disocclusion / OOB / mask rejection flag
@@ -457,7 +457,7 @@ PS_OUTPUT main(PS_INPUT input)
 	reject = (int)reject | (int)maskReject;
 	// Two colour candidates: the rectified history colour and the neighbourhood-weighted colour
 	// (both collapse to the centre tap when the pixel is rejected).
-	float3 workColor = reject.xxx ? centerColor : corner.xyz;  // history/rectified colour, evolves below
+	float3 workColor = reject.xxx ? centerColor : rectifiedColor;  // history/rectified colour, evolves below
 	history.xw = reject.xx ? float2(centerLuma, 0) : history.xw;
 	float3 neighborBlend = reject.xxx ? centerColor : neighborColor;
 	float3 centerVsNeighbor = centerColor + -neighborBlend;

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -408,8 +408,8 @@ PS_OUTPUT main(PS_INPUT input)
 	maxBracket = MergeMaxBracket(tapMin, maxBracket, uvMinBelowHist);
 	tapA0.yzw = maxBracket;
 	bracketMinReg.x = tapA0.z;
-	tapMin.y = cmp(tapA0.w < corner.w);
-	tapMin.yzw = tapMin.yyy ? corner.yzw : tapA0.yzw;
+	// Final ungated corner fold completes the max bracket (gate 1 -> always take the brighter pick).
+	tapMin.yzw = MergeMaxBracket(corner, maxBracket, 1);
 	tapC0.xw = motionReject.yy ? tapMin.yw : tapA0.yw;
 	mergeScratch.x = tapMin.z;
 	tapC1.xyzw = motionReject.yyyy ? mergeScratch.xyzw : bracketMinReg.xyzw;

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -188,6 +188,16 @@ float3 MergeLumaBracket(float4 tap, float3 bracket, float gate)
 	return gate ? bracket : cand;
 }
 
+// MAX-luma counterpart: commit the tap's colour when it is BRIGHTER than the running bracket.
+// NOTE the gate is INVERTED vs MergeLumaBracket — the decompile's max pass commits the new pick
+// when the belowHist gate is SET (gate ? cand : bracket), the opposite of the min pass. (Getting
+// this backwards reads EQUIVALENT on a static menu but diverges under motion.)
+float3 MergeMaxBracket(float4 tap, float3 bracket, float gate)
+{
+	float3 cand = cmp(bracket.z < tap.w) ? tap.yzw : bracket;
+	return gate ? cand : bracket;
+}
+
 // RCAS-style sharpen delta: 2 * (center - 0.25*a - 0.25*b), in the decompile's exact op order.
 float SharpenDelta(float center, float a, float b)
 {
@@ -385,26 +395,18 @@ PS_OUTPUT main(PS_INPUT input)
 	float fcMin = FlickerLumaContribution(centerLuma, tapMin.w);
 	float fcCorner = FlickerLumaContribution(centerLuma, corner.w);
 
-	// --- min-luma colour sort: bubble the lowest-luma neighbour colour through the tap chain,
-	// gated per step by the belowHist masks (.x slots). Irreducible decompile packing — left as-is.
-	tapC0.x = cmp(tapC1.z < tapC0.w);
-	tapC0.xyz = tapC0.xxx ? tapC0.yzw : tapC1.xyz;
-	tapC0.xyz = tapB0.xxx ? tapC0.xyz : tapC1.xyz;
-	tapC0.w = cmp(tapC0.z < tapB1.w);
-	tapC1.xyz = tapC0.www ? tapB1.yzw : tapC0.xyz;
-	tapC0.xyz = tapA1.xxx ? tapC1.xyz : tapC0.xyz;
-	tapB1.y = cmp(tapC0.z < tapB0.w);
-	tapB1.yzw = tapB1.yyy ? tapB0.yzw : tapC0.xyz;
-	tapB1.yzw = tapA0.xxx ? tapB1.yzw : tapC0.xyz;
-	tapB0.y = cmp(tapB1.w < tapA1.w);
-	tapB0.yzw = tapB0.yyy ? tapA1.yzw : tapB1.yzw;
-	tapB0.yzw = tapMin.xxx ? tapB0.yzw : tapB1.yzw;
-	tapA1.y = cmp(tapB0.w < tapA0.w);
-	tapA1.yzw = tapA1.yyy ? tapA0.yzw : tapB0.yzw;
-	tapA1.yzw = corner.xxx ? tapA1.yzw : tapB0.yzw;
-	tapA0.y = cmp(tapA1.w < tapMin.w);
-	tapA0.yzw = tapA0.yyy ? tapMin.yzw : tapA1.yzw;
-	tapA0.yzw = uvMinBelowHist.xxx ? tapA0.yzw : tapA1.yzw;
+	// --- neighbourhood MAX-luma colour bracket (complement to the min bracket above) ---
+	// Running max folded over the taps, each committed when its belowHist gate is set (see
+	// MergeMaxBracket — gate is inverted vs the min fold). Seed = the clamped centre/C1 colour;
+	// result handed back to tapA0.yzw for the bespoke min/max-select tail below.
+	float3 maxBracket = tapC1.xyz;
+	maxBracket = MergeMaxBracket(tapC0, maxBracket, tapB0.x);
+	maxBracket = MergeMaxBracket(tapB1, maxBracket, tapA1.x);
+	maxBracket = MergeMaxBracket(tapB0, maxBracket, tapA0.x);
+	maxBracket = MergeMaxBracket(tapA1, maxBracket, tapMin.x);
+	maxBracket = MergeMaxBracket(tapA0, maxBracket, corner.x);
+	maxBracket = MergeMaxBracket(tapMin, maxBracket, uvMinBelowHist);
+	tapA0.yzw = maxBracket;
 	bracketMinReg.x = tapA0.z;
 	tapMin.y = cmp(tapA0.w < corner.w);
 	tapMin.yzw = tapMin.yyy ? corner.yzw : tapA0.yzw;

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -86,9 +86,10 @@ static const float kFlickerThreshold = 0.200000003;       // luma-spread below t
 
 /*
  * Channel layout (vanilla decompile — swizzles are load-bearing):
- * - Neighbour taps: .yxz sample; luma via dot(.xzy, kLumaWeights); stored as float4(.xyz=GRB, .w=luma).
- * - centre: centerColor float3 = RGB; belowHistC1 scalar = C1 mask; luma via dot(centerColor.yzx, kLumaWeights).
- * - corner: float4 .xyz=corner GRB, .w=corner luma (depth-guided); .x reused for belowHistA0 mask.
+ * - Neighbour taps: .yxz sample; luma via dot(.xzy, kLumaWeights); stored as float4(.xyz=GRB, .w=luma)
+ *   in neighbors[0..6] (uvMin,A0,A1,B0,B1,C0,C1), with masks in neighborBelowHist[].
+ * - centre: centerColor float3 = RGB; luma via dot(centerColor.yzx, kLumaWeights).
+ * - corner: float4 .xyz=corner GRB, .w=corner luma (depth-guided).
  * - Bracket colours (float3): (R, B, luma) with .z = luma — see MergeLumaBracket/MergeMaxBracket.
  * - Output colour lives in .yzw (vanilla r3.yzw after blend; resolved/outPacked .yzw), not .xyz.
  *
@@ -301,9 +302,7 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 colorOut, feedbackOut;
 
 	// float4 packs — component reuse matches vanilla decompile (see header comment).
-	float4 motionReject, history, corner, tapMin;     // decompile r0–r4
-	float4 tapA0, tapA1, tapB0, tapB1, tapC0, tapC1;  // decompile r6–r13
-	float belowHistC1;                                // C1 tap below-history mask (decompile r14.x)
+	float4 motionReject, history, corner, tapMin;  // decompile r0–r4 (tapMin = history UV here)
 
 	float2 drMax = GetDynamicResolutionMax(), drUVMin, drUVMax, drCenter;
 	float4 drNeighborsA, drNeighborsB, drNeighborsC;
@@ -337,22 +336,28 @@ PS_OUTPUT main(PS_INPUT input)
 	float cornerBelowHist = cmp(corner.w < history.x);  // toggles corner-tap inclusion in the AABB
 
 	// --- neighbour colour / luma samples ---
-	float uvMinCoverage;   // uvMin alpha coverage; seeds the allTransparent test far below
-	float uvMinBelowHist;  // uvMin tap below-history mask; consumed in the bracket/flicker cascade
+	// Sample the 9-tap neighbourhood (packed GRB.xyz + luma.w) plus each tap's below-history mask,
+	// in the vanilla sample order so behaviour is bit-exact. Index map (also used by the brackets
+	// and flicker below): [0]=uvMin, [1]=A0, [2]=A1, [3]=B0, [4]=B1, [5]=C0, [6]=C1. The decompile
+	// scattered the masks through reused .x slots; here they live in a parallel array.
+	const float2 neighborUVs[7] = {
+		drUVMin, drNeighborsA.xy, drNeighborsA.zw, drNeighborsB.xy, drNeighborsB.zw, drNeighborsC.xy, drNeighborsC.zw
+	};
+	float4 neighbors[7];
+	float neighborBelowHist[7];
 	{
 		ISTAA_NeighborTap tap = SampleNeighborGRB(drUVMin, history.x);
-		tapMin.xyz = tap.grb;
-		uvMinCoverage = AlphaCoverageMask(drUVMin);
-		tapMin.w = tap.luma;
-		uvMinBelowHist = tap.belowHist;
+		neighbors[0] = PackNeighborTap(tap);
+		neighborBelowHist[0] = tap.belowHist;
 	}
-	AssignPackedNeighbor(drNeighborsA.xy, history.x, tapA0, corner.x);
-	AssignPackedNeighbor(drNeighborsA.zw, history.x, tapA1, tapMin.x);
-	AssignPackedNeighbor(drNeighborsB.xy, history.x, tapB0, tapA0.x);
-	AssignPackedNeighbor(drNeighborsB.zw, history.x, tapB1, tapA1.x);
-	AssignPackedNeighbor(drNeighborsC.xy, history.x, tapC0, tapB0.x);
-	AssignPackedNeighbor(drNeighborsC.zw, history.x, tapC1, belowHistC1);
-	float3 centerColor = SampleCenterRGB(drCenter);  // centre RGB (belowHistC1 holds the C1 mask)
+	float uvMinCoverage = AlphaCoverageMask(drUVMin);  // seeds the allTransparent test far below
+	[unroll] for (int n = 1; n < 7; n++)
+	{
+		ISTAA_NeighborTap tap = SampleNeighborGRB(neighborUVs[n], history.x);
+		neighbors[n] = PackNeighborTap(tap);
+		neighborBelowHist[n] = tap.belowHist;
+	}
+	float3 centerColor = SampleCenterRGB(drCenter);  // centre RGB
 
 	// --- centre bracket seed, neighbourhood bracket, flicker, temporal blend ---
 	float centerLuma = dot(centerColor.yzx, kLumaWeights);
@@ -363,52 +368,48 @@ PS_OUTPUT main(PS_INPUT input)
 	// Nothing in the scene exceeds this, so the ceiling works correctly in PQ working space.
 	// (In linear BT2020 this would be wrong — sky/specular exceed 1.0 linear — but PQ is bounded.)
 	// Seed the min bracket: centre colour (as R,B,luma) clamped to the 1.001 ceiling; if the centre is
-	// below history (belowHistCentre), start at the ceiling. Then fold tapC1 (its belowHist).
+	// below history (belowHistCentre), start at the ceiling. Then fold C1 (neighbors[6]).
 	float3 minBracket = cmp(centerLuma < kMaxLumaCap) ? centerRBL : kMaxLumaCap.xxx;
 	minBracket = belowHistCentre ? kMaxLumaCap.xxx : minBracket;
-	minBracket = MergeLumaBracket(tapC1, minBracket, belowHistC1);
+	minBracket = MergeLumaBracket(neighbors[6], minBracket, neighborBelowHist[6]);
 
 	// --- neighborhood min/max color bracket ---
 	// 4-tap weighted neighbour colour (C + D + L + LD); consumed by the non-reject output path.
-	float3 neighborColor = NeighborWeights.zzz * tapC0.yxz;
-	neighborColor = tapB1.yxz * NeighborWeights.www + neighborColor;
-	neighborColor = tapC1.yxz * NeighborWeights.yyy + neighborColor;
+	float3 neighborColor = NeighborWeights.zzz * neighbors[5].yxz;           // C0
+	neighborColor = neighbors[4].yxz * NeighborWeights.www + neighborColor;  // B1
+	neighborColor = neighbors[6].yxz * NeighborWeights.yyy + neighborColor;  // C1
 	neighborColor = centerColor * NeighborWeights.xxx + neighborColor;
-	// Shared neighbourhood fold sequence (tap + its belowHist gate), in vanilla tap order. The min and
-	// max colour brackets fold the same six taps with the same gates — only the merge rule (lower- vs
-	// higher-luma) and seed differ.
-	const float4 foldTaps[6] = { tapC0, tapB1, tapB0, tapA1, tapA0, tapMin };
-	const float foldGates[6] = { tapB0.x, tapA1.x, tapA0.x, tapMin.x, corner.x, uvMinBelowHist };
-	// Running min-luma colour bracket folded over the neighbourhood taps, each committed unless its
-	// belowHist gate is set (see MergeLumaBracket). Result is the without-corner min bound.
-	[unroll] for (int fold = 0; fold < 6; fold++)
-		minBracket = MergeLumaBracket(foldTaps[fold], minBracket, foldGates[fold]);
+	// Both the min and max colour brackets fold the same six taps in vanilla order — C0,B1,B0,A1,A0,
+	// uvMin = neighbors[5..0] — gated by each tap's belowHist; only the merge rule and seed differ.
+	// Running min-luma bracket: each tap committed unless its gate is set (see MergeLumaBracket).
+	[unroll] for (int fold = 5; fold >= 0; fold--)
+		minBracket = MergeLumaBracket(neighbors[fold], minBracket, neighborBelowHist[fold]);
 	float3 minBoundNoCorner = minBracket;
 	// Final fold: corner tap, ungated (gate 0 → always take the lower-luma colour).
 	float3 minBoundWithCorner = MergeLumaBracket(corner, minBoundNoCorner, 0);
-	// Low-clamp the (max-bracketed) tapC1 to the kMinLumaCap floor: build the centre-vs-floor bound
-	// (gated by belowHistCentre), then fold tapC1 toward it (MergeMaxBracket, gated by tapC1's belowHist).
+	// Low-clamp the (max-bracketed) C1 tap to the kMinLumaCap floor: build the centre-vs-floor bound
+	// (gated by belowHistCentre), then fold C1 toward it (MergeMaxBracket, gated by C1's belowHist).
 	float3 lowClamp = cmp(kMinLumaCap < centerLuma) ? centerRBL : kMinLumaCap.xxx;
 	lowClamp = belowHistCentre ? lowClamp : kMinLumaCap.xxx;
-	tapC1.xyz = MergeMaxBracket(tapC1, lowClamp, belowHistC1);
+	neighbors[6].xyz = MergeMaxBracket(neighbors[6], lowClamp, neighborBelowHist[6]);
 
 	// --- flicker score: 4 minus one integer contribution per neighbourhood tap ---
 	// Each contribution reads a tap's ORIGINAL .w luma; the colour sort below only mutates .w/.yzw
 	// after this, so computing them here is behaviour-preserving. The sum is order-independent (each
 	// contribution is a ceil() integer); tap order matches the original 8-term sum.
-	const float4 flickerTaps[8] = { corner, tapMin, tapA0, tapA1, tapB0, tapB1, tapC0, tapC1 };
+	const float4 flickerTaps[8] = { corner, neighbors[0], neighbors[1], neighbors[2], neighbors[3], neighbors[4], neighbors[5], neighbors[6] };
 	float flickerScore = 4;
 	[unroll] for (int flick = 0; flick < 8; flick++)
 		flickerScore -= FlickerLumaContribution(centerLuma, flickerTaps[flick].w);
 	flickerScore = saturate(flickerScore);
 
 	// --- neighbourhood MAX-luma colour bracket (complement to the min bracket above) ---
-	// Same six folds as the min bracket (foldTaps/foldGates), but the max rule commits a tap when its
+	// Same six taps/order as the min fold (neighbors[5..0]), but the max rule commits a tap when its
 	// belowHist gate is SET — inverted vs the min fold (see MergeMaxBracket). Seeded from the
 	// low-clamped C1 colour.
-	float3 maxBracket = tapC1.xyz;
-	[unroll] for (int maxFold = 0; maxFold < 6; maxFold++)
-		maxBracket = MergeMaxBracket(foldTaps[maxFold], maxBracket, foldGates[maxFold]);
+	float3 maxBracket = neighbors[6].xyz;
+	[unroll] for (int maxFold = 5; maxFold >= 0; maxFold--)
+		maxBracket = MergeMaxBracket(neighbors[maxFold], maxBracket, neighborBelowHist[maxFold]);
 	// Complete the max bracket (ungated corner fold), then select the neighbourhood AABB bounds for
 	// history clamping. cornerBelowHist toggles whether the corner tap is included: when set, max uses
 	// the with-corner bracket and min the without-corner one (opposite when clear).

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -451,8 +451,8 @@ PS_OUTPUT main(PS_INPUT input)
 	history.y = corner.w ? history.y : 0.5;
 	tapMin.xyz = clampToNeighborhood.xxx ? tapMin.xyz : tapC0.xyz;
 	corner.xyz = clampToNeighborhood.xxx ? tapA0.xyz : corner.xyz;
-	corner.xyz = corner.xyz + -tapMin.xyz;
-	corner.xyz = history.yyy * corner.xyz + tapMin.xyz;
+	// Rectified colour: lerp from the low candidate toward the high one by the clip ratio (history.y).
+	corner.xyz = lerp(tapMin.xyz, corner.xyz, history.yyy);
 
 	// --- disocclusion / mask rejection ---
 	// motionLength holds the motion length (motionReject.zw held the reprojected UV on the SE path).

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -346,9 +346,8 @@ PS_OUTPUT main(PS_INPUT input)
 	bracketMax.yzw = bracketMax.yyy ? centerMeta.yzx : kMaxLumaCap.xxx;
 	bracketMax.yzw = bracketMax.xxx ? kMaxLumaCap.xxx : bracketMax.yzw;
 
-	weightedColor.x = cmp(tapC1.w < bracketMax.w);
-	weightedColor.xyz = weightedColor.xxx ? tapC1.yzw : bracketMax.yzw;
-	bracketMax.yzw = center.xxx ? bracketMax.yzw : weightedColor.xyz;
+	// First (tapC1) fold into the max bracket — same merge as the cascade below, gated by belowHistC1.
+	bracketMax.yzw = MergeLumaBracket(tapC1, bracketMax.yzw, center.x);
 
 	// --- neighborhood min/max color bracket ---
 	// 4-tap weighted neighbour colour (C + D + L + LD); consumed by the non-reject output path.

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -282,9 +282,9 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 colorOut, feedbackOut;
 
 	// float4 packs — component reuse matches vanilla decompile (see header comment).
-	float4 motionReject, sampleUV, history, corner, tapMin;  // was r0–r4
-	float4 tapA0, tapA1, tapB0, tapB1, tapC0, tapC1;         // was r6–r13
-	float belowHistC1;                                       // C1 tap below-history mask (was center.x, r14)
+	float4 motionReject, history, corner, tapMin;     // was r0–r4
+	float4 tapA0, tapA1, tapB0, tapB1, tapC0, tapC1;  // was r6–r13
+	float belowHistC1;                                // C1 tap below-history mask (was center.x, r14)
 
 	float2 drMax = GetDynamicResolutionMax(), drUVMin, drUVMax, drCenter;
 	float4 drNeighborsA, drNeighborsB, drNeighborsC;
@@ -301,8 +301,7 @@ PS_OUTPUT main(PS_INPUT input)
 		corner.xyz);
 
 	// --- motion vector and history sample ---
-	history.xy = drMax;
-	motionReject.xy = velocityTex.Sample(velocitySampler, ClampScreenUV(motionReject.xy, history.xy)).xy;
+	motionReject.xy = velocityTex.Sample(velocitySampler, ClampScreenUV(motionReject.xy, drMax)).xy;
 #	ifdef VR
 	// Eyes share one RT in VR; reproject within the current eye (mono-space velocity, per-eye
 	// clamp) so a pixel near the x=0.5 seam never samples the other eye's history. OOB feeds reject.
@@ -325,14 +324,12 @@ PS_OUTPUT main(PS_INPUT input)
 	motionReject.y = cmp(corner.w < history.x);
 
 	// --- neighbour colour / luma samples ---
-	sampleUV.zw = drUVMin;
-	sampleUV.xy = drCenter;
 	float uvMinCoverage;   // uvMin alpha coverage; seeds the allTransparent test far below
 	float uvMinBelowHist;  // uvMin tap below-history mask; consumed in the bracket/flicker cascade
 	{
-		ISTAA_NeighborTap tap = SampleNeighborGRB(sampleUV.zw, history.x);
+		ISTAA_NeighborTap tap = SampleNeighborGRB(drUVMin, history.x);
 		tapMin.xyz = tap.grb;
-		uvMinCoverage = AlphaCoverageMask(sampleUV.zw);
+		uvMinCoverage = AlphaCoverageMask(drUVMin);
 		tapMin.w = tap.luma;
 		uvMinBelowHist = tap.belowHist;
 	}
@@ -342,7 +339,7 @@ PS_OUTPUT main(PS_INPUT input)
 	AssignPackedNeighbor(drNeighborsB.zw, history.x, tapB1, tapA1.x);
 	AssignPackedNeighbor(drNeighborsC.xy, history.x, tapC0, tapB0.x);
 	AssignPackedNeighbor(drNeighborsC.zw, history.x, tapC1, belowHistC1);
-	float3 centerColor = SampleCenterRGB(sampleUV.xy);  // centre RGB (belowHistC1 holds the C1 mask)
+	float3 centerColor = SampleCenterRGB(drCenter);  // centre RGB (belowHistC1 holds the C1 mask)
 
 	// --- centre bracket seed, neighbourhood bracket, flicker, temporal blend (verbatim math) ---
 	float centerLuma = dot(centerColor.yzx, kLumaWeights);
@@ -433,8 +430,8 @@ PS_OUTPUT main(PS_INPUT input)
 	// Clamp history luma into the candidates' luma range: (clamped, lo, hi).
 	float3 clampedHistory = float3(clamp(history.x, clipPick.w, clipFinal.w), clipPick.w, clipFinal.w);
 	float3 historyLumaPack = float3(history.x, clipHi.w, clipLo.w);  // (history luma, max luma, min luma)
-	sampleUV.w = kHistoryLumaDecay * history.y;
-	float historyBlend = saturate(flickerScore * 0.25 + sampleUV.w);
+	float historyMotionDecay = kHistoryLumaDecay * history.y;
+	float historyBlend = saturate(flickerScore * 0.25 + historyMotionDecay);
 	float clampToNeighborhood = cmp(historyBlend < kHistoryBlendThreshold);
 	history.xyz = clampToNeighborhood.xxx ? clampedHistory : historyLumaPack;
 	// Clip ratio: where the selected candidate's luma sits within its [lo, hi] range
@@ -459,8 +456,8 @@ PS_OUTPUT main(PS_INPUT input)
 	reject = (int)uvHigh.x | (int)uvLow;
 	reject = (int)uvHigh.y | (int)reject;
 #	endif
-	float2 maskValues = maskTex.Sample(maskSampler, sampleUV.xy).xy;  // .x depth-mask, .y coverage
-	float centerCoverage = AlphaCoverageMask(sampleUV.xy);
+	float2 maskValues = maskTex.Sample(maskSampler, drCenter).xy;  // .x depth-mask, .y coverage
+	float centerCoverage = AlphaCoverageMask(drCenter);
 	float maskReject = cmp(ThresholdParams.w < maskValues.y);
 	reject = (int)reject | (int)maskReject;
 	// Two colour candidates: the rectified history colour and the neighbourhood-weighted colour

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -282,9 +282,9 @@ PS_OUTPUT main(PS_INPUT input)
 	float4 colorOut, feedbackOut;
 
 	// float4 packs — component reuse matches vanilla decompile (see header comment).
-	float4 motionReject, sampleUV, history, corner, tapMin;                             // was r0–r4
-	float4 tapA0, tapA1, tapB0, tapB1, tapC0, tapC1;                                    // was r6–r13
-	float4 center, centerMeta, bracketMax, weightedColor, mergeScratch, bracketMinReg;  // was r14–r19
+	float4 motionReject, sampleUV, history, corner, tapMin;                 // was r0–r4
+	float4 tapA0, tapA1, tapB0, tapB1, tapC0, tapC1;                        // was r6–r13
+	float4 center, centerMeta, weightedColor, mergeScratch, bracketMinReg;  // was r14–r19
 
 	float2 drMax = GetDynamicResolutionMax(), drUVMin, drUVMax, drCenter;
 	float4 drNeighborsA, drNeighborsB, drNeighborsC;
@@ -347,15 +347,15 @@ PS_OUTPUT main(PS_INPUT input)
 	// --- centre bracket seed, neighbourhood bracket, flicker, temporal blend (verbatim math) ---
 	float centerLuma = dot(centerColor.yzx, kLumaWeights);
 	centerMeta.x = centerLuma;  // .yzx swizzle in the bracket cascade still reads this slot
-	bracketMax.x = cmp(centerLuma < history.x);
+	float belowHistCentre = cmp(centerLuma < history.x);
 	centerMeta.yz = centerColor.xz;
 	// Bracket ceiling: 1.001 is just above the maximum PQ value (1.0 = 10000 nits).
 	// Nothing in the scene exceeds this, so the ceiling works correctly in PQ working space.
 	// (In linear BT2020 this would be wrong — sky/specular exceed 1.0 linear — but PQ is bounded.)
 	// Seed the min bracket: centre colour (as R,B,luma) clamped to the 1.001 ceiling; if the centre is
-	// below history (bracketMax.x = belowHistCentre), start at the ceiling. Then fold tapC1 (its belowHist).
+	// below history (belowHistCentre), start at the ceiling. Then fold tapC1 (its belowHist).
 	float3 minBracket = cmp(centerLuma < kMaxLumaCap) ? centerMeta.yzx : kMaxLumaCap.xxx;
-	minBracket = bracketMax.x ? kMaxLumaCap.xxx : minBracket;
+	minBracket = belowHistCentre ? kMaxLumaCap.xxx : minBracket;
 	minBracket = MergeLumaBracket(tapC1, minBracket, center.x);
 
 	// --- neighborhood min/max color bracket ---
@@ -377,7 +377,7 @@ PS_OUTPUT main(PS_INPUT input)
 	// Low-clamp the (max-bracketed) tapC1 to the kMinLumaCap floor: build the centre-vs-floor bound
 	// (gated by belowHistCentre), then fold tapC1 toward it (MergeMaxBracket, gated by tapC1's belowHist).
 	float3 lowClamp = cmp(kMinLumaCap < centerLuma) ? centerMeta.yzx : kMinLumaCap.xxx;
-	lowClamp = bracketMax.x ? lowClamp : kMinLumaCap.xxx;
+	lowClamp = belowHistCentre ? lowClamp : kMinLumaCap.xxx;
 	tapC1.xyz = MergeMaxBracket(tapC1, lowClamp, center.x);
 
 	// --- flicker contributions, one per neighbourhood tap ---

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -276,6 +276,24 @@ float2 SelectDepthGuidedUV(
 	return selectedUV;
 }
 
+// Reproject the history-sample UV from velocity. VR reprojects within the current eye (mono-space
+// velocity, per-eye clamp; see Stereo::ApplyVelocityToUV) so a pixel near the x=0.5 seam never
+// samples the other eye's history, and reports out-of-bounds via `outOfBounds`. SE adds velocity in
+// screen space and returns the raw reprojected UV in `rawReprojUV` (the SE disocclusion test reads
+// it later). Both paths write both out-params.
+float2 ReprojectHistoryUV(float2 texCoord, float2 velocity, out bool outOfBounds, out float2 rawReprojUV)
+{
+#	ifdef VR
+	float2 prevUV = Stereo::ApplyVelocityToUV(texCoord, velocity, outOfBounds);
+	rawReprojUV = prevUV;
+	return FrameBuffer::GetPreviousDynamicResolutionAdjustedScreenPosition(prevUV);
+#	else
+	rawReprojUV = texCoord + velocity;
+	outOfBounds = false;
+	return ClampHistoryUV(rawReprojUV);
+#	endif
+}
+
 PS_OUTPUT main(PS_INPUT input)
 {
 	PS_OUTPUT psout;
@@ -303,16 +321,10 @@ PS_OUTPUT main(PS_INPUT input)
 
 	// --- motion vector and history sample ---
 	motionReject.xy = velocityTex.Sample(velocitySampler, ClampScreenUV(motionReject.xy, drMax)).xy;
-#	ifdef VR
-	// Eyes share one RT in VR; reproject within the current eye (mono-space velocity, per-eye
-	// clamp) so a pixel near the x=0.5 seam never samples the other eye's history. OOB feeds reject.
+	// Reproject history: VR sets prevUVOutOfBounds (feeds reject); SE writes the raw reprojected UV
+	// into motionReject.zw (the SE disocclusion test reads it later).
 	bool prevUVOutOfBounds;
-	float2 prevUV = Stereo::ApplyVelocityToUV(texCoord.xy, motionReject.xy, prevUVOutOfBounds);
-	tapMin.xy = FrameBuffer::GetPreviousDynamicResolutionAdjustedScreenPosition(prevUV);
-#	else
-	motionReject.zw = texCoord.xy + motionReject.xy;
-	tapMin.xy = ClampHistoryUV(motionReject.zw);
-#	endif
+	tapMin.xy = ReprojectHistoryUV(texCoord.xy, motionReject.xy, prevUVOutOfBounds, motionReject.zw);
 	float motionLength = sqrt(dot(motionReject.xy, motionReject.xy));
 	history.xyw = historyTex.Sample(historySampler, tapMin.xy).xyz;
 #	ifdef HDR_OUTPUT

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -434,10 +434,10 @@ PS_OUTPUT main(PS_INPUT input)
 	tapMin.x = cmp(tapC0.w < 0);
 	tapMin.xyzw = tapMin.xxxx ? corner.xyzw : tapC0.xyzw;
 	tapA0.xyzw = sampleUV.wwww ? tapMin.xyzw : corner.xyzw;
-	sampleUV.w = max(tapMin.w, history.x);
-	tapA1.x = min(sampleUV.w, tapA0.w);
-	tapA1.z = tapA0.w;
+	// Clamp history luma into the two sharpened candidates' luma range; tapA1 = (clamped, lo, hi).
+	tapA1.x = clamp(history.x, tapMin.w, tapA0.w);
 	tapA1.y = tapMin.w;
+	tapA1.z = tapA0.w;
 	tapB0.z = corner.w;
 	tapB0.x = history.x;
 	tapB0.y = tapC0.w;

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -418,13 +418,10 @@ PS_OUTPUT main(PS_INPUT input)
 	// of grouping (each is a ceil() integer).
 	float flickerScore = saturate(4 - fcCorner - fcMin - fcA0 - fcA1 - fcB0 - fcB1 - fcC0 - fcC1);
 
-	// --- temporal blend, clamp, and sharpen ---
-	// Builds two blend candidates and lerps between them by a flicker/motion weight:
-	//  - sharpened vs unsharpened neighbourhood colour (SharpenDelta adds back centre detail), and
-	//  - luma triples for the neighbourhood min/max bracket (tapA1) vs the history sample (tapB0).
-	// historyBlend sets how much history to keep; when it is low, clampToNeighborhood pulls the
-	// result toward the bracket. The final corner.xyz is the resulting lerp. (Dense per-line packing
-	// kept as-is — no repeating structure to factor without re-deriving the decompile.)
+	// --- temporal blend, clamp, and sharpen (history rectification toward the neighbourhood AABB) ---
+	// Build two clip candidates (min/max bound, RCAS-sharpened), clamp history luma into their range,
+	// compute the clip ratio, and lerp the colour toward the rectified value by it. historyBlend sets
+	// how much history to keep; when low, clampToNeighborhood pulls the result toward the bracket.
 	// Two history-clip candidates from the min/max AABB bounds, each packed (R, sharpenDelta, B, luma)
 	// — the decompile stashes the RCAS sharpen in the G slot. corner = min bound, tapC0 = max bound.
 	float minOverbright = cmp(1 < tapC1.w);

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -174,6 +174,16 @@ float FlickerLumaContribution(float centerLuma, float neighborLuma)
 	return ceil(d);
 }
 
+// Fold one neighbour tap into the running min-luma colour bracket. Vanilla decompile pack:
+// a tap is float4(GRB.xyz, luma.w); the bracket is a float3 (R, B, luma) whose .z is the luma.
+// The lower-luma colour is committed unless `gate` (the tap's belowHist mask) is set — matching
+// the decompile's cmp/select/select order exactly.
+float3 MergeLumaBracket(float4 tap, float3 bracket, float gate)
+{
+	float3 cand = cmp(tap.w < bracket.z) ? tap.yzw : bracket;
+	return gate ? bracket : cand;
+}
+
 // shallowestDepth must already include depth before calling.
 float2 PickIfShallowestUV(float2 selectedUV, float shallowestDepth, float depth, float2 uvIfMatch)
 {
@@ -334,24 +344,14 @@ PS_OUTPUT main(PS_INPUT input)
 	neighborColor = tapB1.yxz * NeighborWeights.www + neighborColor;
 	neighborColor = tapC1.yxz * NeighborWeights.yyy + neighborColor;
 	neighborColor = centerColor * NeighborWeights.xxx + neighborColor;
-	tapB1.x = cmp(tapC0.w < bracketMax.w);
-	mergeScratch.xyz = tapB1.xxx ? tapC0.yzw : bracketMax.yzw;
-	bracketMax.yzw = tapB0.xxx ? bracketMax.yzw : mergeScratch.xyz;
-	tapB1.x = cmp(tapB1.w < bracketMax.w);
-	mergeScratch.xyz = tapB1.xxx ? tapB1.yzw : bracketMax.yzw;
-	bracketMax.yzw = tapA1.xxx ? bracketMax.yzw : mergeScratch.xyz;
-	tapB1.x = cmp(tapB0.w < bracketMax.w);
-	mergeScratch.xyz = tapB1.xxx ? tapB0.yzw : bracketMax.yzw;
-	bracketMax.yzw = tapA0.xxx ? bracketMax.yzw : mergeScratch.xyz;
-	tapB1.x = cmp(tapA1.w < bracketMax.w);
-	mergeScratch.xyz = tapB1.xxx ? tapA1.yzw : bracketMax.yzw;
-	bracketMax.yzw = tapMin.xxx ? bracketMax.yzw : mergeScratch.xyz;
-	tapB1.x = cmp(tapA0.w < bracketMax.w);
-	mergeScratch.xyz = tapB1.xxx ? tapA0.yzw : bracketMax.yzw;
-	bracketMax.yzw = corner.xxx ? bracketMax.yzw : mergeScratch.xyz;
-	tapB1.x = cmp(tapMin.w < bracketMax.w);
-	mergeScratch.xyz = tapB1.xxx ? tapMin.yzw : bracketMax.yzw;
-	mergeScratch.yzw = uvMinBelowHist.xxx ? bracketMax.yzw : mergeScratch.xyz;
+	// Running min-luma colour bracket folded over the neighbourhood taps, each committed unless its
+	// belowHist gate is set (see MergeLumaBracket). The final tap lands in mergeScratch.yzw.
+	bracketMax.yzw = MergeLumaBracket(tapC0, bracketMax.yzw, tapB0.x);
+	bracketMax.yzw = MergeLumaBracket(tapB1, bracketMax.yzw, tapA1.x);
+	bracketMax.yzw = MergeLumaBracket(tapB0, bracketMax.yzw, tapA0.x);
+	bracketMax.yzw = MergeLumaBracket(tapA1, bracketMax.yzw, tapMin.x);
+	bracketMax.yzw = MergeLumaBracket(tapA0, bracketMax.yzw, corner.x);
+	mergeScratch.yzw = MergeLumaBracket(tapMin, bracketMax.yzw, uvMinBelowHist);
 	tapB1.x = cmp(corner.w < mergeScratch.w);
 	bracketMinReg.yzw = tapB1.xxx ? corner.yzw : mergeScratch.yzw;
 	tapB1.x = cmp(kMinLumaCap < centerLuma);

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -414,6 +414,12 @@ PS_OUTPUT main(PS_INPUT input)
 	float flickerScore = saturate(4 - fcCorner - fcMin - fcA0 - fcA1 - fcB0 - fcB1 - fcC0 - fcC1);
 
 	// --- temporal blend, clamp, and sharpen ---
+	// Builds two blend candidates and lerps between them by a flicker/motion weight:
+	//  - sharpened vs unsharpened neighbourhood colour (SharpenDelta adds back centre detail), and
+	//  - luma triples for the neighbourhood min/max bracket (tapA1) vs the history sample (tapB0).
+	// historyBlend sets how much history to keep; when it is low, clampToNeighborhood pulls the
+	// result toward the bracket. The final corner.xyz is the resulting lerp. (Dense per-line packing
+	// kept as-is — no repeating structure to factor without re-deriving the decompile.)
 	sampleUV.w = cmp(1 < tapC1.w);
 	// Sharpen deltas for the two blend candidates (centre minus quarter-weighted neighbour pair).
 	corner.y = SharpenDelta(tapC1.w, tapC1.y, tapC1.z);

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -89,10 +89,11 @@ static const float kFlickerThreshold = 0.200000003;       // luma-spread below t
  * - Neighbour taps: .yxz sample; luma via dot(.xzy, kLumaWeights); stored as float4(.xyz=GRB, .w=luma).
  * - centre: centerColor float3 = RGB; belowHistC1 scalar = C1 mask; luma via dot(centerColor.yzx, kLumaWeights).
  * - corner: float4 .xyz=corner GRB, .w=corner luma (depth-guided); .x reused for belowHistA0 mask.
- * - Bracket colours: .yzw holds (R, B, G); .w = luma.
- * - Output colour lives in .yzw (vanilla r3.yzw after blend; colorOut = sampleUV.yzw), not .xyz.
+ * - Bracket colours (float3): (R, B, luma) with .z = luma — see MergeLumaBracket/MergeMaxBracket.
+ * - Output colour lives in .yzw (vanilla r3.yzw after blend; resolved/outPacked .yzw), not .xyz.
  *
- * Registers are float4 packs — names are semantic but components reuse like the decompile.
+ * The few remaining float4 packs (motionReject, history, corner, taps) are semantic but reuse
+ * components like the decompile; the blend-math packs have been split into named locals.
  */
 
 float2 ClampScreenUV(float2 screenUV, float2 drMax)
@@ -321,7 +322,7 @@ PS_OUTPUT main(PS_INPUT input)
 	history.x = DecodeFeedbackLuma(history.x);
 #	endif
 	corner.w = dot(corner.xzy, kLumaWeights);
-	motionReject.y = cmp(corner.w < history.x);
+	float cornerBelowHist = cmp(corner.w < history.x);  // toggles corner-tap inclusion in the AABB
 
 	// --- neighbour colour / luma samples ---
 	float uvMinCoverage;   // uvMin alpha coverage; seeds the allTransparent test far below
@@ -401,12 +402,12 @@ PS_OUTPUT main(PS_INPUT input)
 	[unroll] for (int maxFold = 0; maxFold < 6; maxFold++)
 		maxBracket = MergeMaxBracket(foldTaps[maxFold], maxBracket, foldGates[maxFold]);
 	// Complete the max bracket (ungated corner fold), then select the neighbourhood AABB bounds for
-	// history clamping. motionReject.y toggles whether the corner tap is included: when set, max uses
+	// history clamping. cornerBelowHist toggles whether the corner tap is included: when set, max uses
 	// the with-corner bracket and min the without-corner one (opposite when clear). Packed into
 	// tapC0 (max bound) and tapC1 (max.y, then min bound) in the layout the blend below reads.
 	float3 maxWithCorner = MergeMaxBracket(corner, maxBracket, 1);
-	float3 maxBoundSel = motionReject.yyy ? maxWithCorner : maxBracket;
-	float3 minBoundSel = motionReject.yyy ? minBoundNoCorner : minBoundWithCorner;
+	float3 maxBoundSel = cornerBelowHist.xxx ? maxWithCorner : maxBracket;
+	float3 minBoundSel = cornerBelowHist.xxx ? minBoundNoCorner : minBoundWithCorner;
 	tapC0.xw = maxBoundSel.xz;
 	tapC1.xyzw = float4(maxBoundSel.y, minBoundSel);
 

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -425,15 +425,15 @@ PS_OUTPUT main(PS_INPUT input)
 	// historyBlend sets how much history to keep; when it is low, clampToNeighborhood pulls the
 	// result toward the bracket. The final corner.xyz is the resulting lerp. (Dense per-line packing
 	// kept as-is — no repeating structure to factor without re-deriving the decompile.)
-	sampleUV.w = cmp(1 < tapC1.w);
-	// Sharpen deltas for the two blend candidates (centre minus quarter-weighted neighbour pair).
-	corner.y = SharpenDelta(tapC1.w, tapC1.y, tapC1.z);
-	tapC0.z = tapC1.x;
-	corner.xzw = tapC1.yzw;
-	tapC0.y = SharpenDelta(tapC0.w, tapC0.x, tapC1.x);
-	tapMin.x = cmp(tapC0.w < 0);
-	tapMin.xyzw = tapMin.xxxx ? corner.xyzw : tapC0.xyzw;
-	tapA0.xyzw = sampleUV.wwww ? tapMin.xyzw : corner.xyzw;
+	// Two history-clip candidates from the min/max AABB bounds, each packed (R, sharpenDelta, B, luma)
+	// — the decompile stashes the RCAS sharpen in the G slot. corner = min bound, tapC0 = max bound.
+	float minOverbright = cmp(1 < tapC1.w);
+	corner = float4(tapC1.y, SharpenDelta(tapC1.w, tapC1.y, tapC1.z), tapC1.z, tapC1.w);
+	tapC0 = float4(tapC0.x, SharpenDelta(tapC0.w, tapC0.x, tapC1.x), tapC1.x, tapC0.w);
+	// Prefer the max bound; fall back to the min bound when the max luma is degenerate (<0), then to
+	// that result vs the min bound when the min luma is overbright (>1).
+	tapMin.xyzw = cmp(tapC0.w < 0) ? corner : tapC0;
+	tapA0.xyzw = minOverbright ? tapMin.xyzw : corner;
 	// Clamp history luma into the two sharpened candidates' luma range; tapA1 = (clamped, lo, hi).
 	tapA1.x = clamp(history.x, tapMin.w, tapA0.w);
 	tapA1.y = tapMin.w;

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -270,21 +270,20 @@ float2 SelectDepthGuidedUV(
 	return selectedUV;
 }
 
-// Reproject the history-sample UV from velocity. VR reprojects within the current eye (mono-space
-// velocity, per-eye clamp; see Stereo::ApplyVelocityToUV) so a pixel near the x=0.5 seam never
-// samples the other eye's history, and reports out-of-bounds via `outOfBounds`. SE adds velocity in
-// screen space and returns the raw reprojected UV in `rawReprojUV` (the SE disocclusion test reads
-// it later). Both paths write both out-params.
-float2 ReprojectHistoryUV(float2 texCoord, float2 velocity, out bool outOfBounds, out float2 rawReprojUV)
+// Reproject the history-sample UV from velocity and report whether the reprojection left the frame
+// (disocclusion → reject). VR reprojects within the current eye (mono-space velocity, per-eye clamp;
+// see Stereo::ApplyVelocityToUV) so a pixel near the x=0.5 seam never samples the other eye's
+// history; SE adds velocity in screen space and tests the raw UV against [0,1] (the same boolean the
+// decompile computed inline). Folding the SE test in here lets main() treat both paths uniformly.
+float2 ReprojectHistoryUV(float2 texCoord, float2 velocity, out bool outOfBounds)
 {
 #	ifdef VR
 	float2 prevUV = Stereo::ApplyVelocityToUV(texCoord, velocity, outOfBounds);
-	rawReprojUV = prevUV;
 	return FrameBuffer::GetPreviousDynamicResolutionAdjustedScreenPosition(prevUV);
 #	else
-	rawReprojUV = texCoord + velocity;
-	outOfBounds = false;
-	return ClampHistoryUV(rawReprojUV);
+	float2 prevUV = texCoord + velocity;
+	outOfBounds = any(prevUV >= 1.0) || any(prevUV <= 0.0);
+	return ClampHistoryUV(prevUV);
 #	endif
 }
 
@@ -313,10 +312,9 @@ PS_OUTPUT main(PS_INPUT input)
 
 	// --- motion vector and history sample ---
 	motionReject.xy = velocityTex.Sample(velocitySampler, ClampScreenUV(motionReject.xy, drMax)).xy;
-	// Reproject history: VR sets prevUVOutOfBounds (feeds reject); SE writes the raw reprojected UV
-	// into motionReject.zw (the SE disocclusion test reads it later).
+	// Reproject history; prevUVOutOfBounds feeds the disocclusion reject below (both VR and SE).
 	bool prevUVOutOfBounds;
-	float2 historyUV = ReprojectHistoryUV(texCoord.xy, motionReject.xy, prevUVOutOfBounds, motionReject.zw);
+	float2 historyUV = ReprojectHistoryUV(texCoord.xy, motionReject.xy, prevUVOutOfBounds);
 	float motionLength = sqrt(dot(motionReject.xy, motionReject.xy));
 	// Feedback RT round-trip: .x = prev feedback luma, .y = prev historyFeedback weight, .z = prev
 	// motionConfidence (see feedbackOut writes at the end). The two weights are NOT colour/luma.
@@ -444,17 +442,9 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 rectifiedColor = lerp(rectifyLo, rectifyHi, clipRatio.xxx);
 
 	// --- disocclusion / mask rejection ---
-	float reject;  // disocclusion / OOB / mask rejection flag
-#	ifdef VR
-	// VR resolves out-of-bounds per-eye in mono space; the SE stereo-space test misses the seam.
-	reject = prevUVOutOfBounds ? 1 : 0;
-#	else
-	float2 prevUV = motionReject.zw;  // reprojected UV from the SE path
-	float uvLow = cmp(0 >= min(prevUV.x, prevUV.y));
-	float2 uvHigh = cmp(prevUV >= float2(1, 1));
-	reject = (int)uvHigh.x | (int)uvLow;
-	reject = (int)uvHigh.y | (int)reject;
-#	endif
+	// Reproject OOB (computed per-eye in VR / screen-space in SE inside ReprojectHistoryUV), then
+	// OR in the mask reject below.
+	float reject = prevUVOutOfBounds ? 1 : 0;                      // disocclusion / OOB / mask rejection flag
 	float2 maskValues = maskTex.Sample(maskSampler, drCenter).xy;  // .x depth-mask, .y coverage
 	float centerCoverage = AlphaCoverageMask(drCenter);
 	float maskReject = cmp(ThresholdParams.w < maskValues.y);

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -284,7 +284,7 @@ PS_OUTPUT main(PS_INPUT input)
 	// float4 packs — component reuse matches vanilla decompile (see header comment).
 	float4 motionReject, sampleUV, history, corner, tapMin;  // was r0–r4
 	float4 tapA0, tapA1, tapB0, tapB1, tapC0, tapC1;         // was r6–r13
-	float4 center, centerMeta, mergeScratch, bracketMinReg;  // was r14–r19
+	float4 center;                                           // belowHistC1 mask carrier (was r14)
 
 	float2 drMax = GetDynamicResolutionMax(), drUVMin, drUVMax, drCenter;
 	float4 drNeighborsA, drNeighborsB, drNeighborsC;
@@ -346,15 +346,15 @@ PS_OUTPUT main(PS_INPUT input)
 
 	// --- centre bracket seed, neighbourhood bracket, flicker, temporal blend (verbatim math) ---
 	float centerLuma = dot(centerColor.yzx, kLumaWeights);
-	centerMeta.x = centerLuma;  // .yzx swizzle in the bracket cascade still reads this slot
 	float belowHistCentre = cmp(centerLuma < history.x);
-	centerMeta.yz = centerColor.xz;
+	// Centre colour packed as (R, B, luma) — the bracket seeds clamp this against the luma caps.
+	float3 centerRBL = float3(centerColor.x, centerColor.z, centerLuma);
 	// Bracket ceiling: 1.001 is just above the maximum PQ value (1.0 = 10000 nits).
 	// Nothing in the scene exceeds this, so the ceiling works correctly in PQ working space.
 	// (In linear BT2020 this would be wrong — sky/specular exceed 1.0 linear — but PQ is bounded.)
 	// Seed the min bracket: centre colour (as R,B,luma) clamped to the 1.001 ceiling; if the centre is
 	// below history (belowHistCentre), start at the ceiling. Then fold tapC1 (its belowHist).
-	float3 minBracket = cmp(centerLuma < kMaxLumaCap) ? centerMeta.yzx : kMaxLumaCap.xxx;
+	float3 minBracket = cmp(centerLuma < kMaxLumaCap) ? centerRBL : kMaxLumaCap.xxx;
 	minBracket = belowHistCentre ? kMaxLumaCap.xxx : minBracket;
 	minBracket = MergeLumaBracket(tapC1, minBracket, center.x);
 
@@ -373,12 +373,12 @@ PS_OUTPUT main(PS_INPUT input)
 	// belowHist gate is set (see MergeLumaBracket). Result is the without-corner min bound.
 	[unroll] for (int fold = 0; fold < 6; fold++)
 		minBracket = MergeLumaBracket(foldTaps[fold], minBracket, foldGates[fold]);
-	mergeScratch.yzw = minBracket;
+	float3 minBoundNoCorner = minBracket;
 	// Final fold: corner tap, ungated (gate 0 → always take the lower-luma colour).
-	bracketMinReg.yzw = MergeLumaBracket(corner, mergeScratch.yzw, 0);
+	float3 minBoundWithCorner = MergeLumaBracket(corner, minBoundNoCorner, 0);
 	// Low-clamp the (max-bracketed) tapC1 to the kMinLumaCap floor: build the centre-vs-floor bound
 	// (gated by belowHistCentre), then fold tapC1 toward it (MergeMaxBracket, gated by tapC1's belowHist).
-	float3 lowClamp = cmp(kMinLumaCap < centerLuma) ? centerMeta.yzx : kMinLumaCap.xxx;
+	float3 lowClamp = cmp(kMinLumaCap < centerLuma) ? centerRBL : kMinLumaCap.xxx;
 	lowClamp = belowHistCentre ? lowClamp : kMinLumaCap.xxx;
 	tapC1.xyz = MergeMaxBracket(tapC1, lowClamp, center.x);
 
@@ -409,7 +409,7 @@ PS_OUTPUT main(PS_INPUT input)
 	// tapC0 (max bound) and tapC1 (max.y, then min bound) in the layout the blend below reads.
 	float3 maxWithCorner = MergeMaxBracket(corner, maxBracket, 1);
 	float3 maxBoundSel = motionReject.yyy ? maxWithCorner : maxBracket;
-	float3 minBoundSel = motionReject.yyy ? mergeScratch.yzw : bracketMinReg.yzw;
+	float3 minBoundSel = motionReject.yyy ? minBoundNoCorner : minBoundWithCorner;
 	tapC0.xw = maxBoundSel.xz;
 	tapC1.xyzw = float4(maxBoundSel.y, minBoundSel);
 
@@ -468,8 +468,7 @@ PS_OUTPUT main(PS_INPUT input)
 	motionReject.z = (int)motionReject.z | (int)sampleUV.x;
 	float reject = motionReject.z;  // disocclusion / OOB / mask rejection flag
 	sampleUV.xyw = reject.xxx ? centerColor : corner.xyz;
-	centerMeta.w = 0;
-	history.xw = reject.xx ? centerMeta.xw : history.xw;
+	history.xw = reject.xx ? float2(centerLuma, 0) : history.xw;
 	corner.xyz = reject.xxx ? centerColor : neighborColor;
 	tapMin.xyz = centerColor + -corner.xyz;
 	float motionNormScale = 128 * TexelSizeParams.x;  // 128-texel span used to normalize motion length

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -75,10 +75,13 @@ float DecodeFeedbackLuma(float gammaLuma)
 static const float3 kLumaWeights = float3(0.5, 0.25, 0.25);
 
 // Named magic constants from the vanilla decompile (values unchanged).
-static const float kMaxLumaCap = 1.00100005;             // bracket ceiling (just above 1.0 PQ)
-static const float kMinLumaCap = -0.00100000005;         // bracket floor (just below 0)
-static const float kLumaEpsilon = 0.00999999978;         // negligible-luma threshold
-static const float2 kSimilarityScale = float2(20, 100);  // motion-diff convergence decay (x), strict (y)
+static const float kMaxLumaCap = 1.00100005;              // bracket ceiling (just above 1.0 PQ)
+static const float kMinLumaCap = -0.00100000005;          // bracket floor (just below 0)
+static const float kLumaEpsilon = 0.00999999978;          // negligible-luma threshold
+static const float2 kSimilarityScale = float2(20, 100);   // motion-diff convergence decay (x), strict (y)
+static const float kHistoryLumaDecay = 0.949999988;       // 0.95 decay applied to history motion luma
+static const float kHistoryBlendThreshold = 0.902499974;  // below this blend weight, clamp to neighbourhood
+static const float kFeedbackBlendMax = 0.99000001;        // ~1.0 ceiling for the feedback blend weight
 
 /*
  * Channel layout (vanilla decompile — swizzles are load-bearing):
@@ -436,9 +439,9 @@ PS_OUTPUT main(PS_INPUT input)
 	tapB0.z = corner.w;
 	tapB0.x = history.x;
 	tapB0.y = tapC0.w;
-	sampleUV.w = 0.949999988 * history.y;
+	sampleUV.w = kHistoryLumaDecay * history.y;
 	float historyBlend = saturate(flickerScore * 0.25 + sampleUV.w);
-	float clampToNeighborhood = cmp(historyBlend < 0.902499974);
+	float clampToNeighborhood = cmp(historyBlend < kHistoryBlendThreshold);
 	history.xyz = clampToNeighborhood.xxx ? tapA1.xyz : tapB0.xyz;
 	history.yz = history.zx + -history.yy;
 	corner.w = cmp(kLumaEpsilon < history.y);
@@ -496,7 +499,7 @@ PS_OUTPUT main(PS_INPUT input)
 	motionReject.x = motionConfidence * motionReject.x + BlendParams.y;
 	motionReject.x = min(motionReject.x, history.x);
 	tapA0.y = history.w * historyBlend;
-	motionReject.y = 0.99000001 + -motionReject.x;
+	motionReject.y = kFeedbackBlendMax + -motionReject.x;
 	motionReject.x = tapA0.y * motionReject.y + motionReject.x;
 	feedbackOut.yz = float2(tapA0.y, motionConfidence);
 #	ifdef HDR_OUTPUT

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -463,10 +463,12 @@ PS_OUTPUT main(PS_INPUT input)
 	float centerCoverage = AlphaCoverageMask(sampleUV.xy);
 	float maskReject = cmp(ThresholdParams.w < history.z);
 	reject = (int)reject | (int)maskReject;
-	sampleUV.xyw = reject.xxx ? centerColor : corner.xyz;
+	// Two colour candidates: the rectified history colour and the neighbourhood-weighted colour
+	// (both collapse to the centre tap when the pixel is rejected).
+	float3 workColor = reject.xxx ? centerColor : corner.xyz;  // history/rectified colour, evolves below
 	history.xw = reject.xx ? float2(centerLuma, 0) : history.xw;
-	corner.xyz = reject.xxx ? centerColor : neighborColor;
-	tapMin.xyz = centerColor + -corner.xyz;
+	float3 neighborBlend = reject.xxx ? centerColor : neighborColor;
+	float3 centerVsNeighbor = centerColor + -neighborBlend;
 	float motionNormScale = 128 * TexelSizeParams.x;  // 128-texel span used to normalize motion length
 	float motionConfidence = saturate(motionLength / motionNormScale);
 	float motionVsHistory = motionConfidence + -history.w;
@@ -488,8 +490,8 @@ PS_OUTPUT main(PS_INPUT input)
 	float2 similarity = -abs(motionVsHistory.xx) * kSimilarityScale + float2(1, 1);
 #	endif
 	similarity = max(float2(0, 0), similarity);
-	tapMin.yzw = similarity.xxx * tapMin.xyz + corner.xyz;
-	sampleUV.xyw = -tapMin.yzw + sampleUV.xyw;
+	float3 targetColor = similarity.xxx * centerVsNeighbor + neighborBlend;
+	workColor = -targetColor + workColor;
 	float blendWeight = BlendParams.x + -BlendParams.y;
 	blendWeight = motionConfidence * blendWeight + BlendParams.y;
 	blendWeight = min(blendWeight, similarity.x);
@@ -498,19 +500,19 @@ PS_OUTPUT main(PS_INPUT input)
 	blendWeight = historyFeedback * feedbackComplement + blendWeight;
 	feedbackOut.yz = float2(historyFeedback, motionConfidence);
 #	ifdef HDR_OUTPUT
-	tapMin.yzw = max(tapMin.yzw, 0);
-	sampleUV.xyw = saturate(blendWeight.xxx * sampleUV.xyw + tapMin.yzw);
+	targetColor = max(targetColor, 0);
+	workColor = saturate(blendWeight.xxx * workColor + targetColor);
 	// Skip vanilla BlendParams.z/w detail recovery — neighbourhood delta blows up in linear HDR
 	// and causes dark bezels / halos on the alpha-aware corner.yzw output path.
-	corner.yzw = sampleUV.xyw;
+	corner.yzw = workColor;
 #	else
-	sampleUV.xyw = saturate(blendWeight.xxx * sampleUV.xyw + tapMin.yzw);
+	workColor = saturate(blendWeight.xxx * workColor + targetColor);
 
-	tapA0.xyz = sampleUV.xyw + -corner.xyz;
-	sampleUV.xyw = saturate(tapA0.xyz * BlendParams.zzz + sampleUV.xyw);
+	float3 detailDelta = workColor + -neighborBlend;
+	workColor = saturate(detailDelta * BlendParams.zzz + workColor);
 
-	corner.xyz = corner.xyz + -sampleUV.xyw;
-	corner.yzw = saturate(BlendParams.www * corner.xyz + sampleUV.xyw);
+	corner.xyz = neighborBlend + -workColor;
+	corner.yzw = saturate(BlendParams.www * corner.xyz + workColor);
 #	endif
 
 	// Feedback luma: nudge centre luma by the blend-weighted luma diff, unless that nudge is negligible.
@@ -518,7 +520,7 @@ PS_OUTPUT main(PS_INPUT input)
 	float lumaNudge = blendWeight * lumaDiff;
 	float lumaNudgeTiny = cmp(abs(lumaNudge) < kLumaEpsilon);
 	corner.x = lumaNudgeTiny ? centerLuma : feedbackLuma;
-	float outputLuma = dot(tapMin.zwy, kLumaWeights);
+	float outputLuma = dot(targetColor.yzx, kLumaWeights);
 
 	// --- alpha-aware output ---
 	// allTransparent: every 3x3 tap covered by alpha. Seed = uvMin coverage (uvMinCoverage),
@@ -535,7 +537,7 @@ PS_OUTPUT main(PS_INPUT input)
 	float feedbackWeight = 1 + -history.z;
 	allTransparent = depthMaskPass ? allTransparent : 0;
 	// .x = feedback luma, .yzw = resolved colour
-	float4 resolved = allTransparent.xxxx ? float4(outputLuma, tapMin.yzw) : corner.xyzw;
+	float4 resolved = allTransparent.xxxx ? float4(outputLuma, targetColor) : corner.xyzw;
 	colorOut.xyz = resolved.yzw;
 #	ifdef HDR_OUTPUT
 	// Encode PQ luma to game-gamma for feedback RT storage.

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -363,8 +363,8 @@ PS_OUTPUT main(PS_INPUT input)
 	bracketMax.yzw = MergeLumaBracket(tapA1, bracketMax.yzw, tapMin.x);
 	bracketMax.yzw = MergeLumaBracket(tapA0, bracketMax.yzw, corner.x);
 	mergeScratch.yzw = MergeLumaBracket(tapMin, bracketMax.yzw, uvMinBelowHist);
-	tapB1.x = cmp(corner.w < mergeScratch.w);
-	bracketMinReg.yzw = tapB1.xxx ? corner.yzw : mergeScratch.yzw;
+	// Final fold: corner tap, ungated (gate 0 → always take the lower-luma colour).
+	bracketMinReg.yzw = MergeLumaBracket(corner, mergeScratch.yzw, 0);
 	tapB1.x = cmp(kMinLumaCap < centerLuma);
 	bracketMax.yzw = tapB1.xxx ? centerMeta.yzx : kMinLumaCap.xxx;
 	bracketMax.xyz = bracketMax.xxx ? bracketMax.yzw : kMinLumaCap.xxx;

--- a/package/Shaders/ISTemporalAA.hlsl
+++ b/package/Shaders/ISTemporalAA.hlsl
@@ -74,7 +74,7 @@ float DecodeFeedbackLuma(float gammaLuma)
 
 static const float3 kLumaWeights = float3(0.5, 0.25, 0.25);
 
-// Named magic constants from the vanilla decompile (values unchanged).
+// Tuning constants from the vanilla TAA decompile, named for readability; each role noted inline.
 static const float kMaxLumaCap = 1.00100005;              // bracket ceiling (just above 1.0 PQ)
 static const float kMinLumaCap = -0.00100000005;          // bracket floor (just below 0)
 static const float kLumaEpsilon = 0.00999999978;          // negligible-luma threshold
@@ -93,8 +93,8 @@ static const float kFlickerThreshold = 0.200000003;       // luma-spread below t
  * - Bracket colours (float3): (R, B, luma) with .z = luma — see MergeLumaBracket/MergeMaxBracket.
  * - Output colour lives in .yzw (vanilla r3.yzw after blend; resolved/outPacked .yzw), not .xyz.
  *
- * The few remaining float4 packs (motionReject, corner, the neighbour taps) are semantic but reuse
- * components like the decompile; the blend-math and history packs have been split into named locals.
+ * motionReject, corner, and the neighbour taps stay packed float4s whose components carry distinct
+ * quantities (as in the decompile); other intermediates (blend math, history fields) are named scalars.
  */
 
 float2 ClampScreenUV(float2 screenUV, float2 drMax)
@@ -382,16 +382,16 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 minBoundNoCorner = minBracket;
 	// Final fold: corner tap, ungated (gate 0 → always take the lower-luma colour).
 	float3 minBoundWithCorner = MergeLumaBracket(corner, minBoundNoCorner, 0);
-	// Low-clamp the (max-bracketed) C1 tap to the kMinLumaCap floor: build the centre-vs-floor bound
-	// (gated by belowHistCentre), then fold C1 toward it (MergeMaxBracket, gated by C1's belowHist).
+	// Low-clamp C1 to the kMinLumaCap floor, into its own seed so neighbors[] stays an immutable tap
+	// array: build the centre-vs-floor bound (gated by belowHistCentre), then fold C1's colour toward
+	// it (MergeMaxBracket, gated by C1's belowHist). This seeds the max bracket below.
 	float3 lowClamp = cmp(kMinLumaCap < centerLuma) ? centerRBL : kMinLumaCap.xxx;
 	lowClamp = belowHistCentre ? lowClamp : kMinLumaCap.xxx;
-	neighbors[6].xyz = MergeMaxBracket(neighbors[6], lowClamp, neighborBelowHist[6]);
+	float3 lowClampedC1 = MergeMaxBracket(neighbors[6], lowClamp, neighborBelowHist[6]);
 
 	// --- flicker score: 4 minus one integer contribution per neighbourhood tap ---
-	// Each contribution reads a tap's ORIGINAL .w luma; the colour sort below only mutates .w/.yzw
-	// after this, so computing them here is behaviour-preserving. The sum is order-independent (each
-	// contribution is a ceil() integer); tap order matches the original 8-term sum.
+	// Each contribution reads a tap's .w luma; the sum is order-independent (each is a ceil() integer)
+	// and the tap order matches the original 8-term sum.
 	const float4 flickerTaps[8] = { corner, neighbors[0], neighbors[1], neighbors[2], neighbors[3], neighbors[4], neighbors[5], neighbors[6] };
 	float flickerScore = 4;
 	[unroll] for (int flick = 0; flick < 8; flick++)
@@ -402,7 +402,7 @@ PS_OUTPUT main(PS_INPUT input)
 	// Same six taps/order as the min fold (neighbors[5..0]), but the max rule commits a tap when its
 	// belowHist gate is SET — inverted vs the min fold (see MergeMaxBracket). Seeded from the
 	// low-clamped C1 colour.
-	float3 maxBracket = neighbors[6].xyz;
+	float3 maxBracket = lowClampedC1;
 	[unroll] for (int maxFold = 5; maxFold >= 0; maxFold--)
 		maxBracket = MergeMaxBracket(neighbors[maxFold], maxBracket, neighborBelowHist[maxFold]);
 	// Complete the max bracket (ungated corner fold), then select the neighbourhood AABB bounds for


### PR DESCRIPTION
Restructures `package/Shaders/ISTemporalAA.hlsl` — Skyrim's TAA decompile transcription — into readable, named TAA, with no behaviour change. Single PR (consolidated from the former #90/#96/#98 stack now that the work is complete); built on the VR fix #84, already merged to dev.

## What changed (1 file, ISTemporalAA.hlsl)
- **Named helpers** for the repeated idioms: `MergeLumaBracket`/`MergeMaxBracket` (neighbourhood colour brackets), `SharpenDelta` (RCAS), `FlickerLumaContribution`, `SampleNeighborGRB`/`AssignPackedNeighbor`, `SelectDepthGuidedUV`, the UV clamps.
- **Named constants** for the decompile's magic numbers (`kMaxLumaCap`, `kSimilarityScale`, `kHistoryBlendThreshold`, …).
- **Unified** the min/max bracket folds (same six taps/gates) into a shared `foldTaps`/`foldGates` loop.
- **Destructured every reused float4 register-pack** in `main()` into named locals — the deep decompile aliasing where one component meant different things at different points (`motionReject.z` = reject flag *then* luma diff; `history.xw` = luma *then* similarity weights; `sampleUV.xyw` = UV *then* working colour). Now: `reject`, `lumaDiff`, `similarity`, `blendWeight`, `workColor`, `neighborBlend`, `targetColor`, `clipLo`/`clipHi`, `maskValues`, `outPacked`, `cornerBelowHist`, … The `sampleUV` pack, the `history.xy = drMax` temp, and the `tapC0`/`tapC1` clip bridge are gone. Only genuine packed data (motion vector, history sample, neighbour taps) remains as float4.

## Validation
Two tiers, both green:
- **Runtime A/B (Tier-3)** for the one op-reordering part (the core restructure): RenderDoc same-frame pixel-shader swap on in-game **motion** frames — **EQUIVALENT at the noise floor on both SE (eid 34605) and VR (Dragonsreach frame7323)**.
- **Byte-identity (Tier-1)** for everything else: `tools/verify-shader-refactor.ps1` reports **all four permutations IDENTICAL** (PSHADER × {VR} × {HDR_OUTPUT}) for the destructure + dedup layers.

HDR (non-VR) path: the PQ pipeline is intact; HDR-block changes are value-identical renames (couldn't be runtime-captured because the DX12-interop swapchain hides the D3D11 frame, so it rests on static analysis + the byte-identity check).

Will be **squash-merged** — this PR title becomes the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked temporal anti-aliasing pipeline with centralized history reprojection and clearer motion handling for more reliable history sampling and rejection.
* **Improvements**
  * Reduced flicker and improved temporal stability via refined luma-neighborhood merging, bracket-based clamping and sharpen-aware corrections.
  * More robust disocclusion/mask rejection and preserved HDR/alpha-aware output choices for cleaner temporal blending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->