### PR TITLE
fix(1.7): ctd when upscaling disabled (#120)

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -927,6 +927,8 @@ Upscaling::UpscaleMethod Upscaling::GetUpscaleMethod() const
 
 bool Upscaling::PerfModePrerequisitesMet() const
 {
+	if (!loaded)
+		return false;
 	const auto method = GetUpscaleMethod();
 	const bool methodRedirectsOutput = method == UpscaleMethod::kDLSS || method == UpscaleMethod::kFSR;
 	// >1.0x: a sub-display render res to bank. Native AA (1.0x) banks nothing.


### PR DESCRIPTION
Hotfix candidate for the **1.7** line.

Cherry-picked onto `hotfix/1.7.x` (base `v1.7.0`):
- `fix: ctd when upscaling disabled (#120)` (ca21a1583)

PR checks build a `v1.7.0-prNNNN` prerelease for verification. After merge, cut the release via **Release: Semantic Version** on `main` with `ff_target` = the `hotfix/1.7.x` tip → `v1.7.1`.

Opened by hand: the `Release: Hotfix Candidate` run completed the cherry-pick and pushed both branches, but the Actions token is not permitted to create PRs (repo setting "Allow GitHub Actions to create and approve pull requests"). Branches are correct; only the PR-open step was blocked.
