### PR TITLE
fix(vr): correct shadowmap rasterizer stride; drop #112 workaround

### DIFF
--- a/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
+++ b/features/Light Limit Fix/Shaders/LightLimitFix/LightLimitFix.hlsli
@@ -166,15 +166,8 @@ namespace LightLimitFix
 	// must fall through to the engine mask. Returning 1.0 there leaves distant
 	// pixels fully lit -- visible as global scene brightening with shadows
 	// disappearing past a depth that varies with camera position.
-	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex, float engineMaskShadow, bool useEngineMaskShadow)
+	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex, float engineMaskShadow)
 	{
-#if defined(VR)
-		// VR returns the engine mask for all cascades: the LLF two-cascade PCF
-		// path bands once VR drops the caster-side global rasterizer swap.
-		if (useEngineMaskShadow)
-			return engineMaskShadow;
-#endif
-
 		DirectionalShadowLightData shadowLightData = DirectionalShadowLights[0];
 
 		float shadowMapDepth = SharedData::GetScreenDepth(FrameBuffer::GetShadowDepth(worldPosition, eyeIndex));
@@ -295,21 +288,17 @@ namespace LightLimitFix
 		return shadow;
 	}
 
-	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex, float engineMaskShadow)
-	{
-		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex, engineMaskShadow, true);
-	}
-
-	// Convenience overload for callers without TexShadowMaskSampler bound
-	// (e.g. particles): route through the direct LLF sampler, no engine mask.
+	// Convenience overload: callers without TexShadowMaskSampler bound
+	// (e.g. Particle.hlsl) get the lit-fallback behaviour (1.0) past
+	// cascade 1, matching the pre-engine-mask behaviour for those paths.
 	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix, uint eyeIndex)
 	{
-		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex, 1.0, false);
+		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex, 1.0);
 	}
 
 	float GetDirectionalShadow(float3 worldPosition, float3 worldPositionWS, float2x2 rotationMatrix)
 	{
-		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, 0, 1.0, false);
+		return GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, 0, 1.0);
 	}
 
 	float SampleShadowGather(uint shadowIndex, float2 uv, float receiverDepth)

--- a/package/Shaders/Common/DirectionalShadow.hlsli
+++ b/package/Shaders/Common/DirectionalShadow.hlsli
@@ -5,43 +5,21 @@
 
 namespace DirectionalShadow
 {
-	// Single owner of the directional-shadow routing so new consumers can't read the
-	// stale engine mask under SLF. Under LIGHT_LIMIT_FIX: non-VR samples LLF directly
-	// (lit past range); VR masked returns the engine mask (avoids banding after VR's
-	// rasterizer split); without LLF, returns the mask as-is. Also owns the PCF
-	// noise-rotation. Lighting.hlsl bypasses this (feeds the mask into LLF as the
-	// past-cascade fallback). Needs LightLimitFix.hlsli first.
-#if defined(LIGHT_LIMIT_FIX)
-	float SampleLightLimitFixDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise)
+	// Single owner of the directional-shadow routing decision, so new consumers
+	// can't read the stale engine mask under SLF. Under LIGHT_LIMIT_FIX the engine
+	// mask is a no-op, so sample LLF cascades directly (fully lit past range);
+	// otherwise return the engine mask as-is. Also owns the PCF noise-rotation so
+	// callers skip the sincos boilerplate. Lighting.hlsl deliberately bypasses this
+	// (feeds the mask into LLF as the past-cascade fallback). Needs LightLimitFix.hlsli first.
+	float GetSceneDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise, float a_engineMaskShadow)
 	{
+#if defined(LIGHT_LIMIT_FIX)
 		float2 rotation;
 		sincos(Math::TAU * a_screenNoise, rotation.y, rotation.x);
 		float2x2 rotationMatrix = float2x2(rotation.x, rotation.y, -rotation.y, rotation.x);
 		return LightLimitFix::GetDirectionalShadow(worldPosition, worldPositionWS, rotationMatrix, eyeIndex);
-	}
-#endif
-
-	float GetSceneDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise, float a_engineMaskShadow)
-	{
-#if defined(LIGHT_LIMIT_FIX)
-#	if defined(VR)
-		return a_engineMaskShadow;
-#	else
-		return SampleLightLimitFixDirectionalShadow(worldPosition, worldPositionWS, eyeIndex, a_screenNoise);
-#	endif
 #else
 		return a_engineMaskShadow;
-#endif
-	}
-
-	// Maskless callers (for example particles) still need the direct LLF path
-	// because they have no engine shadowmask sample to return in VR.
-	float GetSceneDirectionalShadow(float3 worldPosition, float3 worldPositionWS, uint eyeIndex, float a_screenNoise)
-	{
-#if defined(LIGHT_LIMIT_FIX)
-		return SampleLightLimitFixDirectionalShadow(worldPosition, worldPositionWS, eyeIndex, a_screenNoise);
-#else
-		return 1.0;
 #endif
 	}
 }

--- a/package/Shaders/Particle.hlsl
+++ b/package/Shaders/Particle.hlsl
@@ -315,7 +315,7 @@ PS_OUTPUT main(PS_INPUT input)
 #	if defined(VOLUMETRIC_SHADOWS)
 		dirSoftShadow = VolumetricShadows::GetVSMShadow2D(positionWS.xyz, worldPositionWS, eyeIndex, dirDetailedShadow);
 #	else
-		dirDetailedShadow = DirectionalShadow::GetSceneDirectionalShadow(positionWS.xyz, worldPositionWS, eyeIndex, screenNoise);
+		dirDetailedShadow = DirectionalShadow::GetSceneDirectionalShadow(positionWS.xyz, worldPositionWS, eyeIndex, screenNoise, 1.0);
 #	endif
 	}
 

--- a/package/Shaders/Utility.hlsl
+++ b/package/Shaders/Utility.hlsl
@@ -529,42 +529,32 @@ PS_OUTPUT main(PS_INPUT input)
 		float shadowVisibility = 0;
 
 		float3 positionLS = mul(transpose(lightProjectionMatrix), float4(positionMS.xyz, 1)).xyz;
-#			if defined(VR)
-		float shadowMapCompareDepth = positionLS.z - shadowMapThreshold;
-#			else
-		float shadowMapCompareDepth = positionLS.z;
-#			endif
 
 #			if SHADOWFILTER == 0
 		float shadowMapValue = TexShadowMapSampler.Sample(SampShadowMapSampler, float3(positionLS.xy, cascadeIndex)).x;
-		if (shadowMapValue >= shadowMapCompareDepth) {
+		if (shadowMapValue >= positionLS.z) {
 			shadowVisibility = 1;
 		}
 #			elif SHADOWFILTER == 1
-		shadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(positionLS.xy, cascadeIndex), shadowMapCompareDepth).x;
+		shadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(positionLS.xy, cascadeIndex), positionLS.z).x;
 #			elif SHADOWFILTER == 3
-		shadowVisibility = SampleShadowPCF(TexShadowMapSamplerComp, SampShadowMapSamplerComp, positionLS.xy, cascadeIndex, shadowMapCompareDepth, rotationMatrix, ShadowSampleParam.z * 0.5);
+		shadowVisibility = SampleShadowPCF(TexShadowMapSamplerComp, SampShadowMapSamplerComp, positionLS.xy, cascadeIndex, positionLS.z, rotationMatrix, ShadowSampleParam.z * 0.5);
 #			endif
 
 		if (cascadeIndex < 1 && StartSplitDistances.y < shadowMapDepth) {
 			float cascade1ShadowVisibility = 0;
 
 			float3 cascade1PositionLS = mul(transpose(ShadowMapProj[eyeIndex][1]), float4(positionMS.xyz, 1)).xyz;
-#			if defined(VR)
-			float cascade1CompareDepth = cascade1PositionLS.z - AlphaTestRef.z;
-#			else
-			float cascade1CompareDepth = cascade1PositionLS.z;
-#			endif
 
 #			if SHADOWFILTER == 0
 			float cascade1ShadowMapValue = TexShadowMapSampler.Sample(SampShadowMapSampler, float3(cascade1PositionLS.xy, 1)).x;
-			if (cascade1ShadowMapValue >= cascade1CompareDepth) {
+			if (cascade1ShadowMapValue >= cascade1PositionLS.z) {
 				cascade1ShadowVisibility = 1;
 			}
 #			elif SHADOWFILTER == 1
-			cascade1ShadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(cascade1PositionLS.xy, 1), cascade1CompareDepth).x;
+			cascade1ShadowVisibility = TexShadowMapSamplerComp.SampleCmpLevelZero(SampShadowMapSamplerComp, float3(cascade1PositionLS.xy, 1), cascade1PositionLS.z).x;
 #			elif SHADOWFILTER == 3
-			cascade1ShadowVisibility = SampleShadowPCF(TexShadowMapSamplerComp, SampShadowMapSamplerComp, cascade1PositionLS.xy, 1, cascade1CompareDepth, rotationMatrix, ShadowSampleParam.z * 0.5);
+			cascade1ShadowVisibility = SampleShadowPCF(TexShadowMapSamplerComp, SampShadowMapSamplerComp, cascade1PositionLS.xy, 1, cascade1PositionLS.z, rotationMatrix, ShadowSampleParam.z * 0.5);
 #			endif
 
 			float cascade1BlendFactor = smoothstep(0, 1, (shadowMapDepth - StartSplitDistances.y) / (EndSplitDistances.x - StartSplitDistances.y));

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -1,5 +1,7 @@
 #include "ShadowmapCascadeRasterizerFix.h"
 
+#include "Utils/D3D.h"
+
 void ShadowmapRasterizerFix::Install()
 {
 	gRasterStates = reinterpret_cast<RasterStatePtr*>(REL::RelocationID(524748, 411363).address());
@@ -74,7 +76,9 @@ void ShadowmapRasterizerFix::CloneRasterStates(RasterStatePtr* inputArray, int c
 						auto*& clonedRaster = shadowmapRasterStates[cascade][i];
 						if (const auto hr = globals::d3d::device->CreateRasterizerState(&desc, &clonedRaster); FAILED(hr)) {
 							logger::warn("ShadowmapRasterizerFix: failed to clone cascade {} rasterizer state (hr=0x{:08X}); keeping engine state", cascade, static_cast<std::uint32_t>(hr));
-							clonedRaster = gRasterizer;
+							clonedRaster = gRasterizer;  // engine's own state; leave its name as-is
+						} else {
+							Util::SetResourceName(clonedRaster, "ShadowmapCascadeRasterizerFix::CascadeBias[%d][%d]", cascade, i);
 						}
 					}
 				}

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -2,9 +2,6 @@
 
 void ShadowmapRasterizerFix::Install()
 {
-	// This function is called once per cascade to begin the updating and rendering process
-	stl::write_thunk_call<BSShadowDirectionalLight_RenderShadowmaps_RenderCascade>(REL::RelocationID(101495, 108489).address() + REL::Relocate(0xC6, 0xC6, 0xF6));
-
 	gRasterStates = reinterpret_cast<RasterStatePtr*>(REL::RelocationID(524748, 411363).address());
 
 	// VR's gRasterStates has 13 depth-bias presets vs 12 on flat; stride accordingly so the
@@ -12,6 +9,11 @@ void ShadowmapRasterizerFix::Install()
 	depthDim = globals::game::isVR ? 13 : 12;
 
 	numCascades = static_cast<uint>(Util::GetGameSettingValue<std::int32_t>("iNumSplits:Display", Settings.at("iNumSplits:Display")));
+
+	// Install the hook LAST, after all static state is set, so a render-thread RenderCascade
+	// can't enter thunk() with a null gRasterStates or an unset VR stride. The hooked function
+	// is called once per cascade to begin the updating and rendering process.
+	stl::write_thunk_call<BSShadowDirectionalLight_RenderShadowmaps_RenderCascade>(REL::RelocationID(101495, 108489).address() + REL::Relocate(0xC6, 0xC6, 0xF6));
 }
 
 void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCascade::thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, uint32_t flags)
@@ -25,11 +27,11 @@ void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCas
 		//Backup
 		if (cascade == 0) {
 			std::memcpy(backupGameRasterStates, gRasterStates, bytes);
-			numCascades = std::min(numCascades, maxCascades);
+			numCascades = std::max(1u, std::min(numCascades, maxCascades));
 		}
 
-		//Clone
-		CloneRasterStates(gRasterStates, cascade);
+		//Clone from the pristine engine table (we overwrite gRasterStates per cascade below)
+		CloneRasterStates(backupGameRasterStates, cascade);
 
 		initialized = cascade == numCascades - 1;
 	}

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -5,27 +5,26 @@ void ShadowmapRasterizerFix::Install()
 	// This function is called once per cascade to begin the updating and rendering process
 	stl::write_thunk_call<BSShadowDirectionalLight_RenderShadowmaps_RenderCascade>(REL::RelocationID(101495, 108489).address() + REL::Relocate(0xC6, 0xC6, 0xF6));
 
-	gRasterStates = reinterpret_cast<RasterStateArray*>(REL::RelocationID(524748, 411363).address());
+	gRasterStates = reinterpret_cast<RasterStatePtr*>(REL::RelocationID(524748, 411363).address());
+
+	// VR's gRasterStates has 13 depth-bias presets vs 12 on flat; stride accordingly so the
+	// per-cascade swap lands in the slots the engine actually binds (fixes VR cascade flicker).
+	depthDim = globals::game::isVR ? 13 : 12;
 
 	numCascades = static_cast<uint>(Util::GetGameSettingValue<std::int32_t>("iNumSplits:Display", Settings.at("iNumSplits:Display")));
 }
 
 void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCascade::thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, uint32_t flags)
 {
-	// VR bypasses the flat global rasterizer-table swap: swapping the shared global table per
-	// cascade is not stereo-safe and flickers; VR routes directional shadows via the engine mask.
-	if (globals::game::isVR) {
-		func(light, arg1, arg2, flags);
-		return;
-	}
-
 	static uint cascade = 0;
+
+	const auto bytes = static_cast<std::size_t>(StateCount()) * sizeof(RasterStatePtr);
 
 	static bool initialized = false;
 	if (!initialized) {
 		//Backup
 		if (cascade == 0) {
-			std::memcpy(backupGameRasterStates, *gRasterStates, sizeof(RasterStateArray));
+			std::memcpy(backupGameRasterStates, gRasterStates, bytes);
 			numCascades = std::min(numCascades, maxCascades);
 		}
 
@@ -36,13 +35,13 @@ void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCas
 	}
 
 	//Emplace
-	std::memcpy(*gRasterStates, shadowmapRasterStates[cascade], sizeof(RasterStateArray));
+	std::memcpy(gRasterStates, shadowmapRasterStates[cascade], bytes);
 
 	func(light, arg1, arg2, flags);
 
 	//Restore
 	if (cascade == numCascades - 1)
-		std::memcpy(*gRasterStates, backupGameRasterStates, sizeof(RasterStateArray));
+		std::memcpy(gRasterStates, backupGameRasterStates, bytes);
 
 	cascade = ++cascade < numCascades ? cascade : 0;
 }
@@ -55,13 +54,14 @@ void ShadowmapRasterizerFix::GetUpdatedRasterDesc(D3D11_RASTERIZER_DESC& outputD
 }
 
 // Since state objects are shared globally across the pipeline we make duplicate arrays that cover the same range of states the game does
-void ShadowmapRasterizerFix::CloneRasterStates(RasterStateArray* inputArray, int cascade)
+void ShadowmapRasterizerFix::CloneRasterStates(RasterStatePtr* inputArray, int cascade)
 {
-	for (int fill = 0; fill < 2; fill++) {
-		for (int cull = 0; cull < 3; cull++) {
-			for (int depth = 0; depth < 12; depth++) {
-				for (int scissor = 0; scissor < 2; scissor++) {
-					if (auto* gRasterizer = (*inputArray)[fill][cull][depth][scissor]) {
+	for (int fill = 0; fill < kFill; fill++) {
+		for (int cull = 0; cull < kCull; cull++) {
+			for (int depth = 0; depth < depthDim; depth++) {
+				for (int scissor = 0; scissor < kScissor; scissor++) {
+					const int i = StateIndex(fill, cull, depth, scissor);
+					if (auto* gRasterizer = inputArray[i]) {
 						D3D11_RASTERIZER_DESC desc{};
 						gRasterizer->GetDesc(&desc);
 
@@ -69,7 +69,7 @@ void ShadowmapRasterizerFix::CloneRasterStates(RasterStateArray* inputArray, int
 
 						// Degrade instead of crashing: on failure keep the engine's own state for this slot
 						// (loses only our added bias, not its cull/fill/scissor) rather than D3D defaults.
-						auto*& clonedRaster = shadowmapRasterStates[cascade][fill][cull][depth][scissor];
+						auto*& clonedRaster = shadowmapRasterStates[cascade][i];
 						if (const auto hr = globals::d3d::device->CreateRasterizerState(&desc, &clonedRaster); FAILED(hr)) {
 							logger::warn("ShadowmapRasterizerFix: failed to clone cascade {} rasterizer state (hr=0x{:08X}); keeping engine state", cascade, static_cast<std::uint32_t>(hr));
 							clonedRaster = gRasterizer;

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
@@ -6,16 +6,30 @@ struct ShadowmapRasterizerFix : EngineFix
 	std::string GetName() override { return "Shadowmap Cascade Rasterizer Fix"; }
 	void Install() override;
 
-	using RasterStateArray = ID3D11RasterizerState* [2][3][12][2];
+	// gRasterStates is [fill=2][cull=3][depthBias=N][scissor=2] of rasterizer-state pointers.
+	// The depth-bias dimension is 12 on flat (SE/AE) but 13 on VR (one extra preset), so the
+	// engine indexes with a per-runtime stride. We store flat and stride at runtime: a fixed C
+	// array type would bake the wrong stride on one platform and scatter the per-cascade caster
+	// states into the wrong slots (the historical VR shadow-cascade flicker).
+	static constexpr int kFill = 2, kCull = 3, kScissor = 2, kMaxDepth = 13;
+	static constexpr int kMaxStates = kFill * kCull * kMaxDepth * kScissor;  // 156 (VR); flat uses 144
+	using RasterStatePtr = ID3D11RasterizerState*;
 
-	static void CloneRasterStates(RasterStateArray* inputArray, int cascade);
+	static inline int depthDim = 12;  // set to 13 for VR in Install()
+	static int StateCount() { return kFill * kCull * depthDim * kScissor; }
+	static int StateIndex(int fill, int cull, int depth, int scissor)
+	{
+		return ((fill * kCull + cull) * depthDim + depth) * kScissor + scissor;
+	}
+
+	static void CloneRasterStates(RasterStatePtr* inputArray, int cascade);
 
 	static constexpr uint maxCascades = 3;
 	static inline uint numCascades = 0;
 
-	static inline RasterStateArray* gRasterStates = nullptr;
-	static inline RasterStateArray backupGameRasterStates = {};
-	static inline RasterStateArray shadowmapRasterStates[maxCascades] = {};
+	static inline RasterStatePtr* gRasterStates = nullptr;
+	static inline RasterStatePtr backupGameRasterStates[kMaxStates] = {};
+	static inline RasterStatePtr shadowmapRasterStates[maxCascades][kMaxStates] = {};
 
 	static constexpr int firstCascadeDepthBias = 160;
 	static constexpr float firstCascadeDepthBiasClamp = 0.015f;


### PR DESCRIPTION
## Problem

VR directional-shadow flicker (the issue #104 / #112 chased) is caused by a **rasterizer-state array stride mismatch**, not the shadow shaders.

The engine's `gRasterStates` is `[fill=2][cull=3][depthBias=N][scissor=2]`. The depth-bias dimension is **12 on flat (SE/AE) but 13 on VR** (one extra preset). `BSGraphics::SetDirtyStates` indexes it with stride **13 on VR** (`IMUL ...,0xd`) vs **12 on flat**, confirmed in both binaries. `ShadowmapCascadeRasterizerFix` hardcoded `[2][3][12][2]`, so on VR every per-cascade caster-bias swap was byte-misaligned (and the 13th depth row never swapped) → caster state bled across cascades → **flicker**.

The bug was latent since the fix was added (#1690) because that hooked the VR `RenderCascade` at the wrong offset; **#1888** corrected the VR hook (`0xC6 → 0xF6`), which first made the swap actually run on VR and exposed the flicker.

**#112** worked around the flicker by bypassing the swap on VR and routing directional shadows through the engine shadow mask + a VR receiver-side compare-depth bias. On setups where the mask reads lit, that removed **exterior shadows entirely** ([reported regression](https://github.com/alandtse/open-shaders/pull/104); the author pre-noted this risk).

## Fix

- **Stride `gRasterStates` at runtime** (13 on VR, 12 on flat) so the caster-bias swap lands in the slots the engine binds.
- **Revert #112's VR shader workaround** — VR samples LLF directly again (no engine-mask routing, no VR receiver-side bias). SE bias presets are byte-identical to VR's, so the flat caster-bias magnitudes transfer 1:1.
- Re-enable the swap on VR (drop the #112 bypass).

## VR-gated / flat untouched

- `depthDim` stays 12 on flat, so `StateIndex`/`StateCount` reduce to the exact original `[2][3][12][2]` index math and 144-pointer memcpy — **byte-identical flat behavior**.
- The shader reverts only undo `#if defined(VR)` blocks; non-VR paths are unchanged.
- #112's platform-neutral `CreateRasterizerState` degrade-on-failure is **kept**.

## Validation

- ALL build green (SE/AE/VR universal).
- VR no-CTD smoke: load + 6 exterior cascade-rebuild transitions, no crash, no crashlog. The new stride-13 swap path runs every frame outdoors.
- Visual A/B (flicker gone + exterior shadows present) to be confirmed on the CI VR prerelease.

Reverts the VR-specific parts of #112; fixes the real cause behind #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized directional shadow rendering pipeline with streamlined cascade calculations
  * Improved shadow consistency across VR and standard rendering paths
  * Enhanced memory efficiency in shadow cascade rasterizer state management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->