### PR TITLE
fix(FrameAnnotations): correct vr100 depth-buffer label

### DIFF
--- a/src/FrameAnnotations.cpp
+++ b/src/FrameAnnotations.cpp
@@ -964,7 +964,7 @@ namespace FrameAnnotations
 				RE::VTABLE_BSImagespaceShaderCopyDepthBuffer[3]);
 			stl::write_vfunc<0x1, BSImagespaceShader_Render<RE::ImageSpaceManager::ISCopyDepthBuffer_DR>>(
 				RE::VTABLE_BSImagespaceShaderCopyDepthBuffer_DR[3]);
-			stl::write_vfunc<0x1, BSImagespaceShader_Render<RE::ImageSpaceManager::ISCopyDepthBuffer_DR>>(
+			stl::write_vfunc<0x1, BSImagespaceShader_Render<RE::ImageSpaceManager::ISCopyDepthBufferTargetSize>>(
 				RE::VTABLE_BSImagespaceShaderDepthBuffer4xDownscale[3]);
 			stl::write_vfunc<0x1, BSImagespaceShader_Render<RE::ImageSpaceManager::ISDownsampleHierarchicalDepthBufferCS>>(
 				RE::VTABLE_BSImagespaceShaderISDownsampleHierarchicalDepthBufferCS[3]);
@@ -995,7 +995,7 @@ namespace FrameAnnotations
 				RE::VTABLE_BSImagespaceShaderCopyDepthBuffer[0]);
 			stl::write_vfunc<0xC, BSImagespaceShader_Dispatch<RE::ImageSpaceManager::ISCopyDepthBuffer_DR>>(
 				RE::VTABLE_BSImagespaceShaderCopyDepthBuffer_DR[0]);
-			stl::write_vfunc<0xC, BSImagespaceShader_Dispatch<RE::ImageSpaceManager::ISCopyDepthBuffer_DR>>(
+			stl::write_vfunc<0xC, BSImagespaceShader_Dispatch<RE::ImageSpaceManager::ISCopyDepthBufferTargetSize>>(
 				RE::VTABLE_BSImagespaceShaderDepthBuffer4xDownscale[0]);
 			stl::write_vfunc<0xC, BSImagespaceShader_Dispatch<RE::ImageSpaceManager::ISDownsampleHierarchicalDepthBufferCS>>(
 				RE::VTABLE_BSImagespaceShaderISDownsampleHierarchicalDepthBufferCS[0]);


### PR DESCRIPTION
The VR-only `DepthBuffer4xDownscale` pass (VR `ImageSpaceEffect` index **100**) was annotated with the enum `ISCopyDepthBuffer_DR` (index 99) — a copy-paste duplicate, so its Render/Dispatch perf events showed the wrong (duplicate) name in captures.

VR index 100 is **`ISCopyDepthBufferTargetSize`**, verified against the engine effect-init dispatcher (SkyrimVR.exe `ImageSpaceManager` init → register helper, index in EDX). Fixed both the Render (vfunc `0x1`) and Dispatch (vfunc `0xC`) hooks for `VTABLE_BSImagespaceShaderDepthBuffer4xDownscale`.

Audited all 278 enum/VTABLE annotation pairs — no other mismatches (`ISCopyGrayScale`/`GreyScale` is the same shader, gray/grey spelling).