### PR TITLE
fix(vr): shadow flicker and banding

### DIFF
--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -159,15 +159,25 @@ namespace LightLimitFix
 	Texture2DArray<float> ShadowMaps : register(t103);
 	Texture2DArray<float> DirectionalShadowCascades : register(t99);
 
-	// engineMaskShadow: the engine's pre-rendered 4-cascade shadow mask sample
-	// at this pixel (TexShadowMaskSampler.Load(int3(Position.xy, 0)).x). LLF's
-	// DirectionalShadowLightData carries only cascades 0/1 (ShadowProj[2] /
-	// EndSplitDistances.xy); past EndSplitDistances.y we have no LLF data and
-	// must fall through to the engine mask. Returning 1.0 there leaves distant
-	// pixels fully lit -- visible as global scene brightening with shadows
-	// disappearing past a depth that varies with camera position.
+	// engineMaskShadow: usually the engine's pre-rendered 4-cascade shadow mask
+	// sample at this pixel (TexShadowMaskSampler.Load(int3(Position.xy, 0)).x).
+	// In VR it becomes the source of truth for all cascades; outside VR LLF's
+	// DirectionalShadowLightData still carries only cascades 0/1 (ShadowProj[2]
+	// / EndSplitDistances.xy), so this value remains the fallback after
+	// EndSplitDistances.y. Returning 1.0 there leaves distant pixels fully lit
+	// -- visible as global scene brightening with shadows disappearing past a
+	// depth that varies with camera position.
 	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex, float engineMaskShadow)
 	{
+#if defined(VR)
+		// VR keeps the engine shadowmask as the source of truth. The LLF
+		// two-cascade PCF path only carries cascades 0/1 and can introduce
+		// broad receiver banding after the rasterizer safety path removes the
+		// old caster-side global rasterizer swap. Utility.hlsl still applies
+		// the VR-only receiver bias while producing this mask.
+		return engineMaskShadow;
+#endif
+
 		DirectionalShadowLightData shadowLightData = DirectionalShadowLights[0];
 
 		float shadowMapDepth = SharedData::GetScreenDepth(FrameBuffer::GetShadowDepth(worldPosition, eyeIndex));
@@ -288,9 +298,10 @@ namespace LightLimitFix
 		return shadow;
 	}
 
-	// Convenience overload: callers without TexShadowMaskSampler bound
-	// (e.g. Particle.hlsl) get the lit-fallback behaviour (1.0) past
-	// cascade 1, matching the pre-engine-mask behaviour for those paths.
+	// Convenience overloads: in VR the 5-arg overload returns its
+	// engineMaskShadow directly. Callers without TexShadowMaskSampler bound
+	// intentionally stay fully lit instead of re-entering the LLF two-cascade
+	// sampler that caused receiver-side banding.
 	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex)
 	{
 		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex, 1.0);

--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -159,14 +159,15 @@ namespace LightLimitFix
 	Texture2DArray<float> ShadowMaps : register(t103);
 	Texture2DArray<float> DirectionalShadowCascades : register(t99);
 
-	// engineMaskShadow: usually the engine's pre-rendered 4-cascade shadow mask
-	// sample at this pixel (TexShadowMaskSampler.Load(int3(Position.xy, 0)).x).
-	// In VR it becomes the source of truth for all cascades; outside VR LLF's
-	// DirectionalShadowLightData still carries only cascades 0/1 (ShadowProj[2]
-	// / EndSplitDistances.xy), so this value remains the fallback after
-	// EndSplitDistances.y. Returning 1.0 there leaves distant pixels fully lit
-	// -- visible as global scene brightening with shadows disappearing past a
-	// depth that varies with camera position.
+	// engineMaskShadow: the engine's pre-rendered 4-cascade shadow mask sample
+	// at this pixel (TexShadowMaskSampler.Load(int3(Position.xy, 0)).x). LLF's
+	// DirectionalShadowLightData carries only cascades 0/1 (ShadowProj[2] /
+	// EndSplitDistances.xy); past EndSplitDistances.y we have no LLF data and
+	// must fall through to the engine mask. In VR this same value also becomes
+	// the source of truth for all cascades.
+	// Returning 1.0 there leaves distant pixels fully lit -- visible as global
+	// scene brightening with shadows disappearing past a depth that varies with
+	// camera position.
 	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex, float engineMaskShadow)
 	{
 #if defined(VR)
@@ -298,10 +299,9 @@ namespace LightLimitFix
 		return shadow;
 	}
 
-	// Convenience overloads: in VR the 5-arg overload returns its
-	// engineMaskShadow directly. Callers without TexShadowMaskSampler bound
-	// intentionally stay fully lit instead of re-entering the LLF two-cascade
-	// sampler that caused receiver-side banding.
+	// Convenience overload: callers without TexShadowMaskSampler bound
+	// (e.g. Particle.hlsl) pass the default 1.0 engine-mask value through the
+	// 5-arg path. In VR that avoids re-entering LLF's direct sampler.
 	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex)
 	{
 		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex, 1.0);

--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -163,20 +163,22 @@ namespace LightLimitFix
 	// at this pixel (TexShadowMaskSampler.Load(int3(Position.xy, 0)).x). LLF's
 	// DirectionalShadowLightData carries only cascades 0/1 (ShadowProj[2] /
 	// EndSplitDistances.xy); past EndSplitDistances.y we have no LLF data and
-	// must fall through to the engine mask. In VR this same value also becomes
-	// the source of truth for all cascades.
+	// must fall through to the engine mask. For mask-backed VR callers this same
+	// value also becomes the source of truth for all cascades.
 	// Returning 1.0 there leaves distant pixels fully lit -- visible as global
 	// scene brightening with shadows disappearing past a depth that varies with
 	// camera position.
-	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex, float engineMaskShadow)
+	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex, float engineMaskShadow, bool useEngineMaskShadow)
 	{
 #if defined(VR)
-		// VR keeps the engine shadowmask as the source of truth. The LLF
-		// two-cascade PCF path only carries cascades 0/1 and can introduce
-		// broad receiver banding after the rasterizer safety path removes the
-		// old caster-side global rasterizer swap. Utility.hlsl still applies
-		// the VR-only receiver bias while producing this mask.
-		return engineMaskShadow;
+		if (useEngineMaskShadow) {
+			// VR keeps the engine shadowmask as the source of truth. The LLF
+			// two-cascade PCF path only carries cascades 0/1 and can introduce
+			// broad receiver banding after the rasterizer safety path removes the
+			// old caster-side global rasterizer swap. Utility.hlsl still applies
+			// the VR-only receiver bias while producing this mask.
+			return engineMaskShadow;
+		}
 #endif
 
 		DirectionalShadowLightData shadowLightData = DirectionalShadowLights[0];
@@ -299,17 +301,22 @@ namespace LightLimitFix
 		return shadow;
 	}
 
+	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex, float engineMaskShadow)
+	{
+		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex, engineMaskShadow, true);
+	}
+
 	// Convenience overload: callers without TexShadowMaskSampler bound
-	// (e.g. Particle.hlsl) pass the default 1.0 engine-mask value through the
-	// 5-arg path. In VR that avoids re-entering LLF's direct sampler.
+	// can still route through the direct LLF sampler without an engine-mask
+	// sample.
 	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex)
 	{
-		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex, 1.0);
+		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex, 1.0, false);
 	}
 
 	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix)
 	{
-		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, 0, 1.0);
+		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, 0, 1.0, false);
 	}
 
 	float SampleShadowGather(uint shadowIndex, float2 uv, float receiverDepth)

--- a/package/Shaders/Common/DirectionalShadow.hlsli
+++ b/package/Shaders/Common/DirectionalShadow.hlsli
@@ -6,12 +6,13 @@
 namespace DirectionalShadow
 {
 	// Single owner of the directional-shadow routing decision, so new consumers
-	// can't read the stale engine mask under SLF. VR keeps the engine mask path
-	// because the LLF two-cascade directional sampler can introduce receiver
-	// banding after the rasterizer safety split; non-VR still samples LLF cascades
-	// directly. Also owns the PCF noise-rotation so callers skip the sincos
-	// boilerplate. Lighting.hlsl deliberately bypasses this helper and feeds the
-	// mask into LLF directly. Needs LightLimitFix.hlsli first.
+	// can't read the stale engine mask under SLF. Under LIGHT_LIMIT_FIX the engine
+	// mask is a no-op, so sample LLF cascades directly (fully lit past range);
+	// VR is the exception and keeps the engine mask path to avoid receiver
+	// banding after the rasterizer safety split.
+	// Also owns the PCF noise-rotation so callers skip the sincos boilerplate.
+	// Lighting.hlsl deliberately bypasses this helper (feeds the mask into LLF
+	// as the past-cascade fallback). Needs LightLimitFix.hlsli first.
 	float GetSceneDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise, float a_engineMaskShadow)
 	{
 #if defined(LIGHT_LIMIT_FIX)

--- a/package/Shaders/Common/DirectionalShadow.hlsli
+++ b/package/Shaders/Common/DirectionalShadow.hlsli
@@ -6,18 +6,25 @@
 namespace DirectionalShadow
 {
 	// Single owner of the directional-shadow routing decision, so new consumers
-	// can't read the stale engine mask under SLF. Under LIGHT_LIMIT_FIX the engine
-	// mask is a no-op, so sample LLF cascades directly (fully lit past range);
-	// otherwise return the engine mask as-is. Also owns the PCF noise-rotation so
-	// callers skip the sincos boilerplate. Lighting.hlsl deliberately bypasses this
-	// (feeds the mask into LLF as the past-cascade fallback). Needs LightLimitFix.hlsli first.
+	// can't read the stale engine mask under SLF. VR keeps the engine mask path
+	// because the LLF two-cascade directional sampler can introduce receiver
+	// banding after the rasterizer safety split; non-VR still samples LLF cascades
+	// directly. Also owns the PCF noise-rotation so callers skip the sincos
+	// boilerplate. Lighting.hlsl deliberately bypasses this helper and feeds the
+	// mask into LLF directly. Needs LightLimitFix.hlsli first.
 	float GetSceneDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise, float a_engineMaskShadow)
 	{
 #if defined(LIGHT_LIMIT_FIX)
+#	if defined(VR)
+		// Keep every VR caller on the engine-produced mask so they stay aligned
+		// with Utility.hlsl's receiver bias and never fall back to LLF's direct sampler.
+		return a_engineMaskShadow;
+#	else
 		float2 rotation;
 		sincos(Math::TAU * a_screenNoise, rotation.y, rotation.x);
 		float2x2 rotationMatrix = float2x2(rotation.x, rotation.y, -rotation.y, rotation.x);
 		return LightLimitFix::GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex);
+#	endif
 #else
 		return a_engineMaskShadow;
 #endif

--- a/package/Shaders/Common/DirectionalShadow.hlsli
+++ b/package/Shaders/Common/DirectionalShadow.hlsli
@@ -8,26 +8,44 @@ namespace DirectionalShadow
 	// Single owner of the directional-shadow routing decision, so new consumers
 	// can't read the stale engine mask under SLF. Under LIGHT_LIMIT_FIX the engine
 	// mask is a no-op, so sample LLF cascades directly (fully lit past range);
-	// VR is the exception and keeps the engine mask path to avoid receiver
-	// banding after the rasterizer safety split.
+	// mask-backed VR callers are the exception and keep the engine mask path to
+	// avoid receiver banding after the rasterizer safety split.
 	// Also owns the PCF noise-rotation so callers skip the sincos boilerplate.
 	// Lighting.hlsl deliberately bypasses this helper (feeds the mask into LLF
 	// as the past-cascade fallback). Needs LightLimitFix.hlsli first.
-	float GetSceneDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise, float a_engineMaskShadow)
-	{
 #if defined(LIGHT_LIMIT_FIX)
-#	if defined(VR)
-		// Keep every VR caller on the engine-produced mask so they stay aligned
-		// with Utility.hlsl's receiver bias and never fall back to LLF's direct sampler.
-		return a_engineMaskShadow;
-#	else
+	float SampleLightLimitFixDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise)
+	{
 		float2 rotation;
 		sincos(Math::TAU * a_screenNoise, rotation.y, rotation.x);
 		float2x2 rotationMatrix = float2x2(rotation.x, rotation.y, -rotation.y, rotation.x);
 		return LightLimitFix::GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex);
+	}
+#endif
+
+	float GetSceneDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise, float a_engineMaskShadow)
+	{
+#if defined(LIGHT_LIMIT_FIX)
+#	if defined(VR)
+		// Keep masked VR callers on the engine-produced mask so they stay
+		// aligned with Utility.hlsl's receiver bias.
+		return a_engineMaskShadow;
+#	else
+		return SampleLightLimitFixDirectionalShadow(worldPosition, worldPositionWS, eyeIndex, a_screenNoise);
 #	endif
 #else
 		return a_engineMaskShadow;
+#endif
+	}
+
+	// Maskless callers (for example particles) still need the direct LLF path
+	// because they have no engine shadowmask sample to return in VR.
+	float GetSceneDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise)
+	{
+#if defined(LIGHT_LIMIT_FIX)
+		return SampleLightLimitFixDirectionalShadow(worldPosition, worldPositionWS, eyeIndex, a_screenNoise);
+#else
+		return 1.0;
 #endif
 	}
 }

--- a/package/Shaders/Particle.hlsl
+++ b/package/Shaders/Particle.hlsl
@@ -315,7 +315,7 @@ PS_OUTPUT main(PS_INPUT input)
 #	if defined(VOLUMETRIC_SHADOWS)
 		dirSoftShadow = VolumetricShadows::GetVSMShadow2D(positionWS.xyz, worldPositionWS, eyeIndex, dirDetailedShadow);
 #	else
-		dirDetailedShadow = DirectionalShadow::GetSceneDirectionalShadow(positionWS.xyz, worldPositionWS, eyeIndex, screenNoise, 1.0);
+		dirDetailedShadow = DirectionalShadow::GetSceneDirectionalShadow(positionWS.xyz, worldPositionWS, eyeIndex, screenNoise);
 #	endif
 	}
 

--- a/package/Shaders/Utility.hlsl
+++ b/package/Shaders/Utility.hlsl
@@ -529,32 +529,42 @@ PS_OUTPUT main(PS_INPUT input)
 		float shadowVisibility = 0;
 
 		float3 positionLS = mul(transpose(lightProjectionMatrix), float4(positionMS.xyz, 1)).xyz;
+#			if defined(VR)
+		float shadowMapCompareDepth = positionLS.z - shadowMapThreshold;
+#			else
+		float shadowMapCompareDepth = positionLS.z;
+#			endif
 
 #			if SHADOWFILTER == 0
 		float shadowMapValue = TexShadowMapSampler.Sample(SampShadowMapSampler, float3(positionLS.xy, cascadeIndex)).x;
-		if (shadowMapValue >= positionLS.z) {
+		if (shadowMapValue >= shadowMapCompareDepth) {
 			shadowVisibility = 1;
 		}
 #			elif SHADOWFILTER == 1
-		shadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(positionLS.xy, cascadeIndex), positionLS.z).x;
+		shadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(positionLS.xy, cascadeIndex), shadowMapCompareDepth).x;
 #			elif SHADOWFILTER == 3
-		shadowVisibility = SampleShadowPCF(TexShadowMapSamplerComp, SampShadowMapSamplerComp, positionLS.xy, cascadeIndex, positionLS.z, rotationMatrix, ShadowSampleParam.z * 0.5);
+		shadowVisibility = SampleShadowPCF(TexShadowMapSamplerComp, SampShadowMapSamplerComp, positionLS.xy, cascadeIndex, shadowMapCompareDepth, rotationMatrix, ShadowSampleParam.z * 0.5);
 #			endif
 
 		if (cascadeIndex < 1 && StartSplitDistances.y < shadowMapDepth) {
 			float cascade1ShadowVisibility = 0;
 
 			float3 cascade1PositionLS = mul(transpose(ShadowMapProj[eyeIndex][1]), float4(positionMS.xyz, 1)).xyz;
+#			if defined(VR)
+			float cascade1CompareDepth = cascade1PositionLS.z - AlphaTestRef.z;
+#			else
+			float cascade1CompareDepth = cascade1PositionLS.z;
+#			endif
 
 #			if SHADOWFILTER == 0
 			float cascade1ShadowMapValue = TexShadowMapSampler.Sample(SampShadowMapSampler, float3(cascade1PositionLS.xy, 1)).x;
-			if (cascade1ShadowMapValue >= cascade1PositionLS.z) {
+			if (cascade1ShadowMapValue >= cascade1CompareDepth) {
 				cascade1ShadowVisibility = 1;
 			}
 #			elif SHADOWFILTER == 1
-			cascade1ShadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(cascade1PositionLS.xy, 1), cascade1PositionLS.z).x;
+			cascade1ShadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(cascade1PositionLS.xy, 1), cascade1CompareDepth).x;
 #			elif SHADOWFILTER == 3
-			cascade1ShadowVisibility = SampleShadowPCF(TexShadowMapSamplerComp, SampShadowMapSamplerComp, cascade1PositionLS.xy, 1, cascade1PositionLS.z, rotationMatrix, ShadowSampleParam.z * 0.5);
+			cascade1ShadowVisibility = SampleShadowPCF(TexShadowMapSamplerComp, SampShadowMapSamplerComp, cascade1PositionLS.xy, 1, cascade1CompareDepth, rotationMatrix, ShadowSampleParam.z * 0.5);
 #			endif
 
 			float cascade1BlendFactor = smoothstep(0, 1, (shadowMapDepth - StartSplitDistances.y) / (EndSplitDistances.x - StartSplitDistances.y));

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -224,7 +224,13 @@ void ShadowmapRasterizerFix::CloneRasterStates(const RasterStateArray& inputArra
 
 			GetUpdatedRasterDesc(desc, descriptors[cascade]);
 
-			DX::ThrowIfFailed(globals::d3d::device->CreateRasterizerState(&desc, &clonedRaster));
+			if (const auto hr = globals::d3d::device->CreateRasterizerState(&desc, &clonedRaster); FAILED(hr)) {
+				logger::warn(
+					"ShadowmapRasterizerFix: failed to clone rasterizer state for cascade {} (hr=0x{:08X}); using original state",
+					cascade,
+					static_cast<std::uint32_t>(hr));
+				clonedRaster = nullptr;
+			}
 		}
 	});
 }

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -105,7 +105,7 @@ void ShadowmapRasterizerFix::Install()
 
 void ShadowmapRasterizerFix::InstallD3DHooks(ID3D11DeviceContext* context)
 {
-	if (!IsVRCasterBiasEnabled())
+	if (!IsVROuterCascadeCasterBiasEnabled())
 		return;
 
 	if (!context || d3dHooksInstalled)
@@ -116,7 +116,7 @@ void ShadowmapRasterizerFix::InstallD3DHooks(ID3D11DeviceContext* context)
 	d3dHooksInstalled = true;
 }
 
-bool ShadowmapRasterizerFix::IsVRCasterBiasEnabled()
+bool ShadowmapRasterizerFix::IsVROuterCascadeCasterBiasEnabled()
 {
 	return REL::Module::IsVR() &&
 	       globals::state &&
@@ -160,7 +160,9 @@ void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCas
 		return;
 	}
 
-	if (!IsVRCasterBiasEnabled()) {
+	// The VR flicker fix is always active: VR never uses the flat global rasterizer table swap.
+	// Only this optional outer-cascade caster bias is controlled by the developer-mode toggle.
+	if (!IsVROuterCascadeCasterBiasEnabled()) {
 		func(light, arg1, arg2, flags);
 		return;
 	}
@@ -263,7 +265,7 @@ void ShadowmapRasterizerFix::RebuildBiasedRasterStateLookup()
 
 ID3D11RasterizerState* ShadowmapRasterizerFix::GetBiasedRasterState(ID3D11RasterizerState* state)
 {
-	if (!IsVRCasterBiasEnabled())
+	if (!IsVROuterCascadeCasterBiasEnabled())
 		return nullptr;
 
 	if (!state || !initialized || activeCascade >= numCascades)

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -46,9 +46,11 @@ namespace
 			if (!MatchDescriptorArguments(arg1, arg2, descriptor))
 				continue;
 
-			if (descriptor.shadowmapIndex < ShadowmapRasterizerFix::maxCascades)
-				return descriptor.shadowmapIndex;
-
+			// In this branch the directional shadow data path consumes
+			// shadowmapDescriptors[i] in descriptor order (see
+			// Deferred::SetShadowCascadeParameters). Keep the rasterizer bias
+			// keyed to that same stable ordering instead of following the live
+			// shadowmapIndex field, which other shadow paths may rewrite.
 			return descriptorIndex;
 		}
 
@@ -79,6 +81,9 @@ namespace
 		if (!currentState)
 			return;
 
+		// The RSSetState hook swaps specific game raster states to biased
+		// clones during the active cascade. Restore the original state after
+		// the cascade render so later non-shadow work sees the engine's state.
 		const auto iter = originalRasterStateLookup.find(currentState);
 		if (iter != originalRasterStateLookup.end()) {
 			ShadowmapRasterizerFix::ID3D11DeviceContext_RSSetState::func(context, iter->second);

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -1,43 +1,198 @@
 #include "ShadowmapCascadeRasterizerFix.h"
 
+#include "Features/VR.h"
+#include "Globals.h"
+#include "State.h"
+
+#include <algorithm>
+#include <memory>
+#include <unordered_map>
+
+namespace
+{
+	std::unordered_map<ID3D11RasterizerState*, std::array<ID3D11RasterizerState*, ShadowmapRasterizerFix::maxCascades>> biasedRasterStateLookup;
+	std::unordered_map<ID3D11RasterizerState*, ID3D11RasterizerState*> originalRasterStateLookup;
+
+	bool MatchDescriptorCandidate(void* candidate, const RE::BSShadowLight::ShadowmapDescriptorVR& descriptor)
+	{
+		if (!candidate)
+			return false;
+
+		return candidate == std::addressof(descriptor) ||
+		       candidate == descriptor.camera[0].get() ||
+		       candidate == descriptor.camera[1].get() ||
+		       candidate == descriptor.shaderAccumulator[0].get() ||
+		       candidate == descriptor.shaderAccumulator[1].get() ||
+		       candidate == descriptor.cullingProcess;
+	}
+
+	bool MatchDescriptorArguments(void* arg1, void* arg2, const RE::BSShadowLight::ShadowmapDescriptorVR& descriptor)
+	{
+		return MatchDescriptorCandidate(arg1, descriptor) || MatchDescriptorCandidate(arg2, descriptor);
+	}
+
+	std::uint32_t ResolveNativeCascadeIndex(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2)
+	{
+		if (!light)
+			return ShadowmapRasterizerFix::invalidCascade;
+
+		auto& runtimeData = light->GetVRRuntimeData();
+		const auto descriptorCount = std::min<std::uint32_t>(
+			static_cast<std::uint32_t>(runtimeData.shadowmapDescriptors.size()),
+			std::min(light->shadowMapCount, ShadowmapRasterizerFix::maxCascades));
+
+		for (std::uint32_t descriptorIndex = 0; descriptorIndex < descriptorCount; descriptorIndex++) {
+			const auto& descriptor = runtimeData.shadowmapDescriptors[descriptorIndex];
+			if (!MatchDescriptorArguments(arg1, arg2, descriptor))
+				continue;
+
+			if (descriptor.shadowmapIndex < ShadowmapRasterizerFix::maxCascades)
+				return descriptor.shadowmapIndex;
+
+			return descriptorIndex;
+		}
+
+		return ShadowmapRasterizerFix::invalidCascade;
+	}
+
+	template <class Fn>
+	void ForEachRasterStateSlot(Fn&& fn)
+	{
+		for (int fill = 0; fill < 2; fill++) {
+			for (int cull = 0; cull < 3; cull++) {
+				for (int depth = 0; depth < 12; depth++) {
+					for (int scissor = 0; scissor < 2; scissor++) {
+						fn(fill, cull, depth, scissor);
+					}
+				}
+			}
+		}
+	}
+
+	void RestoreOriginalRasterState(ID3D11DeviceContext* context)
+	{
+		if (!context || !ShadowmapRasterizerFix::d3dHooksInstalled)
+			return;
+
+		ID3D11RasterizerState* currentState = nullptr;
+		context->RSGetState(&currentState);
+		if (!currentState)
+			return;
+
+		const auto iter = originalRasterStateLookup.find(currentState);
+		if (iter != originalRasterStateLookup.end()) {
+			ShadowmapRasterizerFix::ID3D11DeviceContext_RSSetState::func(context, iter->second);
+		}
+
+		currentState->Release();
+	}
+}
+
 void ShadowmapRasterizerFix::Install()
 {
-	// This function is called once per cascade to begin the updating and rendering process
+	// This function is called once per cascade to begin the updating and rendering process.
 	stl::write_thunk_call<BSShadowDirectionalLight_RenderShadowmaps_RenderCascade>(REL::RelocationID(101495, 108489).address() + REL::Relocate(0xC6, 0xC6, 0xF6));
 
 	gRasterStates = reinterpret_cast<RasterStateArray*>(REL::RelocationID(524748, 411363).address());
 
-	numCascades = static_cast<uint>(Util::GetGameSettingValue<std::int32_t>("iNumSplits:Display", Settings.at("iNumSplits:Display")));
+	auto configuredCascades = Util::GetGameSettingValue<std::int32_t>("iNumSplits:Display", Settings.at("iNumSplits:Display"));
+	numCascades = static_cast<std::uint32_t>(std::clamp(configuredCascades, 1, static_cast<std::int32_t>(maxCascades)));
+	currentCascade = 0;
+	activeCascade = invalidCascade;
+	ReleaseClonedRasterStates();
+	initialized = false;
 }
 
-void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCascade::thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, uint32_t flags)
+void ShadowmapRasterizerFix::InstallD3DHooks(ID3D11DeviceContext* context)
 {
-	static uint cascade = 0;
+	if (!IsVRCasterBiasEnabled())
+		return;
 
-	static bool initialized = false;
-	if (!initialized) {
-		//Backup
-		if (cascade == 0) {
-			std::memcpy(backupGameRasterStates, *gRasterStates, sizeof(RasterStateArray));
-			numCascades = std::min(numCascades, maxCascades);
+	if (!context || d3dHooksInstalled)
+		return;
+
+	stl::detour_vfunc<43, ID3D11DeviceContext_RSSetState>(context);
+
+	d3dHooksInstalled = true;
+}
+
+bool ShadowmapRasterizerFix::IsVRCasterBiasEnabled()
+{
+	return REL::Module::IsVR() &&
+	       globals::state &&
+	       globals::state->IsDeveloperMode() &&
+	       globals::features::vr.settings.EnableOuterCascadeCasterBias;
+}
+
+void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCascade::thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, std::uint32_t flags)
+{
+	if (!REL::Module::IsVR()) {
+		if (!gRasterStates) {
+			func(light, arg1, arg2, flags);
+			return;
 		}
 
-		//Clone
-		CloneRasterStates(gRasterStates, cascade);
+		const auto cascade = currentCascade % numCascades;
+		if (!initialized) {
+			if (cascade == 0) {
+				std::memcpy(backupGameRasterStates, *gRasterStates, sizeof(RasterStateArray));
+				numCascades = std::min(numCascades, maxCascades);
+			}
 
-		initialized = cascade == numCascades - 1;
+			CloneRasterStates(*gRasterStates, cascade, flatCascadeDescriptors);
+
+			initialized = cascade == numCascades - 1;
+		}
+
+		std::memcpy(*gRasterStates, shadowmapRasterStates[cascade], sizeof(RasterStateArray));
+
+		func(light, arg1, arg2, flags);
+
+		if (cascade == numCascades - 1)
+			std::memcpy(*gRasterStates, backupGameRasterStates, sizeof(RasterStateArray));
+
+		currentCascade = (cascade + 1) % numCascades;
+		return;
 	}
 
-	//Emplace
-	std::memcpy(*gRasterStates, shadowmapRasterStates[cascade], sizeof(RasterStateArray));
+	if (!gRasterStates) {
+		func(light, arg1, arg2, flags);
+		return;
+	}
 
-	func(light, arg1, arg2, flags);
+	if (!IsVRCasterBiasEnabled()) {
+		func(light, arg1, arg2, flags);
+		return;
+	}
 
-	//Restore
-	if (cascade == numCascades - 1)
-		std::memcpy(*gRasterStates, backupGameRasterStates, sizeof(RasterStateArray));
+	if (!initialized)
+		InitializeRasterStates();
 
-	cascade = ++cascade < numCascades ? cascade : 0;
+	const auto cascade = ResolveNativeCascadeIndex(light, arg1, arg2);
+	if (cascade >= numCascades) {
+		func(light, arg1, arg2, flags);
+		return;
+	}
+
+	{
+		ScopedCascadeBias scopedCascadeBias(cascade);
+		func(light, arg1, arg2, flags);
+		RestoreOriginalRasterState(globals::d3d::context);
+	}
+}
+
+void ShadowmapRasterizerFix::InitializeRasterStates()
+{
+	ReleaseClonedRasterStates();
+	std::memcpy(backupGameRasterStates, *gRasterStates, sizeof(RasterStateArray));
+
+	if (REL::Module::IsVR()) {
+		for (std::uint32_t cascade = 0; cascade < numCascades; cascade++)
+			CloneRasterStates(backupGameRasterStates, cascade, vrCascadeDescriptors);
+		RebuildBiasedRasterStateLookup();
+	}
+
+	initialized = true;
 }
 
 void ShadowmapRasterizerFix::GetUpdatedRasterDesc(D3D11_RASTERIZER_DESC& outputDesc, ShadowMapRasterizerDescriptor shadowmapDesc)
@@ -47,23 +202,99 @@ void ShadowmapRasterizerFix::GetUpdatedRasterDesc(D3D11_RASTERIZER_DESC& outputD
 	outputDesc.SlopeScaledDepthBias = shadowmapDesc.rasterSlopeScaleBias;
 }
 
-// Since state objects are shared globally across the pipeline we make duplicate arrays that cover the same range of states the game does
-void ShadowmapRasterizerFix::CloneRasterStates(RasterStateArray* inputArray, int cascade)
+void ShadowmapRasterizerFix::CloneRasterStates(const RasterStateArray& inputArray, std::uint32_t cascade, const std::array<ShadowMapRasterizerDescriptor, maxCascades>& descriptors)
 {
-	for (int fill = 0; fill < 2; fill++) {
-		for (int cull = 0; cull < 3; cull++) {
-			for (int depth = 0; depth < 12; depth++) {
-				for (int scissor = 0; scissor < 2; scissor++) {
-					if (auto* gRasterizer = (*inputArray)[fill][cull][depth][scissor]) {
-						D3D11_RASTERIZER_DESC desc{};
-						gRasterizer->GetDesc(&desc);
+	ForEachRasterStateSlot([&](int fill, int cull, int depth, int scissor) {
+		auto*& clonedRaster = shadowmapRasterStates[cascade][fill][cull][depth][scissor];
+		if (clonedRaster) {
+			clonedRaster->Release();
+			clonedRaster = nullptr;
+		}
 
-						GetUpdatedRasterDesc(desc, cascadeDescriptors[cascade]);
+		if (auto* gRasterizer = inputArray[fill][cull][depth][scissor]) {
+			D3D11_RASTERIZER_DESC desc{};
+			gRasterizer->GetDesc(&desc);
 
-						DX::ThrowIfFailed(globals::d3d::device->CreateRasterizerState(&desc, &shadowmapRasterStates[cascade][fill][cull][depth][scissor]));
-					}
-				}
+			GetUpdatedRasterDesc(desc, descriptors[cascade]);
+
+			DX::ThrowIfFailed(globals::d3d::device->CreateRasterizerState(&desc, &clonedRaster));
+		}
+	});
+}
+
+void ShadowmapRasterizerFix::ReleaseClonedRasterStates()
+{
+	ForEachRasterStateSlot([&](int fill, int cull, int depth, int scissor) {
+		for (std::uint32_t cascade = 0; cascade < maxCascades; cascade++) {
+			auto*& clonedRaster = shadowmapRasterStates[cascade][fill][cull][depth][scissor];
+			if (clonedRaster) {
+				clonedRaster->Release();
+				clonedRaster = nullptr;
 			}
 		}
+	});
+
+	biasedRasterStateLookup.clear();
+	originalRasterStateLookup.clear();
+}
+
+void ShadowmapRasterizerFix::RebuildBiasedRasterStateLookup()
+{
+	biasedRasterStateLookup.clear();
+	originalRasterStateLookup.clear();
+
+	if (!REL::Module::IsVR())
+		return;
+
+	ForEachRasterStateSlot([&](int fill, int cull, int depth, int scissor) {
+		auto* gameRaster = backupGameRasterStates[fill][cull][depth][scissor];
+		if (!gameRaster)
+			return;
+
+		auto& cascadedStates = biasedRasterStateLookup[gameRaster];
+		for (std::uint32_t cascade = 0; cascade < numCascades; cascade++) {
+			auto* biasedRaster = shadowmapRasterStates[cascade][fill][cull][depth][scissor];
+			cascadedStates[cascade] = biasedRaster;
+			if (biasedRaster)
+				originalRasterStateLookup[biasedRaster] = gameRaster;
+		}
+	});
+}
+
+ID3D11RasterizerState* ShadowmapRasterizerFix::GetBiasedRasterState(ID3D11RasterizerState* state)
+{
+	if (!IsVRCasterBiasEnabled())
+		return nullptr;
+
+	if (!state || !initialized || activeCascade >= numCascades)
+		return nullptr;
+
+	const auto desc = vrCascadeDescriptors[activeCascade];
+	if (desc.rasterDepthBias == 0 && desc.rasterDepthBiasClamp == 0.0f && desc.rasterSlopeScaleBias == 0.0f)
+		return nullptr;
+
+	const auto iter = biasedRasterStateLookup.find(state);
+	if (iter == biasedRasterStateLookup.end())
+		return nullptr;
+
+	return iter->second[activeCascade];
+}
+
+ShadowmapRasterizerFix::ScopedCascadeBias::ScopedCascadeBias(std::uint32_t cascade) :
+	previousCascade(activeCascade)
+{
+	activeCascade = cascade;
+}
+
+ShadowmapRasterizerFix::ScopedCascadeBias::~ScopedCascadeBias()
+{
+	activeCascade = previousCascade;
+}
+
+void ShadowmapRasterizerFix::ID3D11DeviceContext_RSSetState::thunk(ID3D11DeviceContext* context, ID3D11RasterizerState* state)
+{
+	if (auto* biasedState = GetBiasedRasterState(state)) {
+		state = biasedState;
 	}
+	func(context, state);
 }

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
@@ -6,8 +6,8 @@
 #include <array>
 #include <limits>
 
-// Applies shadowmap caster bias. Flat keeps the v1.5.2 rasterizer table behavior;
-// VR keeps caster bias off by default and exposes only a tiny developer-mode outer-cascade bias.
+// Flat keeps the v1.5.2 shadowmap rasterizer table behavior.
+// VR always bypasses that global table swap; the optional caster bias is developer-mode only.
 struct ShadowmapRasterizerFix : EngineFix
 {
 	std::string GetName() override { return "Shadowmap Cascade Rasterizer Fix"; }

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
@@ -6,8 +6,8 @@
 #include <array>
 #include <limits>
 
-// Flat keeps the v1.5.2 shadowmap rasterizer table behavior.
-// VR always bypasses that global table swap; the optional caster bias is developer-mode only.
+// This overrides the shadow cascade rasterizers to fix issues with peter panning and self shadowing.
+// Flat keeps the v1.5.2 shadowmap rasterizer table behavior; VR always bypasses that global table swap.
 struct ShadowmapRasterizerFix : EngineFix
 {
 	std::string GetName() override { return "Shadowmap Cascade Rasterizer Fix"; }

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
@@ -30,7 +30,7 @@ struct ShadowmapRasterizerFix : EngineFix
 	static void ReleaseClonedRasterStates();
 	static void RebuildBiasedRasterStateLookup();
 	static ID3D11RasterizerState* GetBiasedRasterState(ID3D11RasterizerState* state);
-	static bool IsVRCasterBiasEnabled();
+	static bool IsVROuterCascadeCasterBiasEnabled();
 
 	static inline std::uint32_t numCascades = 0;
 	static inline std::uint32_t currentCascade = 0;

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
@@ -1,6 +1,13 @@
 #pragma once
 
-// This overrides the shadow cascade rasterizers to fix issues with peter panning and self shadowing
+#include "EngineFix.h"
+#include "Utils/GameSetting.h"
+
+#include <array>
+#include <limits>
+
+// Applies shadowmap caster bias. Flat keeps the v1.5.2 rasterizer table behavior;
+// VR keeps caster bias off by default and exposes only a tiny developer-mode outer-cascade bias.
 struct ShadowmapRasterizerFix : EngineFix
 {
 	std::string GetName() override { return "Shadowmap Cascade Rasterizer Fix"; }
@@ -8,44 +15,86 @@ struct ShadowmapRasterizerFix : EngineFix
 
 	using RasterStateArray = ID3D11RasterizerState* [2][3][12][2];
 
-	static void CloneRasterStates(RasterStateArray* inputArray, int cascade);
-
-	static constexpr uint maxCascades = 3;
-	static inline uint numCascades = 0;
-
-	static inline RasterStateArray* gRasterStates = nullptr;
-	static inline RasterStateArray backupGameRasterStates = {};
-	static inline RasterStateArray shadowmapRasterStates[maxCascades] = {};
-
-	static constexpr int firstCascadeDepthBias = 160;
-	static constexpr float firstCascadeDepthBiasClamp = 0.015f;
-	static constexpr float firstCascadeSlopeScaleBias = 3.2f;
-
-	static constexpr int secondCascadeDepthBias = 100;
-	static constexpr float secondCascadeDepthBiasClamp = 0.015f;
-	static constexpr float secondCascadeSlopeScaleBias = 3.8f;
-
-	static constexpr int thirdCascadeDepthBias = 100;
-	static constexpr float thirdCascadeDepthBiasClamp = 0.015f;
-	static constexpr float thirdCascadeSlopeScaleBias = 3.8f;
-
 	struct ShadowMapRasterizerDescriptor
 	{
 		int rasterDepthBias;
 		float rasterDepthBiasClamp;
 		float rasterSlopeScaleBias;
 	};
+
+	static constexpr std::uint32_t maxCascades = 3;
+	static constexpr std::uint32_t invalidCascade = std::numeric_limits<std::uint32_t>::max();
+	static void InstallD3DHooks(ID3D11DeviceContext* context);
+	static void InitializeRasterStates();
+	static void CloneRasterStates(const RasterStateArray& inputArray, std::uint32_t cascade, const std::array<ShadowMapRasterizerDescriptor, maxCascades>& descriptors);
+	static void ReleaseClonedRasterStates();
+	static void RebuildBiasedRasterStateLookup();
+	static ID3D11RasterizerState* GetBiasedRasterState(ID3D11RasterizerState* state);
+	static bool IsVRCasterBiasEnabled();
+
+	static inline std::uint32_t numCascades = 0;
+	static inline std::uint32_t currentCascade = 0;
+	static inline std::uint32_t activeCascade = invalidCascade;
+	static inline bool initialized = false;
+	static inline bool d3dHooksInstalled = false;
+
+	static inline RasterStateArray* gRasterStates = nullptr;
+	static inline RasterStateArray backupGameRasterStates = {};
+	static inline RasterStateArray shadowmapRasterStates[maxCascades] = {};
+
 	static void GetUpdatedRasterDesc(D3D11_RASTERIZER_DESC& outputDesc, ShadowMapRasterizerDescriptor desc);
 
-	static constexpr ShadowMapRasterizerDescriptor cascadeDescriptors[maxCascades] = {
-		{ firstCascadeDepthBias, firstCascadeDepthBiasClamp, firstCascadeSlopeScaleBias },
-		{ secondCascadeDepthBias, secondCascadeDepthBiasClamp, secondCascadeSlopeScaleBias },
-		{ thirdCascadeDepthBias, thirdCascadeDepthBiasClamp, thirdCascadeSlopeScaleBias }
+	static constexpr int flatFirstCascadeDepthBias = 160;
+	static constexpr float flatFirstCascadeDepthBiasClamp = 0.015f;
+	static constexpr float flatFirstCascadeSlopeScaleBias = 3.2f;
+
+	static constexpr int flatSecondCascadeDepthBias = 100;
+	static constexpr float flatSecondCascadeDepthBiasClamp = 0.015f;
+	static constexpr float flatSecondCascadeSlopeScaleBias = 3.8f;
+
+	static constexpr int flatThirdCascadeDepthBias = 100;
+	static constexpr float flatThirdCascadeDepthBiasClamp = 0.015f;
+	static constexpr float flatThirdCascadeSlopeScaleBias = 3.8f;
+
+	static constexpr std::array<ShadowMapRasterizerDescriptor, maxCascades> flatCascadeDescriptors = {
+		ShadowMapRasterizerDescriptor{ flatFirstCascadeDepthBias, flatFirstCascadeDepthBiasClamp, flatFirstCascadeSlopeScaleBias },
+		ShadowMapRasterizerDescriptor{ flatSecondCascadeDepthBias, flatSecondCascadeDepthBiasClamp, flatSecondCascadeSlopeScaleBias },
+		ShadowMapRasterizerDescriptor{ flatThirdCascadeDepthBias, flatThirdCascadeDepthBiasClamp, flatThirdCascadeSlopeScaleBias }
+	};
+
+	// Keep close-range casters unshifted; even small first-cascade bias can make nearby meshes lose contact shadows.
+	static constexpr int vrNearCascadeDepthBias = 0;
+	static constexpr float vrNearCascadeDepthBiasClamp = 0.0f;
+	static constexpr float vrNearCascadeSlopeScaleBias = 0.0f;
+
+	// Developer option only: a tiny outer-cascade caster offset for distant directional shadow acne.
+	static constexpr int vrOuterCascadeDepthBias = 8;
+	static constexpr float vrOuterCascadeDepthBiasClamp = 0.0001f;
+	static constexpr float vrOuterCascadeSlopeScaleBias = 0.05f;
+
+	static constexpr std::array<ShadowMapRasterizerDescriptor, maxCascades> vrCascadeDescriptors = {
+		ShadowMapRasterizerDescriptor{ vrNearCascadeDepthBias, vrNearCascadeDepthBiasClamp, vrNearCascadeSlopeScaleBias },
+		ShadowMapRasterizerDescriptor{ vrOuterCascadeDepthBias, vrOuterCascadeDepthBiasClamp, vrOuterCascadeSlopeScaleBias },
+		ShadowMapRasterizerDescriptor{ vrOuterCascadeDepthBias, vrOuterCascadeDepthBiasClamp, vrOuterCascadeSlopeScaleBias }
+	};
+
+	struct ScopedCascadeBias
+	{
+		explicit ScopedCascadeBias(std::uint32_t cascade);
+		~ScopedCascadeBias();
+
+		std::uint32_t previousCascade;
 	};
 
 	struct BSShadowDirectionalLight_RenderShadowmaps_RenderCascade
 	{
-		static void thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, uint32_t flags);
+		static void thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, std::uint32_t flags);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	struct ID3D11DeviceContext_RSSetState
+	{
+		static void thunk(ID3D11DeviceContext* context, ID3D11RasterizerState* state);
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -1,9 +1,9 @@
 ﻿#include "VR.h"
+#include "EngineFixes/ShadowmapCascadeRasterizerFix.h"
 #include "Menu.h"
 #include "RE/B/BSOpenVR.h"
 #include "RE/P/PlayerCharacter.h"
 #include "Upscaling.h"
-#include "EngineFixes/ShadowmapCascadeRasterizerFix.h"
 #include "VR/OpenVRDetection.h"
 
 #include "State.h"

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -58,7 +58,7 @@ void VR::LoadSettings(json& o_json)
 {
 	settings = o_json.get<Settings>();
 	settings.ClampToValidRanges();
-	if (settings.EnableOuterCascadeCasterBias) {
+	if (ShadowmapRasterizerFix::IsVROuterCascadeCasterBiasEnabled()) {
 		ShadowmapRasterizerFix::InstallD3DHooks(globals::d3d::context);
 	}
 	if (o_json.contains("StereoOptimizations")) {

--- a/src/Features/VR.cpp
+++ b/src/Features/VR.cpp
@@ -3,6 +3,7 @@
 #include "RE/B/BSOpenVR.h"
 #include "RE/P/PlayerCharacter.h"
 #include "Upscaling.h"
+#include "EngineFixes/ShadowmapCascadeRasterizerFix.h"
 #include "VR/OpenVRDetection.h"
 
 #include "State.h"
@@ -46,7 +47,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	StereoBlendDepthSigma,
 	StereoBlendMaxFactor,
 	StereoBlendColorThreshold,
-	StereoBlendDebugMode)
+	StereoBlendDebugMode,
+	EnableOuterCascadeCasterBias)
 
 //=============================================================================
 // FEATURE BASE CLASS OVERRIDES
@@ -56,6 +58,9 @@ void VR::LoadSettings(json& o_json)
 {
 	settings = o_json.get<Settings>();
 	settings.ClampToValidRanges();
+	if (settings.EnableOuterCascadeCasterBias) {
+		ShadowmapRasterizerFix::InstallD3DHooks(globals::d3d::context);
+	}
 	if (o_json.contains("StereoOptimizations")) {
 		json stereoOptJson = o_json["StereoOptimizations"];
 		stereoOpt.LoadSettings(stereoOptJson);

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -177,6 +177,7 @@ public:
 		float StereoBlendMaxFactor = 0.1f;        ///< Maximum blend factor; keep low to preserve stereo parallax
 		float StereoBlendColorThreshold = 0.02f;  ///< Minimum color difference to trigger blending (luminance)
 		int StereoBlendDebugMode = 0;             ///< 0=off, 1=back-check, 2=blend weight, 3=edge detection, 4=overwrite, 5=overwrite Eye1
+		// Developer-only: optional outer-cascade caster bias for residual distant shadow acne.
 		bool EnableOuterCascadeCasterBias = false;
 
 		// VR Menu Overlay positioning settings

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -177,6 +177,7 @@ public:
 		float StereoBlendMaxFactor = 0.1f;        ///< Maximum blend factor; keep low to preserve stereo parallax
 		float StereoBlendColorThreshold = 0.02f;  ///< Minimum color difference to trigger blending (luminance)
 		int StereoBlendDebugMode = 0;             ///< 0=off, 1=back-check, 2=blend weight, 3=edge detection, 4=overwrite, 5=overwrite Eye1
+		bool EnableOuterCascadeCasterBias = false;
 
 		// VR Menu Overlay positioning settings
 		float VRMenuScale = Config::kDefaultMenuScale;  ///< Scale factor for overlay UI (0.5-2.0)

--- a/src/Features/VR/SettingsUI.cpp
+++ b/src/Features/VR/SettingsUI.cpp
@@ -975,13 +975,13 @@ namespace
 
 		if (ImGui::CollapsingHeader("Shadowmap Rasterizer")) {
 			if (ImGui::Checkbox("Apply Outer Cascade Caster Bias", &settings.EnableOuterCascadeCasterBias) &&
-				settings.EnableOuterCascadeCasterBias) {
+				ShadowmapRasterizerFix::IsVROuterCascadeCasterBiasEnabled()) {
 				ShadowmapRasterizerFix::InstallD3DHooks(globals::d3d::context);
 			}
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text(
-					"Developer-only. Leave off unless distant or outer-cascade surfaces still show shadow acne.\n"
-					"Applies a tiny caster-side rasterizer bias to outer cascades without globally swapping VR rasterizer tables.");
+					"The VR rasterizer flicker safety path is always active.\n"
+					"This developer-only toggle only applies a tiny caster-side bias to outer cascades.");
 				ImGui::Text(
 					"Values: DepthBias %d, Clamp %.4f, SlopeScaledDepthBias %.2f.",
 					ShadowmapRasterizerFix::vrOuterCascadeDepthBias,

--- a/src/Features/VR/SettingsUI.cpp
+++ b/src/Features/VR/SettingsUI.cpp
@@ -1,4 +1,5 @@
 #include "FeatureConstraints.h"
+#include "EngineFixes/ShadowmapCascadeRasterizerFix.h"
 #include "Features/DynamicCubemaps.h"
 #include "Features/ScreenSpaceGI.h"
 #include "Features/ScreenSpaceShadows.h"
@@ -965,6 +966,30 @@ namespace
 			ADDRESS_NODE(vrSystem)
 		}
 	}
+	void DrawShadowmapRasterizerSettings()
+	{
+		if (!globals::state || !globals::state->IsDeveloperMode())
+			return;
+
+		auto& settings = globals::features::vr.settings;
+
+		if (ImGui::CollapsingHeader("Shadowmap Rasterizer")) {
+			if (ImGui::Checkbox("Apply Outer Cascade Caster Bias", &settings.EnableOuterCascadeCasterBias) &&
+				settings.EnableOuterCascadeCasterBias) {
+				ShadowmapRasterizerFix::InstallD3DHooks(globals::d3d::context);
+			}
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text(
+					"Developer-only. Leave off unless distant or outer-cascade surfaces still show shadow acne.\n"
+					"Applies a tiny caster-side rasterizer bias to outer cascades without globally swapping VR rasterizer tables.");
+				ImGui::Text(
+					"Values: DepthBias %d, Clamp %.4f, SlopeScaledDepthBias %.2f.",
+					ShadowmapRasterizerFix::vrOuterCascadeDepthBias,
+					ShadowmapRasterizerFix::vrOuterCascadeDepthBiasClamp,
+					ShadowmapRasterizerFix::vrOuterCascadeSlopeScaleBias);
+			}
+		}
+	}
 }  // namespace
 
 //=============================================================================
@@ -1009,6 +1034,7 @@ void VR::DrawSettings()
 
 		if (BeginTabItemWithFont("Debug", Menu::FontRole::Subheading)) {
 			if (ImGui::BeginChild("##VRDebugFrame", { 0, 0 }, true)) {
+				DrawShadowmapRasterizerSettings();
 				DrawDebugSection();
 			}
 			ImGui::EndChild();

--- a/src/Features/VR/SettingsUI.cpp
+++ b/src/Features/VR/SettingsUI.cpp
@@ -1,5 +1,5 @@
-#include "FeatureConstraints.h"
 #include "EngineFixes/ShadowmapCascadeRasterizerFix.h"
+#include "FeatureConstraints.h"
 #include "Features/DynamicCubemaps.h"
 #include "Features/ScreenSpaceGI.h"
 #include "Features/ScreenSpaceShadows.h"

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -399,9 +399,10 @@ namespace globals
 	};
 
 	/**
- * @brief Installs hooks on the Map and Unmap methods of the provided D3D11 device context.
+ * @brief Installs baseline D3D hooks plus any feature-gated context hooks.
  *
- * This enables interception of resource mapping and unmapping operations for frame buffer caching.
+ * Map/Unmap are always intercepted for frame buffer caching. Additional
+ * hooks are installed only when the owning feature has opted into them.
  */
 	void InstallD3DHooks(ID3D11DeviceContext* a_context)
 	{

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -1,6 +1,7 @@
 #include "Globals.h"
 
 #include "Deferred.h"
+#include "EngineFixes/ShadowmapCascadeRasterizerFix.h"
 #include "Features/CloudShadows.h"
 #include "Features/DynamicCubemaps.h"
 #include "Features/ExponentialHeightFog.h"
@@ -406,6 +407,7 @@ namespace globals
 	{
 		stl::detour_vfunc<14, ID3D11DeviceContext_Map>(a_context);
 		stl::detour_vfunc<15, ID3D11DeviceContext_Unmap>(a_context);
+		ShadowmapRasterizerFix::InstallD3DHooks(a_context);
 
 		// VR stereo optimization hooks: installed only when stereo reprojection is enabled at startup.
 		// Changing stereoMode at runtime requires a restart; the UI communicates this to the user.

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -399,11 +399,12 @@ namespace globals
 	};
 
 	/**
- * @brief Installs baseline D3D hooks plus any feature-gated context hooks.
- *
- * Map/Unmap are always intercepted for frame buffer caching. Additional
- * hooks are installed only when the owning feature has opted into them.
- */
+	 * @brief Installs hooks on the Map and Unmap methods of the provided D3D11 device context.
+	 *
+	 * This always enables interception of resource mapping and unmapping
+	 * operations for frame buffer caching. Additional feature-gated context
+	 * hooks may also be installed here.
+	 */
 	void InstallD3DHooks(ID3D11DeviceContext* a_context)
 	{
 		stl::detour_vfunc<14, ID3D11DeviceContext_Map>(a_context);


### PR DESCRIPTION
In VR, directional shadow rendering was still coupled to the flat global rasterizer table swap that the non-VR path relies on. On certain meshes this can make caster state bleed across cascades and show up as strong shadow flicker.

On this branch, simply bypassing that swap is not enough by itself. Once VR stops using the flat global swap, LLF's direct two-cascade directional sampler can diverge from the engine-produced VR shadow mask and introduce broad receiver banding on terrain and other large surfaces.

Implementation:

- bypass the flat global rasterizer table swap for VR directional cascades
- move the optional outer-cascade caster bias behind a developer-only setting and only install the `RSSetState` hook when that optional bias is enabled --> In my fork I did not see any differences yet. I leave it here for dev testing: could be that certain scenes benefit from that extra far-cascade nudge.  May still need follow-up for a cleaner always-on solution.
- resolve the VR cascade bias against descriptor order so it stays aligned with the branch's directional shadow data path
- restore the VR receiver-side cascade compare-depth bias in `Utility.hlsl` so the engine shadow mask matches the expected VR behavior
- route VR directional shadow consumers back to the engine-produced shadow mask instead of LLF's direct two-cascade sampler to avoid receiver banding
- keep non-VR directional shadow behavior unchanged

Potential issues to be addressed in the future:
- VR paths that do not have access to the engine shadow mask no longer fall back to LLF's direct directional sampler and can remain fully lit instead of receiving directional shadows.
- Even on masked VR paths, directional shadows now follow the engine-produced shadow mask rather than LLF's direct sampler, so some LLF-specific sampling behavior is intentionally traded away to avoid the receiver banding regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VR shadow rendering by reducing visual artifacts and banding in distant shadows.
  * Enhanced shadow depth calculations for more accurate shadow rendering across cascades.

* **New Features**
  * Added VR shadow quality settings to optimize shadow rendering in VR environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->