### PR TITLE
fix(slf): restore vanilla shadow lights when disabled

### DIFF
--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -3878,6 +3878,40 @@ namespace ShadowCasterManager
 		return s_lights;
 	}
 
+	bool IsActive()
+	{
+		// Boot-latched: Install() captures s_bootEnabled once and wires the
+		// scheduler hooks only when it was set. Runtime toggles of
+		// s_settings.Enabled are restart-gated (see Hook_CalculateActiveShadowCasters)
+		// so the live flag is the wrong thing to test here. Before Install()
+		// runs, s_bootEnabled is false, which is the safe answer -- the engine's
+		// vanilla pipeline is what's live until our hooks land.
+		return s_bootEnabled && !s_externalConflict;
+	}
+
+	// Reads the engine's own kSHADOWMAPS slice for `light` from the live
+	// shadowmap descriptor. Used only when SCM is inactive (disabled at boot /
+	// external conflict): the SCM pool is empty in that case, but the engine
+	// still renders up to its vanilla 4 casters and stamps each one's slice
+	// into shadowmapDescriptors[0].shadowmapIndex. Directional sun returns -1
+	// (kSHADOWMAPS_ESRAM, no kSHADOWMAPS slice); a light with no descriptor
+	// yet (mid-population) also returns -1 so the caller skips it cleanly.
+	static int32_t GetEngineShadowSlot(RE::BSShadowLight* light)
+	{
+		if (!light || light->GetIsDirectionalLight())
+			return -1;
+		if (globals::game::isVR) {
+			auto& rd = light->GetVRRuntimeData();
+			if (rd.shadowmapDescriptors.empty())
+				return -1;
+			return static_cast<int32_t>(rd.shadowmapDescriptors[0].shadowmapIndex);
+		}
+		auto& rd = light->GetRuntimeData();
+		if (rd.shadowmapDescriptors.empty())
+			return -1;
+		return static_cast<int32_t>(rd.shadowmapDescriptors[0].shadowmapIndex);
+	}
+
 	int32_t GetShadowSlot(RE::BSShadowLight* light)
 	{
 		// Returns the kSHADOWMAPS texture-array slot for `light`, or -1 if the
@@ -3885,6 +3919,16 @@ namespace ShadowCasterManager
 		// lights (1:1). Sun's pool slot returns -1 since the sun renders to
 		// kSHADOWMAPS_ESRAM (a separate texture) — callers in ShadowRenderer
 		// upload and LightLimitFix cluster builder must skip it.
+		//
+		// When SCM is disabled at boot the pool is never populated, so the
+		// lookup below would return -1 for every light. The cluster builder
+		// treats -1 as "already handled, no slot" and drops the light entirely
+		// (it was added to shadowLightPtrs first), which blacked out every
+		// shadow caster. Fall back to the engine's own descriptor slice so LLF
+		// lights and shadows the casters exactly as vanilla would without SLF.
+		if (!IsActive())
+			return GetEngineShadowSlot(light);
+
 		const int32_t poolIdx = s_lights.FindLight(light, s_settings.ShadowLightCount);
 		if (poolIdx < 0)
 			return -1;

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -3880,22 +3880,14 @@ namespace ShadowCasterManager
 
 	bool IsActive()
 	{
-		// Boot-latched: Install() captures s_bootEnabled once and wires the
-		// scheduler hooks only when it was set. Runtime toggles of
-		// s_settings.Enabled are restart-gated (see Hook_CalculateActiveShadowCasters)
-		// so the live flag is the wrong thing to test here. Before Install()
-		// runs, s_bootEnabled is false, which is the safe answer -- the engine's
-		// vanilla pipeline is what's live until our hooks land.
+		// Boot-latched, not the live s_settings.Enabled: hooks install only when
+		// enabled at boot, and runtime toggles are restart-gated.
 		return s_bootEnabled && !s_externalConflict;
 	}
 
-	// Reads the engine's own kSHADOWMAPS slice for `light` from the live
-	// shadowmap descriptor. Used only when SCM is inactive (disabled at boot /
-	// external conflict): the SCM pool is empty in that case, but the engine
-	// still renders up to its vanilla 4 casters and stamps each one's slice
-	// into shadowmapDescriptors[0].shadowmapIndex. Directional sun returns -1
-	// (kSHADOWMAPS_ESRAM, no kSHADOWMAPS slice); a light with no descriptor
-	// yet (mid-population) also returns -1 so the caller skips it cleanly.
+	// Engine's native kSHADOWMAPS slice from the live descriptor, for when SCM
+	// is inactive and its pool is empty. Sun (-> kSHADOWMAPS_ESRAM) and lights
+	// without a descriptor return -1 so callers skip them.
 	static int32_t GetEngineShadowSlot(RE::BSShadowLight* light)
 	{
 		if (!light || light->GetIsDirectionalLight())
@@ -3920,12 +3912,8 @@ namespace ShadowCasterManager
 		// kSHADOWMAPS_ESRAM (a separate texture) — callers in ShadowRenderer
 		// upload and LightLimitFix cluster builder must skip it.
 		//
-		// When SCM is disabled at boot the pool is never populated, so the
-		// lookup below would return -1 for every light. The cluster builder
-		// treats -1 as "already handled, no slot" and drops the light entirely
-		// (it was added to shadowLightPtrs first), which blacked out every
-		// shadow caster. Fall back to the engine's own descriptor slice so LLF
-		// lights and shadows the casters exactly as vanilla would without SLF.
+		// With SCM disabled at boot the pool is empty; without this fallback
+		// every caster returns -1 and the cluster builder drops it (#97).
 		if (!IsActive())
 			return GetEngineShadowSlot(light);
 

--- a/src/Features/LightLimitFix/ShadowCasterManager.h
+++ b/src/Features/LightLimitFix/ShadowCasterManager.h
@@ -610,6 +610,14 @@ namespace ShadowCasterManager
 	/// Returns a read-only view of the active light pool for UI/visualization.
 	const LightContainer& GetLights();
 
+	/// True when SCM is the active shadow manager this session: it was enabled
+	/// at boot (so Install() wired up the scheduler hooks) and no conflicting
+	/// external plugin was detected. False means the engine's vanilla shadow
+	/// pipeline is running untouched -- callers that depend on SCM's pool
+	/// (slot assignment, scheduling) must fall back to the engine's own data.
+	/// Boot-latched, like ShadowLightCount: runtime toggles don't flip it.
+	bool IsActive();
+
 	/// Returns the kSHADOWMAPS texture-array slot for an active point/spot
 	/// shadow light as a raw slice index 0..GetInstalledSlotCount()-1, or -1
 	/// when the light is either not active in the SCM pool OR is the sun.
@@ -617,8 +625,14 @@ namespace ShadowCasterManager
 	/// strict-light shadow-flag setup) treat the -1 sentinel as "skip" --
 	/// the sun renders to kSHADOWMAPS_ESRAM (a separate texture) and has no
 	/// kSHADOWMAPS slice; inactive lights have no slot at all.
-	/// Uses the internal s_lights pool -- does not read the descriptor's
-	/// shadowmapIndex field, which may be corrupted by ReturnShadowmaps().
+	///
+	/// When SCM is active this reads the internal s_lights pool -- it does NOT
+	/// read the descriptor's shadowmapIndex field, which can be corrupted by
+	/// ReturnShadowmaps(). When SCM is NOT active (disabled at boot or an
+	/// external conflict), the pool is never populated, so this falls back to
+	/// the engine's own shadowmapDescriptors[0].shadowmapIndex -- exactly the
+	/// vanilla slice the engine rendered into -- so LLF keeps lighting and
+	/// shadowing point/spot casters as it would without Shadow Limit Fix.
 	int32_t GetShadowSlot(RE::BSShadowLight* light);
 
 	/// Visit every shadow light currently demoted to non-shadow rendering via

--- a/src/Features/LightLimitFix/ShadowCasterManager.h
+++ b/src/Features/LightLimitFix/ShadowCasterManager.h
@@ -610,12 +610,8 @@ namespace ShadowCasterManager
 	/// Returns a read-only view of the active light pool for UI/visualization.
 	const LightContainer& GetLights();
 
-	/// True when SCM is the active shadow manager this session: it was enabled
-	/// at boot (so Install() wired up the scheduler hooks) and no conflicting
-	/// external plugin was detected. False means the engine's vanilla shadow
-	/// pipeline is running untouched -- callers that depend on SCM's pool
-	/// (slot assignment, scheduling) must fall back to the engine's own data.
-	/// Boot-latched, like ShadowLightCount: runtime toggles don't flip it.
+	/// True when SCM owns shadow scheduling this session (enabled at boot, no
+	/// external conflict). False = engine's vanilla pipeline. Boot-latched.
 	bool IsActive();
 
 	/// Returns the kSHADOWMAPS texture-array slot for an active point/spot
@@ -625,14 +621,10 @@ namespace ShadowCasterManager
 	/// strict-light shadow-flag setup) treat the -1 sentinel as "skip" --
 	/// the sun renders to kSHADOWMAPS_ESRAM (a separate texture) and has no
 	/// kSHADOWMAPS slice; inactive lights have no slot at all.
-	///
-	/// When SCM is active this reads the internal s_lights pool -- it does NOT
-	/// read the descriptor's shadowmapIndex field, which can be corrupted by
-	/// ReturnShadowmaps(). When SCM is NOT active (disabled at boot or an
-	/// external conflict), the pool is never populated, so this falls back to
-	/// the engine's own shadowmapDescriptors[0].shadowmapIndex -- exactly the
-	/// vanilla slice the engine rendered into -- so LLF keeps lighting and
-	/// shadowing point/spot casters as it would without Shadow Limit Fix.
+	/// When SCM is active, reads the s_lights pool (not the descriptor's
+	/// shadowmapIndex, which ReturnShadowmaps() can corrupt). When inactive the
+	/// pool is empty, so it falls back to the engine's own
+	/// shadowmapDescriptors[0].shadowmapIndex (the vanilla slice).
 	int32_t GetShadowSlot(RE::BSShadowLight* light);
 
 	/// Visit every shadow light currently demoted to non-shadow rendering via


### PR DESCRIPTION
## Problem

Fixes #97 — with **Shadow Limit Fix unticked and the game restarted, all shadowcasters stop emitting light** (both spots and omnis).

Disabling SLF at boot already skips every SCM game hook ([`Install` early-returns](https://github.com/alandtse/open-shaders/blob/dev/src/Features/LightLimitFix/ShadowCasterManager.cpp)), so the engine's shadow scheduler runs untouched. But the **LightLimitFix cluster pipeline was not gated on SCM** and still routed every shadow light through `ShadowCasterManager::GetShadowSlot()`:

- The scheduler hook never installed → the SCM pool (`s_lights`) stays empty → `GetShadowSlot()` returns `-1` for every light.
- `UpdateLights()` inserts each shadow light into `shadowLightPtrs` (marking it "handled"), then drops it on the `stableSlot < 0` early-return; the `activeLights` fallback loop skips it too. Net: shadow-casting lights contribute **zero** to the cluster → blacked out.
- `CopyShadowLightData()` shared the same dependency, leaving the `Shadows` (t102) buffer empty.

## Fix

One central change — all three consumers (cluster builder, strict-light setup, shadow-data copy) route through `GetShadowSlot()`:

- **`ShadowCasterManager::IsActive()`** — boot-latched; true only when SCM installed its hooks at boot and no conflicting external plugin was detected.
- **`GetShadowSlot()`** now falls back to the engine's own `shadowmapDescriptors[0].shadowmapIndex` when SCM is inactive — the exact vanilla slice the engine rendered into, with the directional sun mapped to `-1`. VR-aware (mirrors `SetShadowParameters`).

Result: with SLF off, point/spot casters light **and** shadow through the existing kSHADOWMAPS (t102/t103) path, exactly as vanilla LightLimitFix would — matching the issue's "no change from the game" intent. SCM-on behavior is unchanged. Downstream bounds checks already clamp any out-of-range slice safely.

## Testing

- Built `ALL` preset clean (0 compile/link errors), deployed to SE + VR.
- **Confirmed in-game (SE):** with Shadow Limit Fix unticked, shadowcasters emit light again; toggling SLF back on leaves normal behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)