### PR TITLE
fix(vr): restore PerfMode/foveated DLSS output height

### DIFF
--- a/src/Features/Upscaling/Streamline.cpp
+++ b/src/Features/Upscaling/Streamline.cpp
@@ -465,9 +465,6 @@ void Streamline::SetDLSSOptions(sl::ViewportHandle p_viewport, uint32_t width, u
 	// produces zeroed output. See SetDLSSOptions decl in Streamline.h for the rationale.
 	dlssOptions.outputHeight = height != 0 ? height : (dlssperfActive ? (uint)perfMode.GetDisplayScreenSize().y : (uint)state->screenSize.y);
 
-	dlssOptions.outputWidth = width;
-	dlssOptions.outputHeight = (uint)state->screenSize.y;
-
 	// Detect HDR from kMAIN format at runtime -- VR kMAIN may be 8-bit while SE is FP16
 	{
 		auto renderer = globals::game::renderer;


### PR DESCRIPTION
## Problem

The v1.7.0 upstream sync (#121) — specifically the VR-restore revert `47821fa6a` ("Revert 'remove all VR support (#2475)'") — re-applied upstream's plain `dlssOptions.outputHeight = state->screenSize.y` **immediately after** the fork's PerfMode/foveation-aware line in `Streamline::SetDLSSOptions`, silently clobbering it:

```cpp
dlssOptions.outputHeight = height != 0 ? height
    : (dlssperfActive ? (uint)perfMode.GetDisplayScreenSize().y : (uint)state->screenSize.y);  // fork (intended)
dlssOptions.outputWidth  = width;                       // <- re-added by the revert
dlssOptions.outputHeight = (uint)state->screenSize.y;   // <- clobbers the line above
```

Confirmed via `git show 47821fa6a -- src/Features/Upscaling/Streamline.cpp` (the two lines are `+` additions from that commit).

## Impact

Under PerfMode (`renderAtUpscaleRes`), `state->screenSize.y` is the renderRes-polluted spoofed HMD size, so DLSS was told a **renderRes** output height that no longer matches the **displayRes** output extent. NGX requires `outputHeight == extentOut.height` (documented in the comment directly above the clobbered line) or it zeroes the output. The clobber also discards the FoveatedRender subrect height passed via `height`.

## Fix

Remove the duplicate so the intended height reaches NGX:
- DisplayRes under PerfMode,
- subrect height under FoveatedRender,
- `screenSize` otherwise.

Net `-3` lines; restores the behavior that shipped before the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)