### PR TITLE
fix: ctd when upscaling disabled

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -927,6 +927,8 @@ Upscaling::UpscaleMethod Upscaling::GetUpscaleMethod() const
 
 bool Upscaling::PerfModePrerequisitesMet() const
 {
+	if (!loaded)
+		return false;
 	const auto method = GetUpscaleMethod();
 	const bool methodRedirectsOutput = method == UpscaleMethod::kDLSS || method == UpscaleMethod::kFSR;
 	// >1.0x: a sub-display render res to bank. Native AA (1.0x) banks nothing.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where performance mode for upscaling could be evaluated before the feature was properly initialized, preventing potential errors during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->