### PR TITLE
ci: use prebuilt CommonLib

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -57,7 +57,8 @@
                 "ENABLE_SKYRIM_AE": "ON",
                 "ENABLE_SKYRIM_SE": "ON",
                 "ENABLE_SKYRIM_VR": "ON",
-                "AUTO_PLUGIN_DEPLOYMENT": "OFF"
+                "AUTO_PLUGIN_DEPLOYMENT": "OFF",
+                "COMMONLIB_PREBUILT_MULTICONFIG": "ON"
             },
             "inherits": "skyrim"
         },
@@ -68,7 +69,8 @@
                 "ENABLE_SKYRIM_AE": "ON",
                 "ENABLE_SKYRIM_SE": "ON",
                 "ENABLE_SKYRIM_VR": "ON",
-                "AUTO_PLUGIN_DEPLOYMENT": "OFF"
+                "AUTO_PLUGIN_DEPLOYMENT": "OFF",
+                "COMMONLIB_PREBUILT_MULTICONFIG": "ON"
             },
             "inherits": "skyrim"
         }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -73,6 +73,14 @@
                 "COMMONLIB_PREBUILT_MULTICONFIG": "ON"
             },
             "inherits": "skyrim"
+        },
+        {
+            "name": "ALL-DEBUG",
+            "description": "Like ALL but builds CommonLib from source. The prebuilt package is Release-only (Debug maps to no imported location), so a Debug build off ALL fails to link — this preset keeps Debug-from-source working in its own build/ALL-DEBUG dir.",
+            "inherits": "ALL",
+            "cacheVariables": {
+                "COMMONLIB_PREBUILT_MULTICONFIG": "OFF"
+            }
         }
     ],
     "buildPresets": [
@@ -114,7 +122,7 @@
         {
             "name": "Debug",
             "description": "Debug build for CS SKSE plugin, generate an AIO folder thats ready to copy",
-            "configurePreset": "ALL",
+            "configurePreset": "ALL-DEBUG",
             "configuration": "Debug",
             "targets": ["CommunityShaders", "AIO"]
         }


### PR DESCRIPTION
**Draft — blocked on [alandtse/CommonLibVR#173](https://github.com/alandtse/CommonLibVR/pull/173) releasing.**

Opts CS into the prebuilt CommonLibSSE auto-fetch so CI downloads + links the prebuilt static lib instead of compiling CommonLib from source (~16 min → a few min). Sets `COMMONLIB_PREBUILT_MULTICONFIG=ON` in the `ALL` / `ALL-VS2022` presets.

## Why the flag is needed
The cmake prebuilt is baked **Release-only, single-config**, and the resolver skips multi-config generators by default (it can't rule out a Debug build, which would mislink the Release lib). CS uses the **Visual Studio generator** but only builds **Release**, so it opts in via `COMMONLIB_PREBUILT_MULTICONFIG` (added in CommonLibVR#173): the IMPORTED target serves Release and maps Debug→nothing (a stray Debug build fails loudly).

## To finalize (after #173 releases)
1. Merge + release CommonLibVR#173 (cuts a new tag, e.g. v4.26.0).
2. **Bump `extern/CommonLibSSE-NG`** from `v4.19.0` → that tag. This is the functional change — the flag is inert until the submodule carries the multi-config opt-in. Note: v4.19→v4.2x is a multi-version CommonLib jump; CI will surface any CS-side API adjustments needed.
3. Un-draft once CI is green (the build job should show it downloading `commonlibsse-ng-prebuilt-<tag>-all-msvc-cmake.zip`).

Until then this is a no-op (the flag is an unknown cache var on v4.19.0) and the build is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enabled prebuilt multiconfig support in build configuration to improve build compatibility and flexibility across different platforms
  * Updated CommonLibSSE-NG dependency to the latest version, providing access to recent improvements, optimizations, and enhanced compatibility features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->