### PR TITLE
chore(sync): merge upstream/dev water + UI fixes (080afc0)

### DIFF
--- a/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
+++ b/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
@@ -38,8 +38,9 @@ namespace WaterEffects
 			float2 causticsUV1 = PanCausticsUV(causticsUV, 0.5 * 0.2, 1.0);
 			float2 causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.2, -0.5);
 
-			const float3 causticsHigh =
-				(causticsFade > 0.0) ? (min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0) : 1.0.xxx;
+			float3 causticsHigh = 1.0.xxx;
+			if (causticsFade > 0.0)
+				causticsHigh = min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0;
 
 			causticsUV *= 0.5;
 			dispersionOffset *= 0.5;
@@ -47,10 +48,11 @@ namespace WaterEffects
 			causticsUV1 = PanCausticsUV(causticsUV, 0.5 * 0.1, 1.0);
 			causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.1, -0.5);
 
-			const float3 causticsLow =
-				(causticsFade < 1.0) ? (min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0) : 1.0.xxx;
+			float3 causticsLow = 1.0.xxx;
+			if (causticsFade < 1.0)
+				causticsLow = min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0;
 
-			const float3 caustics = lerp(causticsLow, causticsHigh, causticsFade);
+			float3 caustics = lerp(causticsLow, causticsHigh, causticsFade);
 			return lerp(1.0.xxx, caustics, shoreFactorCaustics);
 		}
 

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -45,6 +45,32 @@ void SetupRenderTarget(RE::RENDER_TARGET target, D3D11_TEXTURE2D_DESC texDesc, D
 	uavDesc.Format = format;
 
 	auto& data = renderer->GetRuntimeData().renderTargets[target];
+
+	if (data.UAV) {
+		data.UAV->Release();
+		data.UAV = nullptr;
+	}
+	if (data.RTV) {
+		data.RTV->Release();
+		data.RTV = nullptr;
+	}
+	if (data.SRVCopy) {
+		data.SRVCopy->Release();
+		data.SRVCopy = nullptr;
+	}
+	if (data.SRV) {
+		data.SRV->Release();
+		data.SRV = nullptr;
+	}
+	if (data.textureCopy) {
+		data.textureCopy->Release();
+		data.textureCopy = nullptr;
+	}
+	if (data.texture) {
+		data.texture->Release();
+		data.texture = nullptr;
+	}
+
 	DX::ThrowIfFailed(device->CreateTexture2D(&texDesc, nullptr, &data.texture));
 
 	if (texDesc.BindFlags & D3D11_BIND_SHADER_RESOURCE)
@@ -110,6 +136,10 @@ void Deferred::SetupResources()
 		SetupRenderTarget(MASKS, texDesc, srvDesc, rtvDesc, uavDesc, DXGI_FORMAT_R11G11B10_FLOAT, D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE);
 		// Masks2 (vertexAO; fp16 to allow blending)
 		SetupRenderTarget(MASKS2, texDesc, srvDesc, rtvDesc, uavDesc, DXGI_FORMAT_R16_UNORM, D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE);
+
+		// TAA water history buffers need RGBA16: alpha stores premultiplied coverage for ISWaterBlend
+		SetupRenderTarget(RE::RENDER_TARGETS::kWATER_1, texDesc, srvDesc, rtvDesc, uavDesc, DXGI_FORMAT_R16G16B16A16_FLOAT, D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE);
+		SetupRenderTarget(RE::RENDER_TARGETS::kWATER_2, texDesc, srvDesc, rtvDesc, uavDesc, DXGI_FORMAT_R16G16B16A16_FLOAT, D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE);
 	}
 
 	{

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -599,28 +599,6 @@ namespace Hooks
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
-	struct CreateRenderTarget_Water1
-	{
-		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
-		{
-			auto properties = *a_properties;
-			properties.format.set(RE::BSGraphics::Format::kR16G16B16A16_FLOAT);
-			func(This, a_target, &properties);
-		}
-		static inline REL::Relocation<decltype(thunk)> func;
-	};
-
-	struct CreateRenderTarget_Water2
-	{
-		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
-		{
-			auto properties = *a_properties;
-			properties.format.set(RE::BSGraphics::Format::kR16G16B16A16_FLOAT);
-			func(This, a_target, &properties);
-		}
-		static inline REL::Relocation<decltype(thunk)> func;
-	};
-
 	struct BSShader__BeginTechnique_SetVertexShader
 	{
 		static void thunk(RE::BSGraphics::Renderer*, RE::BSGraphics::VertexShader* a_vertexShader)
@@ -920,9 +898,6 @@ namespace Hooks
 
 		stl::write_thunk_call<CreateRenderTarget_RefractionNormals>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x503, 0x502));
 		stl::write_thunk_call<CreateRenderTarget_UnderwaterMask>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0xB19, 0xB19));
-
-		stl::write_thunk_call<CreateRenderTarget_Water1>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0xF4F, 0xF51));
-		stl::write_thunk_call<CreateRenderTarget_Water2>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0xF65, 0xF67));
 
 		stl::write_thunk_call<CreateDepthStencil_PrecipitationMask>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0x1245, 0x123B));
 		stl::write_thunk_call<CreateCubemapRenderTarget_Reflections>(REL::RelocationID(100458, 107175).address() + REL::Relocate(0xA25, 0xA25));

--- a/src/Menu/OverlayRenderer.cpp
+++ b/src/Menu/OverlayRenderer.cpp
@@ -366,7 +366,8 @@ void OverlayRenderer::HandleABTesting()
 
 void OverlayRenderer::FinalizeImGuiFrame()
 {
-	if (auto* menu = Menu::GetSingleton()) {
+	if (auto* menu = Menu::GetSingleton();
+		menu && menu->GetSettings().Theme.UseCustomCursor && Util::CursorLoader::GetLoadedCount() > 0) {
 		Util::CursorLoader::DrawCustomCursor(*menu);
 	}
 


### PR DESCRIPTION
Cherry-picks the 3 upstream Community Shaders `dev` fixes landed since our v1.7.0-rc.1 sync (#121, `b74dedf96`). All are upstream `fix:` commits; history was clean/linear.

## Commits

- **#2488 — `fix(water-caustics): X4000 warnings`** (shader-only, `WaterCaustics.hlsli`). Silences X4000 "potentially uninitialized" warnings; keeps our `--max-warnings 0` shader-validation aligned with upstream. Clean cherry-pick.
- **#2487 — `fix(UI): CTD when alt-tabbing with no cursor png`** (`OverlayRenderer.cpp`, +1 guard). Only draws the custom cursor when `UseCustomCursor && CursorLoader::GetLoadedCount() > 0`. **Directly relevant to this fork** — we intentionally ship no cursor/logo png, so this prevents an alt-tab CTD that can hit us specifically. Auto-merged over the #127 i18n change in this file.
- **#2490 — `fix: fix water blending and vram texture leak`** (`Hooks.cpp` −, `Deferred.cpp` +). See keep-VR note below.

## #2490 — keep-VR conflict resolution (the only conflict)

It's a **moved hook**, resolved to preserve VR:

- Upstream removes the `CreateRenderTarget_Water1/Water2` creation-hooks (which force-set `kR16G16B16A16_FLOAT` at RT creation and leak a texture each time) and instead sets the format in `Deferred::SetupResources` via `SetupRenderTarget(RE::RENDER_TARGETS::kWATER_1/kWATER_2, …R16G16B16A16_FLOAT…)`, which now **releases the existing RTV/SRV/UAV/texture before recreating** (the VRAM-leak fix).
- The replacement addresses water RTs by **RT enum through `GetRuntimeData().renderTargets[]`** — CommonLib resolves the VR member offset internally — so SE/AE/VR are all covered with no raw addresses. The removed hooks' VR offsets (`0x12C2/0x12D8`) retire with the hooks (no orphaning).
- Resolution: dropped the two Water registrations (adopting the leak fix), **kept the fork's VR third-arg offsets** on the surviving Precip/Reflections hooks (`0x1917/0xCD2/0xD13`) and the fork's `perfMode.InstallCreateRTThunks()`. No orphaned `Water1/Water2` references remain.

## Verification

- `BuildRelease ALL` — green.
- `cpp_tests` — 307/307.
- `extract-i18n --check` — en.json in sync (no string changes).

## Pre-merge note

#2490 touches the VR water render targets. The addressing is now runtime-resolved (enum, not offsets), so it should be VR-correct by construction — but a quick **VR water smoke** is worth doing before merge given the fork is the VR maintainer.

## Release impact

Titled `fix:` (patch) — these are user-facing bug fixes (alt-tab CTD, VRAM leak, water blending) that warrant a changelog entry. Retitle to `chore(sync):` if you'd rather they not bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Water effects now include temporal anti-aliasing support for smoother, more stable visuals across frames

* **Bug Fixes**
  * Custom cursor display now properly respects menu theme and cursor load state
  * Improved graphics resource cleanup to prevent leaks and related rendering issues

* **Improvements**
  * Refactored water caustics computation for better performance and visual consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->