### PR TITLE
fix(llf): run scene-transition resets on the render thread

### DIFF
--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -217,6 +217,10 @@ void Deferred::PrepassPasses()
 	auto context = globals::d3d::context;
 	context->OMSetRenderTargets(0, nullptr, nullptr);  // Unbind all bound render targets
 
+	// Run any pending LoadingMenu scene-transition resets on this (render) thread before features
+	// iterate their caches, so the clear can't race the menu/Prepass iteration.
+	Feature::DrainSceneTransitions();
+
 	Feature::ForEachLoadedFeature("Prepass", [](Feature* feature) { feature->Prepass(); }, true);
 }
 

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -314,8 +314,12 @@ void Feature::DrainSceneTransitions()
 	static std::atomic<bool> registered{ false };
 	if (!registered.load(std::memory_order_acquire)) {
 		if (auto* ui = globals::game::ui) {
-			ui->GetEventSource<RE::MenuOpenCloseEvent>()->AddEventSink(SceneTransitionSink::GetSingleton());
-			registered.store(true, std::memory_order_release);
+			// GetEventSource can be null before the UI is fully up; leave registered=false and retry
+			// next frame rather than dereferencing it.
+			if (auto* source = ui->GetEventSource<RE::MenuOpenCloseEvent>()) {
+				source->AddEventSink(SceneTransitionSink::GetSingleton());
+				registered.store(true, std::memory_order_release);
+			}
 		}
 	}
 

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -280,6 +280,51 @@ const std::vector<Feature*>& Feature::GetFeatureList()
 	}
 }
 
+namespace
+{
+	// LoadingMenu fires on the main thread; latch the transition here and let the render thread run
+	// the resets, so feature caches the menu/Prepass iterates aren't cleared mid-iteration.
+	std::atomic<bool> g_loadingMenuOpenPending{ false };
+	std::atomic<bool> g_loadingMenuClosePending{ false };
+
+	class SceneTransitionSink : public RE::BSTEventSink<RE::MenuOpenCloseEvent>
+	{
+	public:
+		RE::BSEventNotifyControl ProcessEvent(const RE::MenuOpenCloseEvent* a_event,
+			RE::BSTEventSource<RE::MenuOpenCloseEvent>*) override
+		{
+			if (a_event && a_event->menuName == RE::LoadingMenu::MENU_NAME) {
+				if (a_event->opening)
+					g_loadingMenuOpenPending.store(true, std::memory_order_release);
+				else
+					g_loadingMenuClosePending.store(true, std::memory_order_release);
+			}
+			return RE::BSEventNotifyControl::kContinue;
+		}
+		static SceneTransitionSink* GetSingleton()
+		{
+			static SceneTransitionSink singleton;
+			return &singleton;
+		}
+	};
+}
+
+void Feature::DrainSceneTransitions()
+{
+	static std::atomic<bool> registered{ false };
+	if (!registered.load(std::memory_order_acquire)) {
+		if (auto* ui = globals::game::ui) {
+			ui->GetEventSource<RE::MenuOpenCloseEvent>()->AddEventSink(SceneTransitionSink::GetSingleton());
+			registered.store(true, std::memory_order_release);
+		}
+	}
+
+	if (g_loadingMenuOpenPending.exchange(false, std::memory_order_acq_rel))
+		ForEachLoadedFeature("OnSceneTransitionReset(open)", [](Feature* f) { f->OnSceneTransitionReset(true); });
+	if (g_loadingMenuClosePending.exchange(false, std::memory_order_acq_rel))
+		ForEachLoadedFeature("OnSceneTransitionReset(close)", [](Feature* f) { f->OnSceneTransitionReset(false); });
+}
+
 Feature* Feature::FindFeatureByShortName(const std::string& shortName)
 {
 	for (auto* feature : GetFeatureList()) {

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -125,6 +125,17 @@ public:
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() { return {}; }
 	virtual void SetupResources() {}
 	virtual void Reset() {}
+
+	/**
+	 * @brief Render-thread scene-transition reset (driven by LoadingMenu open/close).
+	 *
+	 * Dispatched by DrainSceneTransitions() on the render thread, so a feature can clear caches
+	 * its menu or Prepass iterates without racing the main-thread LoadingMenu event. Prefer this
+	 * over a direct MenuOpenCloseEvent sink whenever the reset touches render-thread-iterated state.
+	 * @param opening true when the LoadingMenu is opening (old cell teardown), false when closing.
+	 */
+	virtual void OnSceneTransitionReset(bool /*opening*/) {}
+
 	virtual void DrawSettings() {}
 	virtual void DrawUnloadedUI();
 
@@ -211,6 +222,15 @@ public:
 	virtual void ClearShaderCache() {}
 
 	static const std::vector<Feature*>& GetFeatureList();
+
+	/**
+	 * @brief Drains pending LoadingMenu transitions and dispatches OnSceneTransitionReset.
+	 *
+	 * Lazily registers a single LoadingMenu MenuOpenCloseEvent sink. The sink (main thread) only
+	 * latches a flag; this drain runs the resets on the calling thread. Call once per frame from
+	 * the render path so feature resets serialize with render-thread menu/Prepass iteration.
+	 */
+	static void DrainSceneTransitions();
 
 	/**
 	 * @brief Finds a loaded feature by its short name.

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -158,7 +158,6 @@ void DynamicCubemaps::DataLoaded()
 		Util::EnableBooleanSettings(iniVRCubeMapSettings, GetName());
 		Util::EnableBooleanSettings(hiddenVRCubeMapSettings, GetName());
 	}
-	MenuOpenCloseEventHandler::Register();
 }
 
 void DynamicCubemaps::PostPostLoad()
@@ -180,34 +179,14 @@ void DynamicCubemaps::PostPostLoad()
 	}
 }
 
-RE::BSEventNotifyControl MenuOpenCloseEventHandler::ProcessEvent(const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>*)
+void DynamicCubemaps::OnSceneTransitionReset(bool opening)
 {
-	// When entering a new cell, reset the capture
-	if (a_event->menuName == RE::LoadingMenu::MENU_NAME) {
-		if (!a_event->opening) {
-			auto& dynamicCubemaps = globals::features::dynamicCubemaps;
-			dynamicCubemaps.resetCapture[0] = true;
-			dynamicCubemaps.resetCapture[1] = true;
-		}
+	// On LoadingMenu close (new cell loaded) re-trigger the cubemap capture. Dispatched on the
+	// render thread by Feature::DrainSceneTransitions; resetCapture is consumed there too.
+	if (!opening) {
+		resetCapture[0] = true;
+		resetCapture[1] = true;
 	}
-	return RE::BSEventNotifyControl::kContinue;
-}
-
-bool MenuOpenCloseEventHandler::Register()
-{
-	static MenuOpenCloseEventHandler singleton;
-	auto ui = globals::game::ui;
-
-	if (!ui) {
-		logger::error("UI event source not found");
-		return false;
-	}
-
-	ui->GetEventSource<RE::MenuOpenCloseEvent>()->AddEventSink(&singleton);
-
-	logger::info("Registered {}", typeid(singleton).name());
-
-	return true;
 }
 
 void DynamicCubemaps::ClearShaderCache()

--- a/src/Features/DynamicCubemaps.h
+++ b/src/Features/DynamicCubemaps.h
@@ -3,13 +3,6 @@
 #include "Buffer.h"
 #include "Utils/BootSnapshot.h"
 
-class MenuOpenCloseEventHandler : public RE::BSTEventSink<RE::MenuOpenCloseEvent>
-{
-public:
-	virtual RE::BSEventNotifyControl ProcessEvent(const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>* a_eventSource);
-	static bool Register();
-};
-
 struct DynamicCubemaps : Feature
 {
 public:
@@ -160,6 +153,7 @@ public:
 
 	virtual void SetupResources() override;
 	virtual void Reset() override;
+	virtual void OnSceneTransitionReset(bool opening) override;
 
 	virtual void SaveSettings(json&) override;
 	virtual void LoadSettings(json&) override;

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -524,6 +524,15 @@ void LightLimitFix::Reset()
 	jsonPlacedLightCache.clear();
 }
 
+void LightLimitFix::OnSceneTransitionReset(bool opening)
+{
+	// LoadingMenu open: drop the shadow-caster session caches before the engine tears down the old
+	// cell. Dispatched on the render thread (Feature::DrainSceneTransitions), so it serializes with
+	// the settings-menu table iteration that reads the same caches instead of racing it.
+	if (opening)
+		ShadowCasterManager::ResetSession();
+}
+
 void LightLimitFix::LoadSettings(json& o_json)
 {
 	settings = o_json;

--- a/src/Features/LightLimitFix.h
+++ b/src/Features/LightLimitFix.h
@@ -245,6 +245,7 @@ public:
 
 	virtual void SetupResources() override;
 	virtual void Reset() override;
+	virtual void OnSceneTransitionReset(bool opening) override;
 
 	virtual void LoadSettings(json& o_json) override;
 	virtual void SaveSettings(json& o_json) override;

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -3737,12 +3737,9 @@ namespace ShadowCasterManager
 
 		logger::info("[SCM] Hooks installed (ShadowLightCount={})", settings.ShadowLightCount);
 
-		// Wholesale reset on LoadingMenu open so transient session state
-		// (s_normalConvert, s_lights pool, debug pins) drops the previous
-		// cell's pointers before the engine tears them down. Mirrors the
-		// pattern in DynamicCubemaps for similar reset-on-scene-transition
-		// behaviour.
-		RegisterSceneTransitionEvents();
+		// The LoadingMenu reset is driven via LightLimitFix::OnSceneTransitionReset (render thread)
+		// rather than a local main-thread sink, so ResetSession can't race the settings-menu table
+		// iteration. See Feature::DrainSceneTransitions.
 
 		// DXGI budget snapshot at install. Per-slice geometry follows once
 		// Update() sees a non-null kSHADOWMAPS SRV.
@@ -3814,8 +3811,8 @@ namespace ShadowCasterManager
 	void ResetSession()
 	{
 		// Wholesale drop of pointers the engine is about to free during
-		// a scene transition. Called by RegisterSceneTransitionEvents
-		// when the LoadingMenu opens. The per-frame reconciliation in
+		// a scene transition. Called from LightLimitFix::OnSceneTransitionReset
+		// on the render thread when the LoadingMenu opens. The per-frame reconciliation in
 		// ScheduleShadowCasters keeps these caches honest during normal
 		// play; this is the explicit "scene is gone" signal so the UI
 		// counter, debug pins, and tracking sets read empty during the
@@ -3843,34 +3840,6 @@ namespace ShadowCasterManager
 				s_lights.Lights[i].Clear();
 			s_lights.Sun = false;
 		}
-	}
-
-	class SceneTransitionEventHandler : public RE::BSTEventSink<RE::MenuOpenCloseEvent>
-	{
-	public:
-		RE::BSEventNotifyControl ProcessEvent(const RE::MenuOpenCloseEvent* a_event,
-			RE::BSTEventSource<RE::MenuOpenCloseEvent>*) override
-		{
-			if (a_event && a_event->menuName == RE::LoadingMenu::MENU_NAME && a_event->opening)
-				ResetSession();
-			return RE::BSEventNotifyControl::kContinue;
-		}
-		static SceneTransitionEventHandler* GetSingleton()
-		{
-			static SceneTransitionEventHandler singleton;
-			return &singleton;
-		}
-	};
-
-	void RegisterSceneTransitionEvents()
-	{
-		auto* ui = globals::game::ui;
-		if (!ui) {
-			logger::error("[SCM] No UI singleton; cannot register LoadingMenu handler");
-			return;
-		}
-		ui->AddEventSink(SceneTransitionEventHandler::GetSingleton());
-		logger::info("[SCM] LoadingMenu event handler registered");
 	}
 
 	const LightContainer& GetLights()

--- a/src/Features/LightLimitFix/ShadowCasterManager.h
+++ b/src/Features/LightLimitFix/ShadowCasterManager.h
@@ -600,12 +600,9 @@ namespace ShadowCasterManager
 	/// covers the same ground for incremental changes; this is the wholesale
 	/// reset for known scene boundaries so the UI counter and table read 0
 	/// during the loading screen instead of carrying stale entries forward.
+	/// Driven by LightLimitFix::OnSceneTransitionReset on the render thread (LoadingMenu open),
+	/// so the clear serializes with the settings-menu table iteration instead of racing it.
 	void ResetSession();
-
-	/// Register the LoadingMenu open/close handler so ResetSession fires
-	/// when the user starts a fast-travel or cell transition. Call once
-	/// from SCM::Install after the rest of the hooks are in place.
-	void RegisterSceneTransitionEvents();
 
 	/// Returns a read-only view of the active light pool for UI/visualization.
 	const LightContainer& GetLights();


### PR DESCRIPTION
## Problem

`LoadingMenu`'s `MenuOpenCloseEvent` fires on the **main thread**, but feature caches are iterated on the **render thread** (the settings-menu tables via `DrawSettings`, and the per-frame `Prepass`). When a feature cleared those caches from its own main-thread `LoadingMenu` sink, a `coc`/`cow` cell transition **with the menu open** could clear a `std::vector` while the menu iterated it → dangling-iterator use-after-free → intermittent CTD. LLF/`ShadowCasterManager` (the big shadow-caster table) was the visible offender; a flat-SE crashlog pointed at the LLF render path.

## Fix — a small framework mechanism (closes the whole class)

- `Feature::OnSceneTransitionReset(bool opening)` virtual (default no-op).
- One lazily-registered `LoadingMenu` sink just latches an atomic flag; `Feature::DrainSceneTransitions()` consumes it on the **render thread** (in the `Deferred` `Prepass` dispatch) and calls `OnSceneTransitionReset` on every loaded feature there.

So every feature's scene-reset now runs on the render thread, serialized with menu/Prepass iteration — no cross-thread clear-while-iterate, and no per-feature `MenuOpenCloseEvent` boilerplate.

## Migrated onto it
- **LightLimitFix / ShadowCasterManager**: `OnSceneTransitionReset(opening)` → `ResetSession()`; removed `SceneTransitionEventHandler` / `RegisterSceneTransitionEvents`.
- **DynamicCubemaps**: `OnSceneTransitionReset(!opening)` → `resetCapture`; removed its `MenuOpenCloseEventHandler`.
- **InteriorSun**: unchanged — its sink handles `MainMenu`, not `LoadingMenu`, so it isn't this pattern.

## Testing
Compile-verified (`ALL`, clean). The race is **timing-dependent** (an attached debugger masks it — confirmed: 30 menu-open `coc`/`cow` transitions under cdb didn't fire it), so this is a reasoned fix rather than one validated against a live capture. Behavior is preserved per feature — the resets are the same, only the thread/timing changed (deferred one render frame). A runtime smoke test (load + repeated cell transitions, confirm no regression) is recommended before merge.