### PR TITLE
fix(shadows): deterministic cascade raster bind

### DIFF
--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -10,44 +10,47 @@ void ShadowmapRasterizerFix::Install()
 	// per-cascade swap lands in the slots the engine actually binds (fixes VR cascade flicker).
 	depthDim = globals::game::isVR ? 13 : 12;
 
-	numCascades = static_cast<uint>(Util::GetGameSettingValue<std::int32_t>("iNumSplits:Display", Settings.at("iNumSplits:Display")));
-
 	// Install the hook LAST, after all static state is set, so a render-thread RenderCascade
 	// can't enter thunk() with a null gRasterStates or an unset VR stride. The hooked function
 	// is called once per cascade to begin the updating and rendering process.
 	stl::write_thunk_call<BSShadowDirectionalLight_RenderShadowmaps_RenderCascade>(REL::RelocationID(101495, 108489).address() + REL::Relocate(0xC6, 0xC6, 0xF6));
 }
 
-void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCascade::thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, uint32_t flags)
+void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCascade::thunk(RE::BSShadowDirectionalLight* light, void* a_descriptor, void* arg2, uint32_t flags)
 {
-	static uint cascade = 0;
+	// The engine writes the cascade index into the shadowmap descriptor right before this call
+	// (SE/AE +0x58, VR +0x70); read it rather than counting calls so we can never desync from
+	// the engine's own loop (its cascade count is not capped at 3 like ours).
+	const auto index = *reinterpret_cast<const std::uint32_t*>(
+		static_cast<const std::byte*>(a_descriptor) + REL::Relocate(0x58, 0x58, 0x70));
+	const uint cascade = std::min(index, maxCascades - 1);
 
 	const auto bytes = static_cast<std::size_t>(StateCount()) * sizeof(RasterStatePtr);
 
-	static bool initialized = false;
-	if (!initialized) {
-		//Backup
-		if (cascade == 0) {
-			std::memcpy(backupGameRasterStates, gRasterStates, bytes);
-			numCascades = std::max(1u, std::min(numCascades, maxCascades));
-		}
-
-		//Clone from the pristine engine table (we overwrite gRasterStates per cascade below)
-		CloneRasterStates(backupGameRasterStates, cascade);
-
-		initialized = cascade == numCascades - 1;
+	static bool backedUp = false;
+	if (!backedUp) {
+		std::memcpy(backupGameRasterStates, gRasterStates, bytes);
+		backedUp = true;
 	}
 
-	//Emplace
+	static bool cloned[maxCascades] = {};
+	if (!cloned[cascade]) {
+		// Clone from the pristine engine table (we overwrite gRasterStates below)
+		CloneRasterStates(backupGameRasterStates, cascade);
+		cloned[cascade] = true;
+	}
+
+	// Emplace, and force a rebind: the engine issues RSSetState only when a raster dirty flag
+	// is set and caches by table index, so swapping table contents alone leaves the previous
+	// cascade's state bound until unrelated state traffic happens to dirty it (= flicker).
 	std::memcpy(gRasterStates, shadowmapRasterStates[cascade], bytes);
+	globals::game::stateUpdateFlags->set(RE::BSGraphics::ShaderFlags::DIRTY_RASTER_DEPTH_BIAS);
 
-	func(light, arg1, arg2, flags);
+	func(light, a_descriptor, arg2, flags);
 
-	//Restore
-	if (cascade == numCascades - 1)
-		std::memcpy(gRasterStates, backupGameRasterStates, bytes);
-
-	cascade = ++cascade < numCascades ? cascade : 0;
+	// Restore unconditionally so the biased table can never leak past this cascade.
+	std::memcpy(gRasterStates, backupGameRasterStates, bytes);
+	globals::game::stateUpdateFlags->set(RE::BSGraphics::ShaderFlags::DIRTY_RASTER_DEPTH_BIAS);
 }
 
 void ShadowmapRasterizerFix::GetUpdatedRasterDesc(D3D11_RASTERIZER_DESC& outputDesc, ShadowMapRasterizerDescriptor shadowmapDesc)

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -18,11 +18,10 @@ void ShadowmapRasterizerFix::Install()
 
 void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCascade::thunk(RE::BSShadowDirectionalLight* light, void* a_descriptor, void* arg2, uint32_t flags)
 {
-	// The engine writes the cascade index into the shadowmap descriptor right before this call
-	// (SE/AE +0x58, VR +0x70); read it rather than counting calls so we can never desync from
-	// the engine's own loop (its cascade count is not capped at 3 like ours).
-	const auto index = *reinterpret_cast<const std::uint32_t*>(
-		static_cast<const std::byte*>(a_descriptor) + REL::Relocate(0x58, 0x58, 0x70));
+	// The engine writes the cascade index into the shadowmap descriptor right before this call;
+	// read it rather than counting calls so we can never desync from the engine's own loop (its
+	// cascade count is not capped at 3 like ours).
+	const auto index = REL::RelocateMember<const std::uint32_t>(a_descriptor, 0x58, 0x70);
 	const uint cascade = std::min(index, maxCascades - 1);
 
 	const auto bytes = static_cast<std::size_t>(StateCount()) * sizeof(RasterStatePtr);

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.cpp
@@ -20,8 +20,10 @@ void ShadowmapRasterizerFix::BSShadowDirectionalLight_RenderShadowmaps_RenderCas
 {
 	// The engine writes the cascade index into the shadowmap descriptor right before this call;
 	// read it rather than counting calls so we can never desync from the engine's own loop (its
-	// cascade count is not capped at 3 like ours).
-	const auto index = REL::RelocateMember<const std::uint32_t>(a_descriptor, 0x58, 0x70);
+	// cascade count is not capped at 3 like ours). The descriptor layout differs per runtime.
+	const auto index = globals::game::isVR ?
+	                       static_cast<RE::BSShadowLight::ShadowmapDescriptorVR*>(a_descriptor)->shadowmapIndex :
+	                       static_cast<RE::BSShadowLight::ShadowmapDescriptor*>(a_descriptor)->shadowmapIndex;
 	const uint cascade = std::min(index, maxCascades - 1);
 
 	const auto bytes = static_cast<std::size_t>(StateCount()) * sizeof(RasterStatePtr);

--- a/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
+++ b/src/EngineFixes/ShadowmapCascadeRasterizerFix.h
@@ -25,7 +25,6 @@ struct ShadowmapRasterizerFix : EngineFix
 	static void CloneRasterStates(RasterStatePtr* inputArray, int cascade);
 
 	static constexpr uint maxCascades = 3;
-	static inline uint numCascades = 0;
 
 	static inline RasterStatePtr* gRasterStates = nullptr;
 	static inline RasterStatePtr backupGameRasterStates[kMaxStates] = {};
@@ -59,15 +58,7 @@ struct ShadowmapRasterizerFix : EngineFix
 
 	struct BSShadowDirectionalLight_RenderShadowmaps_RenderCascade
 	{
-		static void thunk(RE::BSShadowDirectionalLight* light, void* arg1, void* arg2, uint32_t flags);
+		static void thunk(RE::BSShadowDirectionalLight* light, void* a_descriptor, void* arg2, uint32_t flags);
 		static inline REL::Relocation<decltype(thunk)> func;
-	};
-
-	std::map<std::string, Util::GameSetting> Settings{
-		{ "iNumSplits:Display", { "Number of Shadow Map Cascades (INI) ",
-									"Controls the number of shadow map cascades used for directional lighting. "
-									"Higher values provide better shadow quality but use more GPU resources. "
-									"Maximum of 3 cascades supported. ",
-									REL::Relocate<uintptr_t>(0, 0, 0x1ed6350), 2, 1, 3 } },
 	};
 };


### PR DESCRIPTION
## Problem

Shadow flicker persisted after #118's stride fix. Re-derived the mechanism from all three binaries: the engine issues `RSSetState` **only when a `DIRTY_RASTER_*` flag is set** and caches rasterizer state **by table index**, while our fix swaps `gRasterStates` **content** without touching dirty flags. Whether a cascade's biased clone actually gets bound therefore depends on incidental state traffic inside `RenderCascade` (cull-mode flips from alpha-tested geometry, etc.). Which draws get which caster bias varies with culling results and draw order — nondeterministic frame to frame. In VR, head motion changes the dirty traffic every frame, so the effective bias oscillates at shadow boundaries → flicker. Flat has the same latent nondeterminism; a static camera just hides it.

Verified in SE 1.5.97, AE 1.6.1170, and VR 1.4.15:
- bind sites (`SetDirtyStates` + `UpdateRenderTargetsAndStates`) gate `RSSetState` on the raster dirty mask (AE: `flags & 0x1070`)
- the `DIRTY_RASTER_DEPTH_BIAS` side branch (viewport MaxDepth bias) recomputes from `cameraData` each time — idempotent, so forcing the flag is safe
- `BSShadowDirectionalLight::Render` is structurally identical on all three (hook call at SE/AE +0xC6, VR +0xF6); the engine's loop bound is the light's `shadowMapCount` (= `iNumSplits:Display`, **not** engine-capped at 3)

## Fix

- **Force a rebind**: set `DIRTY_RASTER_DEPTH_BIAS` after each per-cascade table emplace and after the restore, so the first draw of every cascade (and of the main scene afterward) deterministically binds from the just-written table.
- **Read the cascade index from the shadowmap descriptor** the engine passes to `RenderCascade` (SE/AE +0x58, VR +0x70) instead of a static call counter. Since the engine doesn't cap `iNumSplits` at 3, the counter could desync and leak the biased table into main-scene rendering (scene-wide z-bias flicker).
- **Restore unconditionally after every cascade call** — the biased table can no longer outlive a cascade under any cascade-count configuration. Drops `numCascades` and the `iNumSplits` read it existed for.

Keeps #118's runtime stride handling (12 flat / 13 VR) unchanged.

## Testing

- ALL build green (SE/AE/VR universal).
- SE 1.6.1170 smoke: launch → coc whiterun → 6 exterior cell transitions (cascade rebuilds), `SHADOWSPLITCOUNT=3`, no CTD, no crashlog, no errors in CommunityShaders.log.
- VR smoke (SteamVR null driver, no HMD): same 6-transition exterior run, no CTD, no crashlog, no errors.
- Visual A/B (flicker gone, exterior shadows present) to be confirmed on the CI prerelease before merge per the runtime test gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)