### PR TITLE
chore: bump CommonLibVR submodule

### DIFF
--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1847,9 +1847,7 @@ namespace SIE
 				// { "BSImagespaceShaderCopyDepthBuffer", RE::ImageSpaceManager::GetCurrentIndex(ISCopyDepthBuffer) },
 				// { "BSImagespaceShaderCopyDepthBuffer_DR", RE::ImageSpaceManager::GetCurrentIndex(ISCopyDepthBuffer_DR) },
 				// { "BSImagespaceShaderCopyDepthBufferTargetSize", RE::ImageSpaceManager::GetCurrentIndex(ISCopyDepthBufferTargetSize) },
-				// Removed: BSImagespaceShaderGraphicsTextureFilterMode was a phantom IS effect — VR index 111
-				// is actually ISReflectionBlurHCS, so the enum entry was dropped in CommonLibVR (#178).
-				// { "BSImagespaceShaderGraphicsTextureFilterMode", RE::ImageSpaceManager::GetCurrentIndex(ISGraphicsTextureFilterMode) },
+				// BSImagespaceShaderGraphicsTextureFilterMode is intentionally omitted because VR index 111 is ISReflectionBlurHCS.
 				{ "BSImagespaceShaderISDownsampleHierarchicalDepthBufferCS", RE::ImageSpaceManager::GetCurrentIndex(ISDownsampleHierarchicalDepthBufferCS) },
 				{ "BSImagespaceShaderISDiffScaleDownsampleDepthBufferCS", RE::ImageSpaceManager::GetCurrentIndex(ISDiffScaleDownsampleDepthBufferCS) },
 				{ "BSImagespaceShaderISFullScreenVR", RE::ImageSpaceManager::GetCurrentIndex(ISFullScreenVR) },

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -1847,7 +1847,9 @@ namespace SIE
 				// { "BSImagespaceShaderCopyDepthBuffer", RE::ImageSpaceManager::GetCurrentIndex(ISCopyDepthBuffer) },
 				// { "BSImagespaceShaderCopyDepthBuffer_DR", RE::ImageSpaceManager::GetCurrentIndex(ISCopyDepthBuffer_DR) },
 				// { "BSImagespaceShaderCopyDepthBufferTargetSize", RE::ImageSpaceManager::GetCurrentIndex(ISCopyDepthBufferTargetSize) },
-				{ "BSImagespaceShaderGraphicsTextureFilterMode", RE::ImageSpaceManager::GetCurrentIndex(ISGraphicsTextureFilterMode) },
+				// Removed: BSImagespaceShaderGraphicsTextureFilterMode was a phantom IS effect — VR index 111
+				// is actually ISReflectionBlurHCS, so the enum entry was dropped in CommonLibVR (#178).
+				// { "BSImagespaceShaderGraphicsTextureFilterMode", RE::ImageSpaceManager::GetCurrentIndex(ISGraphicsTextureFilterMode) },
 				{ "BSImagespaceShaderISDownsampleHierarchicalDepthBufferCS", RE::ImageSpaceManager::GetCurrentIndex(ISDownsampleHierarchicalDepthBufferCS) },
 				{ "BSImagespaceShaderISDiffScaleDownsampleDepthBufferCS", RE::ImageSpaceManager::GetCurrentIndex(ISDiffScaleDownsampleDepthBufferCS) },
 				{ "BSImagespaceShaderISFullScreenVR", RE::ImageSpaceManager::GetCurrentIndex(ISFullScreenVR) },


### PR DESCRIPTION
Bumps `extern/CommonLibSSE-NG` (= alandtse/CommonLibVR) from `8f4205da5` to `6b48ca992` on `ng`:

- **#177** MenuEventHandler VR vtable shift — correct VR menu input dispatch across flat/VR/multi-runtime.
- **#178** remove phantom `ISGraphicsTextureFilterMode` IS effect (VR index 111 collided with `ISReflectionBlurHCS`).

Includes the required source adaptation: **`ShaderCache.cpp`** dropped the `ISGraphicsTextureFilterMode` name→index entry (the enum value was removed in #178; the entry was a no-op phantom anyway).

**Verified locally:** full `ALL` preset configures + builds clean (`CommunityShaders.dll` produced) against the bumped submodule. Pairs with the FrameAnnotations vr100 fix (#108).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented problematic image-space shader compilation by removing a shader descriptor, avoiding related runtime shader loading/compilation errors.
* **Chores**
  * Updated an external library reference to the latest tracked revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->