### PR TITLE
chore(upscaling): Tracy GPU zone for SSR ReflectionsRayTracing

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -810,12 +810,13 @@ struct BSImageSpace_Init_FXAA
 };
 
 #ifdef TRACY_ENABLE
+#	include <optional>
 // Diagnostic GPU zone around the engine SSR raymarch DRAW, bracketed by the shader's PreRender
 // (0x0A) / PostRender (0x0B) vfuncs — the correct hook points, stable on SE/AE/VR (see commit message).
 static constexpr tracy::SourceLocationData kSSRZoneSrcLoc{ "SSR ReflectionsRayTracing", "ISReflectionsRayTracing::Render", __FILE__, (uint32_t)__LINE__, 0 };
-// Single raw holder is safe: opened on PreRender, closed on PostRender, render-thread only and
-// non-nested for this shader.
-static tracy::D3D11ZoneScope* g_ssrGpuZone = nullptr;
+// In-place holder (no per-frame heap): opened on PreRender, closed on PostRender, render-thread only
+// and non-nested for this shader.
+static std::optional<tracy::D3D11ZoneScope> g_ssrGpuZone;
 
 struct SSRPreRender_Hook
 {
@@ -823,8 +824,8 @@ struct SSRPreRender_Hook
 	{
 		func(a_this);  // original PreRender (engine SSR render-state setup)
 		if (globals::state->tracyCtx) {
-			delete g_ssrGpuZone;  // defensive: close a prior zone if PostRender was ever skipped (no-op on nullptr)
-			g_ssrGpuZone = new tracy::D3D11ZoneScope(globals::state->tracyCtx, &kSSRZoneSrcLoc, true);
+			g_ssrGpuZone.reset();  // defensive: close a prior zone if PostRender was ever skipped
+			g_ssrGpuZone.emplace(globals::state->tracyCtx, &kSSRZoneSrcLoc, true);
 		}
 	}
 	static inline REL::Relocation<decltype(thunk)> func;
@@ -833,11 +834,8 @@ struct SSRPostRender_Hook
 {
 	static void thunk(void* a_this)
 	{
-		if (g_ssrGpuZone) {  // close the GPU zone right after the draw
-			delete g_ssrGpuZone;
-			g_ssrGpuZone = nullptr;
-		}
-		func(a_this);  // original PostRender
+		g_ssrGpuZone.reset();  // close the GPU zone right after the draw
+		func(a_this);          // original PostRender
 	}
 	static inline REL::Relocation<decltype(thunk)> func;
 };

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -808,6 +808,41 @@ struct BSImageSpace_Init_FXAA
 	}
 	static inline REL::Relocation<decltype(thunk)> func;
 };
+
+#ifdef TRACY_ENABLE
+// Diagnostic GPU zone around the engine SSR raymarch DRAW, bracketed by the shader's PreRender
+// (0x0A) / PostRender (0x0B) vfuncs — the correct hook points, stable on SE/AE/VR (see commit message).
+static constexpr tracy::SourceLocationData kSSRZoneSrcLoc{ "SSR ReflectionsRayTracing", "ISReflectionsRayTracing::Render", __FILE__, (uint32_t)__LINE__, 0 };
+// Single raw holder is safe: opened on PreRender, closed on PostRender, render-thread only and
+// non-nested for this shader.
+static tracy::D3D11ZoneScope* g_ssrGpuZone = nullptr;
+
+struct SSRPreRender_Hook
+{
+	static void thunk(void* a_this)
+	{
+		func(a_this);  // original PreRender (engine SSR render-state setup)
+		if (globals::state->tracyCtx) {
+			delete g_ssrGpuZone;  // defensive: close a prior zone if PostRender was ever skipped (no-op on nullptr)
+			g_ssrGpuZone = new tracy::D3D11ZoneScope(globals::state->tracyCtx, &kSSRZoneSrcLoc, true);
+		}
+	}
+	static inline REL::Relocation<decltype(thunk)> func;
+};
+struct SSRPostRender_Hook
+{
+	static void thunk(void* a_this)
+	{
+		if (g_ssrGpuZone) {  // close the GPU zone right after the draw
+			delete g_ssrGpuZone;
+			g_ssrGpuZone = nullptr;
+		}
+		func(a_this);  // original PostRender
+	}
+	static inline REL::Relocation<decltype(thunk)> func;
+};
+#endif
+
 void Upscaling::PostPostLoad()
 {
 	// Guard before foveatedRender.PostPostLoad() so its hooks also stand down.
@@ -846,6 +881,13 @@ void Upscaling::PostPostLoad()
 
 	// Forces FXAA off
 	stl::detour_thunk<BSImageSpace_Init_FXAA>(REL::RelocationID(98974, 105626));
+
+#ifdef TRACY_ENABLE
+	// SSR raymarch GPU zone — see the SSRPreRender_Hook / SSRPostRender_Hook definitions above.
+	stl::write_vfunc<0x0A, SSRPreRender_Hook>(RE::VTABLE_BSImagespaceShaderReflectionsRayTracing[0]);
+	stl::write_vfunc<0x0B, SSRPostRender_Hook>(RE::VTABLE_BSImagespaceShaderReflectionsRayTracing[0]);
+	logger::info("[Upscaling] Installed SSR ReflectionsRayTracing Tracy zone (PreRender/PostRender 0x0A/0x0B, TRACY_ENABLE)");
+#endif
 
 	logger::info("[Upscaling] Installed hooks");
 }


### PR DESCRIPTION
Adds a diagnostic-only Tracy GPU zone around the engine SSR raymarch pass (`ISReflectionsRayTracing`), so the pass is visible on the Tracy GPU timeline. Split out of #82 (foveated SSR) since it's independent profiling infrastructure, not part of the feature.

## What it does

Wraps the SSR raymarch DRAW with a `tracy::D3D11ZoneScope`, opened on the shader's `PreRender` (vfunc `0x0A`) and closed on `PostRender` (`0x0B`).

## Why these hook points

RenderDoc callstacks proved the effect renders as a pixel-shader DRAW issued by the deferred batch renderer through the **non-virtual** `BSImagespaceShader::Render` — not the `ImageSpaceManager` vtable Render slot and not `DispatchComputeShader` (both of which were tried first and never fired). `Render` brackets the draw with the per-shader `PreRender`/`PostRender` vfuncs, which CommonLib keeps at stable indices across SE/AE/VR (the VR-only `FakeDispatchComputeShader` inserts at `0x0D`, after them), so hooking `0x0A`/`0x0B` on the cross-versioned `ReflectionsRayTracing` vtable wraps exactly the SSR draw on all three runtimes with no per-version addresses.

## Safety

- `TRACY_ENABLE`-gated — zero impact on shipping builds.
- Behaviour-preserving: each thunk only chains the original vfunc.
- Single raw zone holder is safe: render-thread only, non-nested for this shader; the `PreRender` thunk defensively closes any prior zone if `PostRender` were ever skipped.

Verified live (ALL-TRACY build): zone fires ~525/530 frames, ~88us baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)