### PR TITLE
fix(vr): shadow flicker and banding

### DIFF
--- a/features/Light Limit Fix/Shaders/Features/LightLimitFix.ini
+++ b/features/Light Limit Fix/Shaders/Features/LightLimitFix.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 3-2-0
+Version = 3-2-1
 
 [Nexus]
 autoupload = false

--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -163,11 +163,24 @@ namespace LightLimitFix
 	// at this pixel (TexShadowMaskSampler.Load(int3(Position.xy, 0)).x). LLF's
 	// DirectionalShadowLightData carries only cascades 0/1 (ShadowProj[2] /
 	// EndSplitDistances.xy); past EndSplitDistances.y we have no LLF data and
-	// must fall through to the engine mask. Returning 1.0 there leaves distant
-	// pixels fully lit -- visible as global scene brightening with shadows
-	// disappearing past a depth that varies with camera position.
-	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex, float engineMaskShadow)
+	// must fall through to the engine mask. For mask-backed VR callers this same
+	// value also becomes the source of truth for all cascades.
+	// Returning 1.0 there leaves distant pixels fully lit -- visible as global
+	// scene brightening with shadows disappearing past a depth that varies with
+	// camera position.
+	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex, float engineMaskShadow, bool useEngineMaskShadow)
 	{
+#if defined(VR)
+		if (useEngineMaskShadow) {
+			// VR keeps the engine shadowmask as the source of truth. The LLF
+			// two-cascade PCF path only carries cascades 0/1 and can introduce
+			// broad receiver banding after the rasterizer safety path removes the
+			// old caster-side global rasterizer swap. Utility.hlsl still applies
+			// the VR-only receiver bias while producing this mask.
+			return engineMaskShadow;
+		}
+#endif
+
 		DirectionalShadowLightData shadowLightData = DirectionalShadowLights[0];
 
 		float shadowMapDepth = SharedData::GetScreenDepth(FrameBuffer::GetShadowDepth(worldPosition, eyeIndex));
@@ -288,17 +301,22 @@ namespace LightLimitFix
 		return shadow;
 	}
 
+	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex, float engineMaskShadow)
+	{
+		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex, engineMaskShadow, true);
+	}
+
 	// Convenience overload: callers without TexShadowMaskSampler bound
-	// (e.g. Particle.hlsl) get the lit-fallback behaviour (1.0) past
-	// cascade 1, matching the pre-engine-mask behaviour for those paths.
+	// can still route through the direct LLF sampler without an engine-mask
+	// sample.
 	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex)
 	{
-		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex, 1.0);
+		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex, 1.0, false);
 	}
 
 	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix)
 	{
-		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, 0, 1.0);
+		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, 0, 1.0, false);
 	}
 
 	float SampleShadowGather(uint shadowIndex, float2 uv, float receiverDepth)

--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -163,22 +163,16 @@ namespace LightLimitFix
 	// at this pixel (TexShadowMaskSampler.Load(int3(Position.xy, 0)).x). LLF's
 	// DirectionalShadowLightData carries only cascades 0/1 (ShadowProj[2] /
 	// EndSplitDistances.xy); past EndSplitDistances.y we have no LLF data and
-	// must fall through to the engine mask. For mask-backed VR callers this same
-	// value also becomes the source of truth for all cascades.
-	// Returning 1.0 there leaves distant pixels fully lit -- visible as global
-	// scene brightening with shadows disappearing past a depth that varies with
-	// camera position.
+	// must fall through to the engine mask. Returning 1.0 there leaves distant
+	// pixels fully lit -- visible as global scene brightening with shadows
+	// disappearing past a depth that varies with camera position.
 	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex, float engineMaskShadow, bool useEngineMaskShadow)
 	{
 #if defined(VR)
-		if (useEngineMaskShadow) {
-			// VR keeps the engine shadowmask as the source of truth. The LLF
-			// two-cascade PCF path only carries cascades 0/1 and can introduce
-			// broad receiver banding after the rasterizer safety path removes the
-			// old caster-side global rasterizer swap. Utility.hlsl still applies
-			// the VR-only receiver bias while producing this mask.
+		// VR returns the engine mask for all cascades: the LLF two-cascade PCF
+		// path bands once VR drops the caster-side global rasterizer swap.
+		if (useEngineMaskShadow)
 			return engineMaskShadow;
-		}
 #endif
 
 		DirectionalShadowLightData shadowLightData = DirectionalShadowLights[0];
@@ -306,9 +300,8 @@ namespace LightLimitFix
 		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex, engineMaskShadow, true);
 	}
 
-	// Convenience overload: callers without TexShadowMaskSampler bound
-	// can still route through the direct LLF sampler without an engine-mask
-	// sample.
+	// Convenience overload for callers without TexShadowMaskSampler bound
+	// (e.g. particles): route through the direct LLF sampler, no engine mask.
 	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex)
 	{
 		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex, 1.0, false);

--- a/package/Shaders/Common/DirectionalShadow.hlsli
+++ b/package/Shaders/Common/DirectionalShadow.hlsli
@@ -5,14 +5,12 @@
 
 namespace DirectionalShadow
 {
-	// Single owner of the directional-shadow routing decision, so new consumers
-	// can't read the stale engine mask under SLF. Routing under LIGHT_LIMIT_FIX:
-	// non-VR samples LLF cascades directly (fully lit past range); VR masked
-	// callers return the engine mask (stays aligned with Utility.hlsl's receiver
-	// bias, avoids banding after the rasterizer split). Without LLF, returns the
-	// engine mask as-is. Also owns the PCF noise-rotation so callers skip the
-	// sincos boilerplate. Lighting.hlsl deliberately bypasses this helper (feeds
-	// the mask into LLF as the past-cascade fallback). Needs LightLimitFix.hlsli first.
+	// Single owner of the directional-shadow routing so new consumers can't read the
+	// stale engine mask under SLF. Under LIGHT_LIMIT_FIX: non-VR samples LLF directly
+	// (lit past range); VR masked returns the engine mask (avoids banding after VR's
+	// rasterizer split); without LLF, returns the mask as-is. Also owns the PCF
+	// noise-rotation. Lighting.hlsl bypasses this (feeds the mask into LLF as the
+	// past-cascade fallback). Needs LightLimitFix.hlsli first.
 #if defined(LIGHT_LIMIT_FIX)
 	float SampleLightLimitFixDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise)
 	{
@@ -27,8 +25,6 @@ namespace DirectionalShadow
 	{
 #if defined(LIGHT_LIMIT_FIX)
 #	if defined(VR)
-		// Keep masked VR callers on the engine-produced mask so they stay
-		// aligned with Utility.hlsl's receiver bias.
 		return a_engineMaskShadow;
 #	else
 		return SampleLightLimitFixDirectionalShadow(worldPosition, worldPositionWS, eyeIndex, a_screenNoise);

--- a/package/Shaders/Common/DirectionalShadow.hlsli
+++ b/package/Shaders/Common/DirectionalShadow.hlsli
@@ -8,18 +8,44 @@ namespace DirectionalShadow
 	// Single owner of the directional-shadow routing decision, so new consumers
 	// can't read the stale engine mask under SLF. Under LIGHT_LIMIT_FIX the engine
 	// mask is a no-op, so sample LLF cascades directly (fully lit past range);
-	// otherwise return the engine mask as-is. Also owns the PCF noise-rotation so
-	// callers skip the sincos boilerplate. Lighting.hlsl deliberately bypasses this
-	// (feeds the mask into LLF as the past-cascade fallback). Needs LightLimitFix.hlsli first.
-	float GetSceneDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise, float a_engineMaskShadow)
-	{
+	// mask-backed VR callers are the exception and keep the engine mask path to
+	// avoid receiver banding after the rasterizer safety split.
+	// Also owns the PCF noise-rotation so callers skip the sincos boilerplate.
+	// Lighting.hlsl deliberately bypasses this helper (feeds the mask into LLF
+	// as the past-cascade fallback). Needs LightLimitFix.hlsli first.
 #if defined(LIGHT_LIMIT_FIX)
+	float SampleLightLimitFixDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise)
+	{
 		float2 rotation;
 		sincos(Math::TAU * a_screenNoise, rotation.y, rotation.x);
 		float2x2 rotationMatrix = float2x2(rotation.x, rotation.y, -rotation.y, rotation.x);
 		return LightLimitFix::GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex);
+	}
+#endif
+
+	float GetSceneDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise, float a_engineMaskShadow)
+	{
+#if defined(LIGHT_LIMIT_FIX)
+#	if defined(VR)
+		// Keep masked VR callers on the engine-produced mask so they stay
+		// aligned with Utility.hlsl's receiver bias.
+		return a_engineMaskShadow;
+#	else
+		return SampleLightLimitFixDirectionalShadow(worldPosition, worldPositionWS, eyeIndex, a_screenNoise);
+#	endif
 #else
 		return a_engineMaskShadow;
+#endif
+	}
+
+	// Maskless callers (for example particles) still need the direct LLF path
+	// because they have no engine shadowmask sample to return in VR.
+	float GetSceneDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise)
+	{
+#if defined(LIGHT_LIMIT_FIX)
+		return SampleLightLimitFixDirectionalShadow(worldPosition, worldPositionWS, eyeIndex, a_screenNoise);
+#else
+		return 1.0;
 #endif
 	}
 }

--- a/package/Shaders/Common/DirectionalShadow.hlsli
+++ b/package/Shaders/Common/DirectionalShadow.hlsli
@@ -6,13 +6,13 @@
 namespace DirectionalShadow
 {
 	// Single owner of the directional-shadow routing decision, so new consumers
-	// can't read the stale engine mask under SLF. Under LIGHT_LIMIT_FIX the engine
-	// mask is a no-op, so sample LLF cascades directly (fully lit past range);
-	// mask-backed VR callers are the exception and keep the engine mask path to
-	// avoid receiver banding after the rasterizer safety split.
-	// Also owns the PCF noise-rotation so callers skip the sincos boilerplate.
-	// Lighting.hlsl deliberately bypasses this helper (feeds the mask into LLF
-	// as the past-cascade fallback). Needs LightLimitFix.hlsli first.
+	// can't read the stale engine mask under SLF. Routing under LIGHT_LIMIT_FIX:
+	// non-VR samples LLF cascades directly (fully lit past range); VR masked
+	// callers return the engine mask (stays aligned with Utility.hlsl's receiver
+	// bias, avoids banding after the rasterizer split). Without LLF, returns the
+	// engine mask as-is. Also owns the PCF noise-rotation so callers skip the
+	// sincos boilerplate. Lighting.hlsl deliberately bypasses this helper (feeds
+	// the mask into LLF as the past-cascade fallback). Needs LightLimitFix.hlsli first.
 #if defined(LIGHT_LIMIT_FIX)
 	float SampleLightLimitFixDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise)
 	{

--- a/package/Shaders/Particle.hlsl
+++ b/package/Shaders/Particle.hlsl
@@ -315,7 +315,7 @@ PS_OUTPUT main(PS_INPUT input)
 #	if defined(VOLUMETRIC_SHADOWS)
 		dirSoftShadow = VolumetricShadows::GetVSMShadow2D(positionWS.xyz, worldPositionWS, eyeIndex, dirDetailedShadow);
 #	else
-		dirDetailedShadow = DirectionalShadow::GetSceneDirectionalShadow(positionWS.xyz, worldPositionWS, eyeIndex, screenNoise, 1.0);
+		dirDetailedShadow = DirectionalShadow::GetSceneDirectionalShadow(positionWS.xyz, worldPositionWS, eyeIndex, screenNoise);
 #	endif
 	}
 

--- a/package/Shaders/Utility.hlsl
+++ b/package/Shaders/Utility.hlsl
@@ -529,32 +529,42 @@ PS_OUTPUT main(PS_INPUT input)
 		float shadowVisibility = 0;
 
 		float3 positionLS = mul(transpose(lightProjectionMatrix), float4(positionMS.xyz, 1)).xyz;
+#			if defined(VR)
+		float shadowMapCompareDepth = positionLS.z - shadowMapThreshold;
+#			else
+		float shadowMapCompareDepth = positionLS.z;
+#			endif
 
 #			if SHADOWFILTER == 0
 		float shadowMapValue = TexShadowMapSampler.Sample(SampShadowMapSampler, float3(positionLS.xy, cascadeIndex)).x;
-		if (shadowMapValue >= positionLS.z) {
+		if (shadowMapValue >= shadowMapCompareDepth) {
 			shadowVisibility = 1;
 		}
 #			elif SHADOWFILTER == 1
-		shadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(positionLS.xy, cascadeIndex), positionLS.z).x;
+		shadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(positionLS.xy, cascadeIndex), shadowMapCompareDepth).x;
 #			elif SHADOWFILTER == 3
-		shadowVisibility = SampleShadowPCF(TexShadowMapSamplerComp, SampShadowMapSamplerComp, positionLS.xy, cascadeIndex, positionLS.z, rotationMatrix, ShadowSampleParam.z * 0.5);
+		shadowVisibility = SampleShadowPCF(TexShadowMapSamplerComp, SampShadowMapSamplerComp, positionLS.xy, cascadeIndex, shadowMapCompareDepth, rotationMatrix, ShadowSampleParam.z * 0.5);
 #			endif
 
 		if (cascadeIndex < 1 && StartSplitDistances.y < shadowMapDepth) {
 			float cascade1ShadowVisibility = 0;
 
 			float3 cascade1PositionLS = mul(transpose(ShadowMapProj[eyeIndex][1]), float4(positionMS.xyz, 1)).xyz;
+#			if defined(VR)
+			float cascade1CompareDepth = cascade1PositionLS.z - AlphaTestRef.z;
+#			else
+			float cascade1CompareDepth = cascade1PositionLS.z;
+#			endif
 
 #			if SHADOWFILTER == 0
 			float cascade1ShadowMapValue = TexShadowMapSampler.Sample(SampShadowMapSampler, float3(cascade1PositionLS.xy, 1)).x;
-			if (cascade1ShadowMapValue >= cascade1PositionLS.z) {
+			if (cascade1ShadowMapValue >= cascade1CompareDepth) {
 				cascade1ShadowVisibility = 1;
 			}
 #			elif SHADOWFILTER == 1
-			cascade1ShadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(cascade1PositionLS.xy, 1), cascade1PositionLS.z).x;
+			cascade1ShadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(cascade1PositionLS.xy, 1), cascade1CompareDepth).x;
 #			elif SHADOWFILTER == 3
-			cascade1ShadowVisibility = SampleShadowPCF(TexShadowMapSamplerComp, SampShadowMapSamplerComp, cascade1PositionLS.xy, 1, cascade1PositionLS.z, rotationMatrix, ShadowSampleParam.z * 0.5);
+			cascade1ShadowVisibility = SampleShadowPCF(TexShadowMapSamplerComp, SampShadowMapSamplerComp, cascade1PositionLS.xy, 1, cascade1CompareDepth, rotationMatrix, ShadowSampleParam.z * 0.5);
 #			endif
 
 			float cascade1BlendFactor = smoothstep(0, 1, (shadowMapDepth - StartSplitDistances.y) / (EndSplitDistances.x - StartSplitDistances.y));

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -67,7 +67,12 @@ void ShadowmapRasterizerFix::CloneRasterStates(RasterStateArray* inputArray, int
 
 						GetUpdatedRasterDesc(desc, cascadeDescriptors[cascade]);
 
-						DX::ThrowIfFailed(globals::d3d::device->CreateRasterizerState(&desc, &shadowmapRasterStates[cascade][fill][cull][depth][scissor]));
+						// Degrade instead of crashing: a null slot binds the engine's default rasterizer for that draw.
+						auto*& clonedRaster = shadowmapRasterStates[cascade][fill][cull][depth][scissor];
+						if (const auto hr = globals::d3d::device->CreateRasterizerState(&desc, &clonedRaster); FAILED(hr)) {
+							logger::warn("ShadowmapRasterizerFix: failed to clone cascade {} rasterizer state (hr=0x{:08X}); using engine default", cascade, static_cast<std::uint32_t>(hr));
+							clonedRaster = nullptr;
+						}
 					}
 				}
 			}

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -1,70 +1,50 @@
 #include "ShadowmapCascadeRasterizerFix.h"
 
-#include "Globals.h"
-
-#include <algorithm>
-
-namespace
-{
-	template <class Fn>
-	void ForEachRasterStateSlot(Fn&& fn)
-	{
-		for (int fill = 0; fill < 2; fill++) {
-			for (int cull = 0; cull < 3; cull++) {
-				for (int depth = 0; depth < 12; depth++) {
-					for (int scissor = 0; scissor < 2; scissor++) {
-						fn(fill, cull, depth, scissor);
-					}
-				}
-			}
-		}
-	}
-}
-
 void ShadowmapRasterizerFix::Install()
 {
-	// This function is called once per cascade to begin the updating and rendering process.
+	// This function is called once per cascade to begin the updating and rendering process
 	stl::write_thunk_call<BSShadowDirectionalLight_RenderShadowmaps_RenderCascade>(REL::RelocationID(101495, 108489).address() + REL::Relocate(0xC6, 0xC6, 0xF6));
 
 	gRasterStates = reinterpret_cast<RasterStateArray*>(REL::RelocationID(524748, 411363).address());
 
-	auto configuredCascades = Util::GetGameSettingValue<std::int32_t>("iNumSplits:Display", Settings.at("iNumSplits:Display"));
-	numCascades = static_cast<std::uint32_t>(std::clamp(configuredCascades, 1, static_cast<std::int32_t>(maxCascades)));
-	currentCascade = 0;
-	ReleaseClonedRasterStates();
-	initialized = false;
+	numCascades = static_cast<uint>(Util::GetGameSettingValue<std::int32_t>("iNumSplits:Display", Settings.at("iNumSplits:Display")));
 }
 
-void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCascade::thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, std::uint32_t flags)
+void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCascade::thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, uint32_t flags)
 {
-	// VR bypasses the flat global rasterizer-table swap entirely: swapping the shared global table
-	// per cascade is not stereo-safe and produces directional-shadow flicker. The banding fix routes
-	// VR directional shadows through the engine mask in the shaders instead.
-	if (REL::Module::IsVR() || !gRasterStates) {
+	// VR bypasses the flat global rasterizer-table swap: swapping the shared global table per
+	// cascade is not stereo-safe and flickers; VR routes directional shadows via the engine mask.
+	if (globals::game::isVR) {
 		func(light, arg1, arg2, flags);
 		return;
 	}
 
-	const auto cascade = currentCascade % numCascades;
+	static uint cascade = 0;
+
+	static bool initialized = false;
 	if (!initialized) {
+		//Backup
 		if (cascade == 0) {
 			std::memcpy(backupGameRasterStates, *gRasterStates, sizeof(RasterStateArray));
 			numCascades = std::min(numCascades, maxCascades);
 		}
 
-		CloneRasterStates(*gRasterStates, cascade, flatCascadeDescriptors);
+		//Clone
+		CloneRasterStates(gRasterStates, cascade);
 
 		initialized = cascade == numCascades - 1;
 	}
 
+	//Emplace
 	std::memcpy(*gRasterStates, shadowmapRasterStates[cascade], sizeof(RasterStateArray));
 
 	func(light, arg1, arg2, flags);
 
+	//Restore
 	if (cascade == numCascades - 1)
 		std::memcpy(*gRasterStates, backupGameRasterStates, sizeof(RasterStateArray));
 
-	currentCascade = (cascade + 1) % numCascades;
+	cascade = ++cascade < numCascades ? cascade : 0;
 }
 
 void ShadowmapRasterizerFix::GetUpdatedRasterDesc(D3D11_RASTERIZER_DESC& outputDesc, ShadowMapRasterizerDescriptor shadowmapDesc)
@@ -75,41 +55,22 @@ void ShadowmapRasterizerFix::GetUpdatedRasterDesc(D3D11_RASTERIZER_DESC& outputD
 }
 
 // Since state objects are shared globally across the pipeline we make duplicate arrays that cover the same range of states the game does
-void ShadowmapRasterizerFix::CloneRasterStates(const RasterStateArray& inputArray, std::uint32_t cascade, const std::array<ShadowMapRasterizerDescriptor, maxCascades>& descriptors)
+void ShadowmapRasterizerFix::CloneRasterStates(RasterStateArray* inputArray, int cascade)
 {
-	ForEachRasterStateSlot([&](int fill, int cull, int depth, int scissor) {
-		auto*& clonedRaster = shadowmapRasterStates[cascade][fill][cull][depth][scissor];
-		if (clonedRaster) {
-			clonedRaster->Release();
-			clonedRaster = nullptr;
-		}
+	for (int fill = 0; fill < 2; fill++) {
+		for (int cull = 0; cull < 3; cull++) {
+			for (int depth = 0; depth < 12; depth++) {
+				for (int scissor = 0; scissor < 2; scissor++) {
+					if (auto* gRasterizer = (*inputArray)[fill][cull][depth][scissor]) {
+						D3D11_RASTERIZER_DESC desc{};
+						gRasterizer->GetDesc(&desc);
 
-		if (auto* gRasterizer = inputArray[fill][cull][depth][scissor]) {
-			D3D11_RASTERIZER_DESC desc{};
-			gRasterizer->GetDesc(&desc);
+						GetUpdatedRasterDesc(desc, cascadeDescriptors[cascade]);
 
-			GetUpdatedRasterDesc(desc, descriptors[cascade]);
-
-			if (const auto hr = globals::d3d::device->CreateRasterizerState(&desc, &clonedRaster); FAILED(hr)) {
-				logger::warn(
-					"ShadowmapRasterizerFix: failed to clone rasterizer state for cascade {} (hr=0x{:08X}); using original state",
-					cascade,
-					static_cast<std::uint32_t>(hr));
-				clonedRaster = nullptr;
+						DX::ThrowIfFailed(globals::d3d::device->CreateRasterizerState(&desc, &shadowmapRasterStates[cascade][fill][cull][depth][scissor]));
+					}
+				}
 			}
 		}
-	});
-}
-
-void ShadowmapRasterizerFix::ReleaseClonedRasterStates()
-{
-	ForEachRasterStateSlot([&](int fill, int cull, int depth, int scissor) {
-		for (std::uint32_t cascade = 0; cascade < maxCascades; cascade++) {
-			auto*& clonedRaster = shadowmapRasterStates[cascade][fill][cull][depth][scissor];
-			if (clonedRaster) {
-				clonedRaster->Release();
-				clonedRaster = nullptr;
-			}
-		}
-	});
+	}
 }

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -67,11 +67,12 @@ void ShadowmapRasterizerFix::CloneRasterStates(RasterStateArray* inputArray, int
 
 						GetUpdatedRasterDesc(desc, cascadeDescriptors[cascade]);
 
-						// Degrade instead of crashing: a null slot binds the engine's default rasterizer for that draw.
+						// Degrade instead of crashing: on failure keep the engine's own state for this slot
+						// (loses only our added bias, not its cull/fill/scissor) rather than D3D defaults.
 						auto*& clonedRaster = shadowmapRasterStates[cascade][fill][cull][depth][scissor];
 						if (const auto hr = globals::d3d::device->CreateRasterizerState(&desc, &clonedRaster); FAILED(hr)) {
-							logger::warn("ShadowmapRasterizerFix: failed to clone cascade {} rasterizer state (hr=0x{:08X}); using engine default", cascade, static_cast<std::uint32_t>(hr));
-							clonedRaster = nullptr;
+							logger::warn("ShadowmapRasterizerFix: failed to clone cascade {} rasterizer state (hr=0x{:08X}); keeping engine state", cascade, static_cast<std::uint32_t>(hr));
+							clonedRaster = gRasterizer;
 						}
 					}
 				}

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -1,43 +1,70 @@
 #include "ShadowmapCascadeRasterizerFix.h"
 
+#include "Globals.h"
+
+#include <algorithm>
+
+namespace
+{
+	template <class Fn>
+	void ForEachRasterStateSlot(Fn&& fn)
+	{
+		for (int fill = 0; fill < 2; fill++) {
+			for (int cull = 0; cull < 3; cull++) {
+				for (int depth = 0; depth < 12; depth++) {
+					for (int scissor = 0; scissor < 2; scissor++) {
+						fn(fill, cull, depth, scissor);
+					}
+				}
+			}
+		}
+	}
+}
+
 void ShadowmapRasterizerFix::Install()
 {
-	// This function is called once per cascade to begin the updating and rendering process
+	// This function is called once per cascade to begin the updating and rendering process.
 	stl::write_thunk_call<BSShadowDirectionalLight_RenderShadowmaps_RenderCascade>(REL::RelocationID(101495, 108489).address() + REL::Relocate(0xC6, 0xC6, 0xF6));
 
 	gRasterStates = reinterpret_cast<RasterStateArray*>(REL::RelocationID(524748, 411363).address());
 
-	numCascades = static_cast<uint>(Util::GetGameSettingValue<std::int32_t>("iNumSplits:Display", Settings.at("iNumSplits:Display")));
+	auto configuredCascades = Util::GetGameSettingValue<std::int32_t>("iNumSplits:Display", Settings.at("iNumSplits:Display"));
+	numCascades = static_cast<std::uint32_t>(std::clamp(configuredCascades, 1, static_cast<std::int32_t>(maxCascades)));
+	currentCascade = 0;
+	ReleaseClonedRasterStates();
+	initialized = false;
 }
 
-void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCascade::thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, uint32_t flags)
+void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCascade::thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, std::uint32_t flags)
 {
-	static uint cascade = 0;
+	// VR bypasses the flat global rasterizer-table swap entirely: swapping the shared global table
+	// per cascade is not stereo-safe and produces directional-shadow flicker. The banding fix routes
+	// VR directional shadows through the engine mask in the shaders instead.
+	if (REL::Module::IsVR() || !gRasterStates) {
+		func(light, arg1, arg2, flags);
+		return;
+	}
 
-	static bool initialized = false;
+	const auto cascade = currentCascade % numCascades;
 	if (!initialized) {
-		//Backup
 		if (cascade == 0) {
 			std::memcpy(backupGameRasterStates, *gRasterStates, sizeof(RasterStateArray));
 			numCascades = std::min(numCascades, maxCascades);
 		}
 
-		//Clone
-		CloneRasterStates(gRasterStates, cascade);
+		CloneRasterStates(*gRasterStates, cascade, flatCascadeDescriptors);
 
 		initialized = cascade == numCascades - 1;
 	}
 
-	//Emplace
 	std::memcpy(*gRasterStates, shadowmapRasterStates[cascade], sizeof(RasterStateArray));
 
 	func(light, arg1, arg2, flags);
 
-	//Restore
 	if (cascade == numCascades - 1)
 		std::memcpy(*gRasterStates, backupGameRasterStates, sizeof(RasterStateArray));
 
-	cascade = ++cascade < numCascades ? cascade : 0;
+	currentCascade = (cascade + 1) % numCascades;
 }
 
 void ShadowmapRasterizerFix::GetUpdatedRasterDesc(D3D11_RASTERIZER_DESC& outputDesc, ShadowMapRasterizerDescriptor shadowmapDesc)
@@ -48,22 +75,41 @@ void ShadowmapRasterizerFix::GetUpdatedRasterDesc(D3D11_RASTERIZER_DESC& outputD
 }
 
 // Since state objects are shared globally across the pipeline we make duplicate arrays that cover the same range of states the game does
-void ShadowmapRasterizerFix::CloneRasterStates(RasterStateArray* inputArray, int cascade)
+void ShadowmapRasterizerFix::CloneRasterStates(const RasterStateArray& inputArray, std::uint32_t cascade, const std::array<ShadowMapRasterizerDescriptor, maxCascades>& descriptors)
 {
-	for (int fill = 0; fill < 2; fill++) {
-		for (int cull = 0; cull < 3; cull++) {
-			for (int depth = 0; depth < 12; depth++) {
-				for (int scissor = 0; scissor < 2; scissor++) {
-					if (auto* gRasterizer = (*inputArray)[fill][cull][depth][scissor]) {
-						D3D11_RASTERIZER_DESC desc{};
-						gRasterizer->GetDesc(&desc);
+	ForEachRasterStateSlot([&](int fill, int cull, int depth, int scissor) {
+		auto*& clonedRaster = shadowmapRasterStates[cascade][fill][cull][depth][scissor];
+		if (clonedRaster) {
+			clonedRaster->Release();
+			clonedRaster = nullptr;
+		}
 
-						GetUpdatedRasterDesc(desc, cascadeDescriptors[cascade]);
+		if (auto* gRasterizer = inputArray[fill][cull][depth][scissor]) {
+			D3D11_RASTERIZER_DESC desc{};
+			gRasterizer->GetDesc(&desc);
 
-						DX::ThrowIfFailed(globals::d3d::device->CreateRasterizerState(&desc, &shadowmapRasterStates[cascade][fill][cull][depth][scissor]));
-					}
-				}
+			GetUpdatedRasterDesc(desc, descriptors[cascade]);
+
+			if (const auto hr = globals::d3d::device->CreateRasterizerState(&desc, &clonedRaster); FAILED(hr)) {
+				logger::warn(
+					"ShadowmapRasterizerFix: failed to clone rasterizer state for cascade {} (hr=0x{:08X}); using original state",
+					cascade,
+					static_cast<std::uint32_t>(hr));
+				clonedRaster = nullptr;
 			}
 		}
-	}
+	});
+}
+
+void ShadowmapRasterizerFix::ReleaseClonedRasterStates()
+{
+	ForEachRasterStateSlot([&](int fill, int cull, int depth, int scissor) {
+		for (std::uint32_t cascade = 0; cascade < maxCascades; cascade++) {
+			auto*& clonedRaster = shadowmapRasterStates[cascade][fill][cull][depth][scissor];
+			if (clonedRaster) {
+				clonedRaster->Release();
+				clonedRaster = nullptr;
+			}
+		}
+	});
 }

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
@@ -1,13 +1,6 @@
 #pragma once
 
-#include "EngineFix.h"
-#include "Utils/GameSetting.h"
-
-#include <array>
-
-// This overrides the shadow cascade rasterizers to fix issues with peter panning and self shadowing.
-// Flat keeps the v1.5.2 shadowmap rasterizer table behavior; VR bypasses that global table swap to
-// avoid directional-shadow flicker (the per-cascade global table swap is not stereo-safe).
+// This overrides the shadow cascade rasterizers to fix issues with peter panning and self shadowing
 struct ShadowmapRasterizerFix : EngineFix
 {
 	std::string GetName() override { return "Shadowmap Cascade Rasterizer Fix"; }
@@ -15,48 +8,44 @@ struct ShadowmapRasterizerFix : EngineFix
 
 	using RasterStateArray = ID3D11RasterizerState* [2][3][12][2];
 
+	static void CloneRasterStates(RasterStateArray* inputArray, int cascade);
+
+	static constexpr uint maxCascades = 3;
+	static inline uint numCascades = 0;
+
+	static inline RasterStateArray* gRasterStates = nullptr;
+	static inline RasterStateArray backupGameRasterStates = {};
+	static inline RasterStateArray shadowmapRasterStates[maxCascades] = {};
+
+	static constexpr int firstCascadeDepthBias = 160;
+	static constexpr float firstCascadeDepthBiasClamp = 0.015f;
+	static constexpr float firstCascadeSlopeScaleBias = 3.2f;
+
+	static constexpr int secondCascadeDepthBias = 100;
+	static constexpr float secondCascadeDepthBiasClamp = 0.015f;
+	static constexpr float secondCascadeSlopeScaleBias = 3.8f;
+
+	static constexpr int thirdCascadeDepthBias = 100;
+	static constexpr float thirdCascadeDepthBiasClamp = 0.015f;
+	static constexpr float thirdCascadeSlopeScaleBias = 3.8f;
+
 	struct ShadowMapRasterizerDescriptor
 	{
 		int rasterDepthBias;
 		float rasterDepthBiasClamp;
 		float rasterSlopeScaleBias;
 	};
-
-	static constexpr std::uint32_t maxCascades = 3;
-	static void CloneRasterStates(const RasterStateArray& inputArray, std::uint32_t cascade, const std::array<ShadowMapRasterizerDescriptor, maxCascades>& descriptors);
-	static void ReleaseClonedRasterStates();
-
-	static inline std::uint32_t numCascades = 0;
-	static inline std::uint32_t currentCascade = 0;
-	static inline bool initialized = false;
-
-	static inline RasterStateArray* gRasterStates = nullptr;
-	static inline RasterStateArray backupGameRasterStates = {};
-	static inline RasterStateArray shadowmapRasterStates[maxCascades] = {};
-
 	static void GetUpdatedRasterDesc(D3D11_RASTERIZER_DESC& outputDesc, ShadowMapRasterizerDescriptor desc);
 
-	static constexpr int flatFirstCascadeDepthBias = 160;
-	static constexpr float flatFirstCascadeDepthBiasClamp = 0.015f;
-	static constexpr float flatFirstCascadeSlopeScaleBias = 3.2f;
-
-	static constexpr int flatSecondCascadeDepthBias = 100;
-	static constexpr float flatSecondCascadeDepthBiasClamp = 0.015f;
-	static constexpr float flatSecondCascadeSlopeScaleBias = 3.8f;
-
-	static constexpr int flatThirdCascadeDepthBias = 100;
-	static constexpr float flatThirdCascadeDepthBiasClamp = 0.015f;
-	static constexpr float flatThirdCascadeSlopeScaleBias = 3.8f;
-
-	static constexpr std::array<ShadowMapRasterizerDescriptor, maxCascades> flatCascadeDescriptors = {
-		ShadowMapRasterizerDescriptor{ flatFirstCascadeDepthBias, flatFirstCascadeDepthBiasClamp, flatFirstCascadeSlopeScaleBias },
-		ShadowMapRasterizerDescriptor{ flatSecondCascadeDepthBias, flatSecondCascadeDepthBiasClamp, flatSecondCascadeSlopeScaleBias },
-		ShadowMapRasterizerDescriptor{ flatThirdCascadeDepthBias, flatThirdCascadeDepthBiasClamp, flatThirdCascadeSlopeScaleBias }
+	static constexpr ShadowMapRasterizerDescriptor cascadeDescriptors[maxCascades] = {
+		{ firstCascadeDepthBias, firstCascadeDepthBiasClamp, firstCascadeSlopeScaleBias },
+		{ secondCascadeDepthBias, secondCascadeDepthBiasClamp, secondCascadeSlopeScaleBias },
+		{ thirdCascadeDepthBias, thirdCascadeDepthBiasClamp, thirdCascadeSlopeScaleBias }
 	};
 
 	struct BSShadowDirectionalLight_RenderShadowmaps_RenderCascade
 	{
-		static void thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, std::uint32_t flags);
+		static void thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, uint32_t flags);
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
@@ -1,6 +1,13 @@
 #pragma once
 
-// This overrides the shadow cascade rasterizers to fix issues with peter panning and self shadowing
+#include "EngineFix.h"
+#include "Utils/GameSetting.h"
+
+#include <array>
+
+// This overrides the shadow cascade rasterizers to fix issues with peter panning and self shadowing.
+// Flat keeps the v1.5.2 shadowmap rasterizer table behavior; VR bypasses that global table swap to
+// avoid directional-shadow flicker (the per-cascade global table swap is not stereo-safe).
 struct ShadowmapRasterizerFix : EngineFix
 {
 	std::string GetName() override { return "Shadowmap Cascade Rasterizer Fix"; }
@@ -8,44 +15,48 @@ struct ShadowmapRasterizerFix : EngineFix
 
 	using RasterStateArray = ID3D11RasterizerState* [2][3][12][2];
 
-	static void CloneRasterStates(RasterStateArray* inputArray, int cascade);
-
-	static constexpr uint maxCascades = 3;
-	static inline uint numCascades = 0;
-
-	static inline RasterStateArray* gRasterStates = nullptr;
-	static inline RasterStateArray backupGameRasterStates = {};
-	static inline RasterStateArray shadowmapRasterStates[maxCascades] = {};
-
-	static constexpr int firstCascadeDepthBias = 160;
-	static constexpr float firstCascadeDepthBiasClamp = 0.015f;
-	static constexpr float firstCascadeSlopeScaleBias = 3.2f;
-
-	static constexpr int secondCascadeDepthBias = 100;
-	static constexpr float secondCascadeDepthBiasClamp = 0.015f;
-	static constexpr float secondCascadeSlopeScaleBias = 3.8f;
-
-	static constexpr int thirdCascadeDepthBias = 100;
-	static constexpr float thirdCascadeDepthBiasClamp = 0.015f;
-	static constexpr float thirdCascadeSlopeScaleBias = 3.8f;
-
 	struct ShadowMapRasterizerDescriptor
 	{
 		int rasterDepthBias;
 		float rasterDepthBiasClamp;
 		float rasterSlopeScaleBias;
 	};
+
+	static constexpr std::uint32_t maxCascades = 3;
+	static void CloneRasterStates(const RasterStateArray& inputArray, std::uint32_t cascade, const std::array<ShadowMapRasterizerDescriptor, maxCascades>& descriptors);
+	static void ReleaseClonedRasterStates();
+
+	static inline std::uint32_t numCascades = 0;
+	static inline std::uint32_t currentCascade = 0;
+	static inline bool initialized = false;
+
+	static inline RasterStateArray* gRasterStates = nullptr;
+	static inline RasterStateArray backupGameRasterStates = {};
+	static inline RasterStateArray shadowmapRasterStates[maxCascades] = {};
+
 	static void GetUpdatedRasterDesc(D3D11_RASTERIZER_DESC& outputDesc, ShadowMapRasterizerDescriptor desc);
 
-	static constexpr ShadowMapRasterizerDescriptor cascadeDescriptors[maxCascades] = {
-		{ firstCascadeDepthBias, firstCascadeDepthBiasClamp, firstCascadeSlopeScaleBias },
-		{ secondCascadeDepthBias, secondCascadeDepthBiasClamp, secondCascadeSlopeScaleBias },
-		{ thirdCascadeDepthBias, thirdCascadeDepthBiasClamp, thirdCascadeSlopeScaleBias }
+	static constexpr int flatFirstCascadeDepthBias = 160;
+	static constexpr float flatFirstCascadeDepthBiasClamp = 0.015f;
+	static constexpr float flatFirstCascadeSlopeScaleBias = 3.2f;
+
+	static constexpr int flatSecondCascadeDepthBias = 100;
+	static constexpr float flatSecondCascadeDepthBiasClamp = 0.015f;
+	static constexpr float flatSecondCascadeSlopeScaleBias = 3.8f;
+
+	static constexpr int flatThirdCascadeDepthBias = 100;
+	static constexpr float flatThirdCascadeDepthBiasClamp = 0.015f;
+	static constexpr float flatThirdCascadeSlopeScaleBias = 3.8f;
+
+	static constexpr std::array<ShadowMapRasterizerDescriptor, maxCascades> flatCascadeDescriptors = {
+		ShadowMapRasterizerDescriptor{ flatFirstCascadeDepthBias, flatFirstCascadeDepthBiasClamp, flatFirstCascadeSlopeScaleBias },
+		ShadowMapRasterizerDescriptor{ flatSecondCascadeDepthBias, flatSecondCascadeDepthBiasClamp, flatSecondCascadeSlopeScaleBias },
+		ShadowMapRasterizerDescriptor{ flatThirdCascadeDepthBias, flatThirdCascadeDepthBiasClamp, flatThirdCascadeSlopeScaleBias }
 	};
 
 	struct BSShadowDirectionalLight_RenderShadowmaps_RenderCascade
 	{
-		static void thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, uint32_t flags);
+		static void thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, std::uint32_t flags);
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 


### PR DESCRIPTION
Fixes VR directional-shadow **flicker** and **banding**. Splits the reviewed a/b/c fix out of #104 — GitHub blocks maintainer push to that fork (the "allow edits by maintainers" box is set but the push 403s), so this lands the proven part here. Authorship preserved: every commit carries `Co-Authored-By: ParticleTroned`.

## What's here (a/b/c)

- **(a) VR bypasses the flat global rasterizer-table swap.** Swapping the shared global rasterizer table per cascade is not stereo-safe and causes directional-shadow flicker. VR returns early and routes directional shadows through the engine mask instead. `ShadowmapCascadeRasterizerFix` is the dev baseline plus that one early-out (using `globals::game::isVR`), with a graceful-degrade if a cascade rasterizer clone ever fails (binds the engine default instead of crashing). The EngineFix/Globals feature boundary is intact — no D3D-hook install reaching across.
- **(b) Engine-mask routing** for VR directional shadows (`DirectionalShadow.hlsli` / `LightLimitFix.hlsli`), with a maskless overload so callers without an engine shadowmask (e.g. particles) still sample LLF directly rather than going fully lit.
- **(c) VR-only receiver depth bias** in `Utility.hlsl`, matching the engine's own compare-depth convention.

## Deferred — (d) continues on #104

The dev-mode outer-cascade caster bias is **not** here. It's gated behind VR + developer mode + a default-off toggle, so it never runs in a normal install, and the RE pass showed its bias magnitudes are too small to be visually meaningful as-is. It deserves the clean always-on treatment, which is better done deliberately. #104 stays open as the home for that work.

## Testing

Confirmed in VR (flicker + banding resolved). Builds green on `ALL`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directional shadow rendering with VR-specific handling for more accurate visuals.
  * Optimized shadow cascade depth comparisons to respect VR viewport/cascade thresholds.
  * Strengthened shadow system initialization to gracefully fall back when state creation fails.
  * Refined shadow sampling and blending for more consistent results across rendering modes.
* **Chores**
  * Updated light-fix shader feature version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->