### PR TITLE
fix(sk_hdr_png): guard 32-bit dimension overflow in write_image_to_disk

### DIFF
--- a/extern/sk_hdr_png/include/sk_hdr_png.hpp
+++ b/extern/sk_hdr_png/include/sk_hdr_png.hpp
@@ -878,8 +878,17 @@ sk_hdr_png::write_image_to_disk (const wchar_t* image_path, unsigned int width, 
 
 	HRESULT hr = E_OUTOFMEMORY;
 
-	UINT row_stride  = (width * 48 + 7)/8;
-	UINT buffer_size = height * row_stride;
+	// Compute packed dimensions in 64-bit, then reject anything exceeding the WIC
+	// WritePixels UINT cbStride/cbBufferSize limit (such images are unencodable here
+	// anyway). Prevents a 32-bit overflow from undersizing png_buffer -> heap overflow.
+	const uint64_t row_stride64  = ((uint64_t)width * 48ull + 7ull) / 8ull;
+	const uint64_t buffer_size64 = (uint64_t)height * row_stride64;
+	if (row_stride64 > 0xFFFFFFFFull || buffer_size64 > 0xFFFFFFFFull)
+	{
+		return false;
+	}
+	UINT row_stride  = static_cast<UINT>(row_stride64);
+	UINT buffer_size = static_cast<UINT>(buffer_size64);
 
 	BYTE*     png_buffer      =     (BYTE *)_aligned_malloc(sizeof (    BYTE) * buffer_size,    16);
 	XMFLOAT4* rgba32_scanline = (XMFLOAT4 *)_aligned_malloc(sizeof (XMFLOAT4) * width,          16);
@@ -918,7 +927,7 @@ sk_hdr_png::write_image_to_disk (const wchar_t* image_path, unsigned int width, 
 
 				auto pixel_luminance = luminance;
 
-				for (size_t i = 0; i < width * height; i++)
+				for (size_t i = 0; i < static_cast<size_t>(width) * height; i++)
 				{
 					const uint32_t color = *reinterpret_cast<const uint32_t *>(src_pixels++);
 


### PR DESCRIPTION
Resolves the CodeQL alert in `extern/sk_hdr_png/include/sk_hdr_png.hpp` (`cpp/integer-multiplication-cast-to-long`, "multiplication may overflow `unsigned int`") and the related, more dangerous latent overflow CodeQL did **not** flag.

## The flaw

`width`/`height` are `unsigned int`. All packed-dimension math is 32-bit:
- `UINT buffer_size = height * row_stride;` sizes the `png_buffer` heap allocation; the encode loops write 6 bytes/pixel into it. A 32-bit overflow here → undersized buffer → **heap overflow** (CWE-190 → CWE-787). This is the real risk; CodeQL missed it because it overflows to the same type (`UINT`), not a wider one.
- `for (size_t i = 0; i < width * height; i++)` — the 32-bit product is widened to `size_t` only after it can overflow. This is the line CodeQL flagged.

## Reachability

Not reachable in this codebase: capture dimensions come from D3D11 textures, so `width, height ≤ 16384`. Worst case 16384² → `buffer_size = 1.61×10⁹ < UINT_MAX`, `width·height = 2.68×10⁸`; nothing overflows. WIC `WritePixels` itself takes `UINT cbBufferSize`, so the function is structurally limited to UINT-sized images. So this is **defensive hardening**, not a live exploit.

## Fix

Compute `row_stride`/`buffer_size` in 64-bit and reject images that exceed the WIC `UINT` limit (unencodable anyway); keep the loop count in 64-bit. Behavior is identical for every valid input; pathological dimensions are now cleanly rejected instead of overflowing.

Upstream: this file is public-domain, vendored from ReShade (`crosire/reshade` @ e7cce82). A matching fix is being prepared for an upstream PR so the source is fixed too; this lands the hardening in our copy now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed buffer overflow vulnerabilities in PNG encoding operations that could occur when processing images with very large dimensions, improving stability and preventing potential crashes.
  * Enhanced dimension validation to prevent arithmetic overflow when computing internal buffer sizes for PNG encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->