### PR TITLE
fix(vr): clear PerfMode fakeDS depth per frame

### DIFF
--- a/src/Features/Upscaling/PerfMode.h
+++ b/src/Features/Upscaling/PerfMode.h
@@ -90,6 +90,10 @@ struct PerfMode
 	// Fake 3k DepthStencil for Post pass DS swap
 	ID3D11DepthStencilView* GetFakeDSV() const { return fakeDSV.get(); }
 
+	// Reset fakeDS to far depth (1.0) + stencil 0 — its intended throwaway state. Must run
+	// per-frame, not just at init, or UI-pass depth writes (controllers) linger and occlude menus.
+	void ClearFakeDS();
+
 	// Bridge the DLSS-reconstructed menu BG (testTexture, displayRes) into
 	// the bound enlarged RT so OpenVR submit sees both BG + UI compositor
 	// output. One-shot per frame; gated via blittedFrameId.
@@ -319,6 +323,7 @@ private:
 	// Fake 3k DepthStencil (DisplayRes, same format as engine kMAIN DS)
 	winrt::com_ptr<ID3D11Texture2D> fakeDS;
 	winrt::com_ptr<ID3D11DepthStencilView> fakeDSV;
+	uint32_t lastFakeDSClearFrame = UINT32_MAX;  // frame guard so ClearFakeDS runs once/frame
 
 	// autoSwapDSIdx == UINT32_MAX → no active swap; otherwise it's the
 	// kMAIN/kMAIN_COPY slot whose views[] were rewritten and must be

--- a/src/Features/Upscaling/PerfMode/Core.cpp
+++ b/src/Features/Upscaling/PerfMode/Core.cpp
@@ -10,6 +10,13 @@
 // (same one Upscaling.cpp uses), avoiding a duplicate scale table here.
 #include <FidelityFX/host/ffx_fsr3.h>
 
+void PerfMode::ClearFakeDS()
+{
+	if (!hookActive || !fakeDSV)
+		return;
+	globals::d3d::context->ClearDepthStencilView(fakeDSV.get(), D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
+}
+
 void PerfMode::SetupResources()
 {
 	if (!globals::game::isVR)
@@ -163,10 +170,7 @@ void PerfMode::SetupResources()
 		}
 	}
 
-	if (hookActive && fakeDSV) {
-		auto* ctx = globals::d3d::context;
-		ctx->ClearDepthStencilView(fakeDSV.get(), D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
-	}
+	ClearFakeDS();
 
 	// IS shader hooks (must be installed AFTER FrameAnnotations)
 	if (hookActive && !tonemapHookInstalled) {

--- a/src/Features/Upscaling/PerfMode/MenuBridge.cpp
+++ b/src/Features/Upscaling/PerfMode/MenuBridge.cpp
@@ -64,6 +64,14 @@ void PerfMode::UIPassDispatch_Hook::thunk(RE::BSGraphics::BSShaderAccumulator* s
 		globals::game::stateUpdateFlags->set(RE::BSGraphics::ShaderFlags::DIRTY_VIEWPORT);
 	}
 
+	// fakeDS is only cleared at init, so without this a prior frame's UI-pass depth (controllers)
+	// lingers and LessEqual-occludes the menu compositor — the persistent hand-shaped cutout.
+	const uint32_t frame = globals::state ? globals::state->frameCount : 0;
+	if (perfMode.lastFakeDSClearFrame != frame) {
+		perfMode.ClearFakeDS();
+		perfMode.lastFakeDSClearFrame = frame;
+	}
+
 	// Skip VP compression in UpdateViewPort hook during UI pass
 	perfMode.postInterceptActive = true;
 


### PR DESCRIPTION
## Problem

Under PerfMode ("Render engine at upscaled resolution"), VR menus (inventory, **world map**, tween/transition) showed a persistent **controller/hand-shaped cutout** punched through the menu that only cleared on a full game restart — the long-standing "transparent hands block the UI" report.

## Root cause (RenderDoc-confirmed)

PerfMode's UI pass binds **`fakeDS`** as its depth-stencil — the displayRes throwaway depth that lets the enlarged RTs avoid the renderRes `kMAIN` DS mismatch. `fakeDS` was cleared **exactly once**, at `SetupResources`. UI-pass draws that depth-write (the VR controllers/hands) accumulated into it and were never re-cleared, so a prior gameplay frame's near geometry lingered.

The stereo menu compositor depth-tests **read-only** (`depthWrites=false`, `LessEqual`) against that same `fakeDS`. The controller sits closer than the menu panel, so the menu fails the depth test inside the controller silhouette → the cutout. It persisted until restart because only re-init re-cleared `fakeDS`.

RenderDoc evidence (frame in the world map / tween menu):
- Menu compositor draws (`DrawIndexedInstanced`, 2 instances = stereo) bind depth target `155824` = `fakeDS` (6144×3264, matches `displayEyeWidth*2 × displayEyeHeight`, unnamed raw `CreateTexture2D`).
- `depthEnable=true, depthWrites=false, LessEqual`.
- `GetUsage(fakeDS)` for the whole frame: 5 bindings, **all read-only depth tests, zero clears/writes** → the occluder came from an earlier frame.

## Fix

Clear `fakeDS` to far depth (1.0) + stencil 0 **once per frame** at the start of the UI pass (`UIPassDispatch_Hook`), restoring the intended throwaway-depth invariant every frame instead of only at init. Extracted the clear into `PerfMode::ClearFakeDS()` so init and the per-frame path share one implementation (DRY); frame-guarded so multiple UI dispatches in one frame don't wipe each other.

Fixes both the map and tween-menu cutouts (same root cause). Independent of upscaler (verified the mechanism with PerfMode+FSR under RenderDoc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed a rendering issue that was causing visual artifacts and inconsistencies in menus and user interface elements across frame transitions. The graphics system now properly resets its rendering data between frames, ensuring clean and consistent visual presentation of all UI components and menus throughout gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->