### PR TITLE
fix(llf): guard against null sceneLights[0]

### DIFF
--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -1215,6 +1215,45 @@ void LightLimitFix::UpdateStructure()
 
 void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
 {
+	// Defensive pre-call guard for the engine's directional-light setup.
+	// BSLightingShader::SetupGeometry unconditionally calls
+	// GeometrySetupConstantDirectionalLight, which reads sceneLights[0], then
+	// sceneLights[0]->light (NiLight, BSLight+0x48), then dereferences
+	// NiLight+0x15C with NO validation. Verified via Ghidra on SkyrimVR 1.4.15
+	// (SetupGeometry 0x141338f60 -> 0x1412f4500): numLights==0 makes it read
+	// sceneLights[0] off a null array; numLights>=1 with a null/stale
+	// sceneLights[0].light derefs a bad NiLight at +0x15C.
+	//
+	// PBR books rendered in the UI 3D scene (UI3DSceneManager) reach this path
+	// with a sceneLights[0] whose NiLight is null or stale, producing a
+	// reproducible CTD (issue #92: rdx=0 reads [0x15C], stale rdx reads
+	// [rdx+0x15C]). The BSLight* itself is valid (the crash is past the BSLight
+	// read), so the unsafe field is specifically sceneLights[0]->light. The
+	// engine reads slot 0 regardless of numLights and there is no safe
+	// substitute light, so clamping numLights (as the BSEffectShader guard
+	// below does) would only move the crash -- the only safe action is to skip
+	// the engine call for this geometry: one mis-lit frame instead of a crash.
+	if (Pass) {
+		const auto isPlausible = [](const void* p) {
+			const auto v = reinterpret_cast<std::uintptr_t>(p);
+			return v >= 0x10000 && v < 0x800000000000ull && (v & 0x7) == 0;
+		};
+		RE::BSLight* dirLight = (Pass->numLights > 0 && Pass->sceneLights) ? Pass->sceneLights[0] : nullptr;
+		if (Pass->numLights == 0 || !isPlausible(dirLight) || !isPlausible(dirLight->light.get())) {
+			static int logged = 0;
+			if (logged++ < 10) {
+				logger::warn(
+					"[LLF] BSLightingShader_SetupGeometry: directional sceneLights[0] unsafe "
+					"(numLights={} BSLight=0x{:x} NiLight=0x{:x}); skipping engine SetupGeometry "
+					"to avoid GeometrySetupConstantDirectionalLight null-deref (#92)",
+					Pass->numLights,
+					reinterpret_cast<std::uintptr_t>(dirLight),
+					reinterpret_cast<std::uintptr_t>(isPlausible(dirLight) ? dirLight->light.get() : nullptr));
+			}
+			return;
+		}
+	}
+
 	auto& singleton = globals::features::lightLimitFix;
 	singleton.BSLightingShader_SetupGeometry_Before(Pass);
 	func(This, Pass, RenderFlags);

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -1213,6 +1213,28 @@ void LightLimitFix::UpdateStructure()
 	context->CSSetUnorderedAccessViews(0, 3, null_uavs, nullptr);
 }
 
+namespace
+{
+	// SEH-guarded read of sceneLights[0]->light. The pointer-value plausibility
+	// check can't distinguish a live BSLight from a stale-but-canonical one, so
+	// reading dirLight->light can itself AV (#92). Treat any fault as "no NiLight"
+	// so the caller skips the engine's null-deref path instead of crashing in the
+	// guard. Kept in its own function (no C++ unwinding objects) per MSVC's __try
+	// restriction. Matches the __except(1) AV-guard pattern used elsewhere here.
+	RE::NiLight* SafeReadDirectionalNiLight(RE::BSLight* dirLight)
+	{
+#if defined(_MSC_VER)
+		__try {
+			return dirLight->light.get();
+		} __except (1) {
+			return nullptr;
+		}
+#else
+		return dirLight->light.get();
+#endif
+	}
+}
+
 void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
 {
 	// Engine derefs sceneLights[0]->light with no null check -> CTD on a null/
@@ -1225,7 +1247,11 @@ void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* T
 			return v >= 0x10000 && v < 0x800000000000ull && (v & 0x7) == 0;
 		};
 		RE::BSLight* dirLight = (Pass->numLights > 0 && Pass->sceneLights) ? Pass->sceneLights[0] : nullptr;
-		if (Pass->numLights == 0 || !isPlausible(dirLight) || !isPlausible(dirLight->light.get())) {
+		// isPlausible only validates the pointer VALUE; a stale-but-canonical
+		// dirLight still AVs when we read dirLight->light, so capture the NiLight
+		// under SEH and reuse it below (no second deref).
+		RE::NiLight* niLight = isPlausible(dirLight) ? SafeReadDirectionalNiLight(dirLight) : nullptr;
+		if (Pass->numLights == 0 || !isPlausible(niLight)) {
 			directionalSlotSafe = false;
 			static int logged = 0;
 			if (logged++ < 10) {
@@ -1235,7 +1261,7 @@ void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* T
 					"to avoid GeometrySetupConstantDirectionalLight null-deref (#92)",
 					Pass->numLights,
 					reinterpret_cast<std::uintptr_t>(dirLight),
-					reinterpret_cast<std::uintptr_t>(isPlausible(dirLight) ? dirLight->light.get() : nullptr));
+					reinterpret_cast<std::uintptr_t>(niLight));
 			}
 		}
 	}

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -1215,24 +1215,15 @@ void LightLimitFix::UpdateStructure()
 
 void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
 {
-	// Defensive pre-call guard for the engine's directional-light setup.
-	// BSLightingShader::SetupGeometry unconditionally calls
-	// GeometrySetupConstantDirectionalLight, which reads sceneLights[0], then
-	// sceneLights[0]->light (NiLight, BSLight+0x48), then dereferences
-	// NiLight+0x15C with NO validation. Verified via Ghidra on SkyrimVR 1.4.15
-	// (SetupGeometry 0x141338f60 -> 0x1412f4500): numLights==0 makes it read
-	// sceneLights[0] off a null array; numLights>=1 with a null/stale
-	// sceneLights[0].light derefs a bad NiLight at +0x15C.
-	//
-	// PBR books rendered in the UI 3D scene (UI3DSceneManager) reach this path
-	// with a sceneLights[0] whose NiLight is null or stale, producing a
-	// reproducible CTD (issue #92: rdx=0 reads [0x15C], stale rdx reads
-	// [rdx+0x15C]). The BSLight* itself is valid (the crash is past the BSLight
-	// read), so the unsafe field is specifically sceneLights[0]->light. The
-	// engine reads slot 0 regardless of numLights and there is no safe
-	// substitute light, so clamping numLights (as the BSEffectShader guard
-	// below does) would only move the crash -- the only safe action is to skip
-	// the engine call for this geometry: one mis-lit frame instead of a crash.
+	// The engine's BSLightingShader::SetupGeometry unconditionally derefs
+	// sceneLights[0]->light (the directional slot) with no null check, so a
+	// null/stale entry CTDs -- reproducible with PBR books in the UI 3D scene
+	// (#92). The sibling BSEffectShader guard below clamps numLights, but that
+	// can't help here: slot 0 is read regardless of count and there's no
+	// substitute light. So validate the slot and skip only the engine call when
+	// it isn't safely dereferenceable -- one mis-lit frame instead of a crash.
+	// Full disassembly / crash signature in PR #102.
+	bool directionalSlotSafe = true;
 	if (Pass) {
 		const auto isPlausible = [](const void* p) {
 			const auto v = reinterpret_cast<std::uintptr_t>(p);
@@ -1240,6 +1231,7 @@ void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* T
 		};
 		RE::BSLight* dirLight = (Pass->numLights > 0 && Pass->sceneLights) ? Pass->sceneLights[0] : nullptr;
 		if (Pass->numLights == 0 || !isPlausible(dirLight) || !isPlausible(dirLight->light.get())) {
+			directionalSlotSafe = false;
 			static int logged = 0;
 			if (logged++ < 10) {
 				logger::warn(
@@ -1250,13 +1242,16 @@ void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* T
 					reinterpret_cast<std::uintptr_t>(dirLight),
 					reinterpret_cast<std::uintptr_t>(isPlausible(dirLight) ? dirLight->light.get() : nullptr));
 			}
-			return;
 		}
 	}
 
+	// Run the before/after callbacks even when skipping the engine call, so the
+	// strict-light constant buffer is reset (empty) for this pass rather than
+	// leaving the previous geometry's data bound for subsequent draws.
 	auto& singleton = globals::features::lightLimitFix;
 	singleton.BSLightingShader_SetupGeometry_Before(Pass);
-	func(This, Pass, RenderFlags);
+	if (directionalSlotSafe)
+		func(This, Pass, RenderFlags);
 	singleton.BSLightingShader_SetupGeometry_After(Pass);
 }
 

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -1215,14 +1215,9 @@ void LightLimitFix::UpdateStructure()
 
 void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
 {
-	// The engine's BSLightingShader::SetupGeometry unconditionally derefs
-	// sceneLights[0]->light (the directional slot) with no null check, so a
-	// null/stale entry CTDs -- reproducible with PBR books in the UI 3D scene
-	// (#92). The sibling BSEffectShader guard below clamps numLights, but that
-	// can't help here: slot 0 is read regardless of count and there's no
-	// substitute light. So validate the slot and skip only the engine call when
-	// it isn't safely dereferenceable -- one mis-lit frame instead of a crash.
-	// Full disassembly / crash signature in PR #102.
+	// Engine derefs sceneLights[0]->light with no null check -> CTD on a null/
+	// stale directional slot (#92). Skip the engine call when it isn't safe;
+	// clamping numLights (sibling guard) can't help -- slot 0 is always read.
 	bool directionalSlotSafe = true;
 	if (Pass) {
 		const auto isPlausible = [](const void* p) {
@@ -1245,9 +1240,7 @@ void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* T
 		}
 	}
 
-	// Run the before/after callbacks even when skipping the engine call, so the
-	// strict-light constant buffer is reset (empty) for this pass rather than
-	// leaving the previous geometry's data bound for subsequent draws.
+	// Run before/after even on skip so the strict-light CB is reset, not stale.
 	auto& singleton = globals::features::lightLimitFix;
 	singleton.BSLightingShader_SetupGeometry_Before(Pass);
 	if (directionalSlotSafe)

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -1,6 +1,7 @@
 #include "LightLimitFix.h"
 #include "Features/InverseSquareLighting/Common.h"
 #include "Features/LightLimitFix/SettingsSanitize.h"
+#include "Features/LightLimitFix/ShadowCasterMath.h"
 #include "Globals.h"
 #include "InverseSquareLighting.h"
 #include "LinearLighting.h"
@@ -1242,16 +1243,12 @@ void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* T
 	// clamping numLights (sibling guard) can't help -- slot 0 is always read.
 	bool directionalSlotSafe = true;
 	if (Pass) {
-		const auto isPlausible = [](const void* p) {
-			const auto v = reinterpret_cast<std::uintptr_t>(p);
-			return v >= 0x10000 && v < 0x800000000000ull && (v & 0x7) == 0;
-		};
+		using ShadowCasterManager::IsPlausibleShadowLightPtr;
 		RE::BSLight* dirLight = (Pass->numLights > 0 && Pass->sceneLights) ? Pass->sceneLights[0] : nullptr;
-		// isPlausible only validates the pointer VALUE; a stale-but-canonical
-		// dirLight still AVs when we read dirLight->light, so capture the NiLight
-		// under SEH and reuse it below (no second deref).
-		RE::NiLight* niLight = isPlausible(dirLight) ? SafeReadDirectionalNiLight(dirLight) : nullptr;
-		if (Pass->numLights == 0 || !isPlausible(niLight)) {
+		// A stale-but-canonical dirLight passes the pointer-value check yet still AVs on
+		// dirLight->light, so capture the NiLight under SEH and reuse it below (no second deref).
+		RE::NiLight* niLight = IsPlausibleShadowLightPtr(reinterpret_cast<std::uintptr_t>(dirLight)) ? SafeReadDirectionalNiLight(dirLight) : nullptr;
+		if (Pass->numLights == 0 || !IsPlausibleShadowLightPtr(reinterpret_cast<std::uintptr_t>(niLight))) {
 			directionalSlotSafe = false;
 			static int logged = 0;
 			if (logged++ < 10) {
@@ -1293,14 +1290,11 @@ void LightLimitFix::Hooks::BSEffectShader_SetupGeometry::thunk(RE::BSShader* Thi
 	// Entries failing either check stop the loop; the engine's own loop
 	// bails on the first bad entry too, so clamping matches its contract.
 	if (Pass && Pass->sceneLights && Pass->numLights > 0) {
-		const auto isPlausible = [](const void* p) {
-			const auto v = reinterpret_cast<std::uintptr_t>(p);
-			return v >= 0x10000 && v < 0x800000000000ull && (v & 0x7) == 0;
-		};
+		using ShadowCasterManager::IsPlausibleShadowLightPtr;
 		std::uint8_t validCount = 0;
 		for (std::uint8_t i = 0; i < Pass->numLights; ++i) {
 			RE::BSLight* bsLight = Pass->sceneLights[i];
-			if (!isPlausible(bsLight)) {
+			if (!IsPlausibleShadowLightPtr(reinterpret_cast<std::uintptr_t>(bsLight))) {
 				static int loggedBsLight = 0;
 				if (loggedBsLight++ < 10) {
 					logger::warn(
@@ -1311,7 +1305,7 @@ void LightLimitFix::Hooks::BSEffectShader_SetupGeometry::thunk(RE::BSShader* Thi
 				break;
 			}
 			RE::NiLight* niLight = bsLight->light.get();
-			if (!isPlausible(niLight)) {
+			if (!IsPlausibleShadowLightPtr(reinterpret_cast<std::uintptr_t>(niLight))) {
 				// Catches both NULL (engine cleared the NiPointer) and
 				// garbage (BSLight memory recycled). NULL is the more common
 				// observed failure -- the engine's loop has no null check


### PR DESCRIPTION
## Problem

Fixes #92 — reproducible **CTD when rendering a PBR book** (e.g. Book Covers Skyrim PBR, Faultier's PBR Clutter) in the VR UI scene.

The reporter's stack pointed at `TruePBR.cpp:1073`, but that's only the **return address**. Ghidra analysis (SkyrimVR 1.4.15) shows the fault is in the engine's `BSLightingShader::SetupGeometry` (`0x141338f60`), which **unconditionally** calls `GeometrySetupConstantDirectionalLight` (`0x1412f4500`):

```
+133AD0A  CMP [RDX+0x1f], 0       ; numLights == 0?
+133AD25  MOV RAX,[RAX]           ; sceneLights[0]        (AV if numLights==0 → RAX=0)
+133AD33  MOV RDX,[RAX+0x48]      ; sceneLights[0]->light (NiLight)
+133AD4B  MULSS XMM2,[RDX+0x15C]  ; <-- CRASH: NiLight null/stale
```

The engine never null-checks `sceneLights[0]->light`. The two reported faults match the disassembly **exactly**:
- `rdx=0` → read `[0x15C]`
- `rdx=0x1002BD59C04` → read `[rdx+0x15C]=0x1002BD59D60`

So `sceneLights[0]` is a valid `BSLight*` (the fault is past the BSLight read) but its `NiLight` is null/stale — the state PBR books carry in the `UI3DSceneManager` scene.

## Fix

The sibling `BSEffectShader_SetupGeometry` hook already guards this bug class by clamping `numLights` — but that's unsafe here: the directional setup reads slot 0 **regardless of count**, so clamping to 0 would just move the crash to `+133AD25`, and there's no safe substitute light. So the `BSLightingShader_SetupGeometry` hook now validates the directional slot (`sceneLights[0]->light`) and **skips the engine call** when it isn't safely dereferenceable — one mis-lit frame instead of a crash. Pure CommonLib accessors → protects SE/AE/VR alike.

## Testing

- Built `ALL` preset clean (0 compile/link errors).
- Root cause confirmed via Ghidra (crash-offset math matches both reported `rdx` values exactly).
- **In-game repro confirmation still pending** the reporter's exact mod setup / `.log`; the guard is defensive and only engages on already-invalid state that would otherwise CTD, so it's safe to land regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes occurring during light rendering by implementing safety validation checks.
  * Added safeguards to ensure the lighting system handles edge cases correctly.
  * Included diagnostic logging (limited to 10 warnings per session) to aid troubleshooting of lighting-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->