### PR TITLE
chore(profiler): unify GPU pass instrumentation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -407,6 +407,7 @@ Feature versions are automatically extracted from `.ini` files and compiled into
 -   **A/B Testing Framework**: Built-in performance comparison system for measuring feature impact
 -   **VR Performance**: VR has higher performance requirements; some features may need different settings
 -   **Tracy Profiler**: Optional build-time integration (`TRACY_SUPPORT`) for detailed performance analysis
+-   **New Pass Instrumentation**: Use `CS_GPU_PASS("Feature::Pass")` (RAII `ScopedGpuPass`) at every render pass entry point. Direct `TracyD3D11Zone` / `State::BeginPerfEvent` at new pass sites are discouraged — they bypass the profiler table and create name divergence. Raw/legacy zones are still appropriate for sub-dispatch annotations within a pass where profiler timer granularity is not needed.
 
 **Shader Performance Patterns**:
 

--- a/src/Deferred.cpp
+++ b/src/Deferred.cpp
@@ -2,6 +2,7 @@
 
 #include <DDSTextureLoader.h>
 
+#include "GpuPass.h"
 #include "ShaderCache.h"
 #include "State.h"
 #include "Utils/D3D.h"
@@ -188,8 +189,7 @@ void Deferred::SetupResources()
 
 void Deferred::ReflectionsPrepasses()
 {
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "Reflections Prepass");
+	CS_GPU_PASS("Deferred::ReflectionsPrepass");
 
 	auto shaderCache = globals::shaderCache;
 
@@ -211,8 +211,7 @@ void Deferred::ReflectionsPrepasses()
 
 void Deferred::EarlyPrepasses()
 {
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "Early Prepass");
+	CS_GPU_PASS("Deferred::EarlyPrepass");
 
 	auto shaderCache = globals::shaderCache;
 
@@ -234,8 +233,7 @@ void Deferred::EarlyPrepasses()
 
 void Deferred::PrepassPasses()
 {
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "Prepass");
+	CS_GPU_PASS("Deferred::Prepass");
 
 	auto shaderCache = globals::shaderCache;
 
@@ -324,8 +322,7 @@ void Deferred::StartDeferred()
 
 void Deferred::DeferredPasses()
 {
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "Deferred");
+	CS_GPU_PASS("Deferred::DeferredPasses");
 
 	auto renderer = globals::game::renderer;
 	auto context = globals::d3d::context;
@@ -383,7 +380,7 @@ void Deferred::DeferredPasses()
 
 	// Deferred Composite
 	{
-		TracyD3D11Zone(globals::state->tracyCtx, "Deferred Composite");
+		CS_GPU_PASS("Deferred::DeferredComposite");
 
 		ID3D11ShaderResourceView* srvs[16]{
 			specular.SRV,                                                                                    // t0  SpecularTexture
@@ -423,12 +420,7 @@ void Deferred::DeferredPasses()
 		auto shader = interior ? GetComputeMainCompositeInterior() : GetComputeMainComposite();
 		context->CSSetShader(shader, nullptr, 0);
 
-		{
-			TracyD3D11Zone(globals::state->tracyCtx, "Deferred Composite - Dispatch");
-			globals::profiler->BeginPass("DeferredComposite");
-			context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
-			globals::profiler->EndPass();
-		}
+		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
 
 		// Unbind mode texture SRV
 		ID3D11ShaderResourceView* nullSRV = nullptr;
@@ -447,9 +439,8 @@ void Deferred::DeferredPasses()
 	// VR: Stereo reprojection fills Eye 1 holes here (after DeferredComposite, before SSR/water/sky)
 	// so that ISReflectionsRayTracing sees valid pixels in both eyes.
 	if (globals::game::isVR) {
-		globals::profiler->BeginPass("VR::StereoBlend");
+		CS_GPU_PASS("VR::StereoBlend");
 		globals::features::vr.DrawStereoBlend();
-		globals::profiler->EndPass();
 	}
 
 	// Clear
@@ -633,8 +624,7 @@ void Deferred::SetShadowCascadeParameters(T& lightData, DirectionalShadowLightDa
 
 void Deferred::CopyShadowLightData()
 {
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "CopyShadowLightData");
+	CS_GPU_PASS("Deferred::CopyShadowLightData");
 
 	auto* shadowSceneNode = globals::game::smState->shadowSceneNode[0];
 	if (!shadowSceneNode)

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -3,6 +3,7 @@
 #include <DDSTextureLoader.h>
 #include <DirectXTex.h>
 
+#include "GpuPass.h"
 #include "I18n/I18n.h"
 #include "ShaderCache.h"
 #include "State.h"
@@ -352,9 +353,10 @@ void DynamicCubemaps::UpdateCubemapCapture(bool a_reflections)
 
 	context->CSSetShader(a_reflections ? (fakeReflections ? GetComputeShaderUpdateFakeReflections() : GetComputeShaderUpdateReflections()) : GetComputeShaderUpdate(), nullptr, 0);
 
-	globals::profiler->BeginPass(a_reflections ? "DynamicCubemaps::CaptureReflections" : "DynamicCubemaps::Capture");
-	context->Dispatch((uint32_t)std::ceil(envCaptureTexture->desc.Width / 8.0f), (uint32_t)std::ceil(envCaptureTexture->desc.Height / 8.0f), 6);
-	globals::profiler->EndPass();
+	{
+		CS_GPU_PASS(a_reflections ? "DynamicCubemaps::CaptureReflections" : "DynamicCubemaps::Capture");
+		context->Dispatch((uint32_t)std::ceil(envCaptureTexture->desc.Width / 8.0f), (uint32_t)std::ceil(envCaptureTexture->desc.Height / 8.0f), 6);
+	}
 
 	uavs[0] = nullptr;
 	uavs[1] = nullptr;
@@ -395,9 +397,10 @@ void DynamicCubemaps::Inferrence(bool a_reflections)
 
 	context->CSSetShader(a_reflections ? (fakeReflections ? GetComputeShaderInferrenceFakeReflections() : GetComputeShaderInferrenceReflections()) : GetComputeShaderInferrence(), nullptr, 0);
 
-	globals::profiler->BeginPass(a_reflections ? "DynamicCubemaps::InferReflections" : "DynamicCubemaps::Infer");
-	context->Dispatch((uint32_t)std::ceil(envCaptureTexture->desc.Width / 8.0f), (uint32_t)std::ceil(envCaptureTexture->desc.Height / 8.0f), 6);
-	globals::profiler->EndPass();
+	{
+		CS_GPU_PASS(a_reflections ? "DynamicCubemaps::InferReflections" : "DynamicCubemaps::Infer");
+		context->Dispatch((uint32_t)std::ceil(envCaptureTexture->desc.Width / 8.0f), (uint32_t)std::ceil(envCaptureTexture->desc.Height / 8.0f), 6);
+	}
 
 	srvs[0] = nullptr;
 	srvs[1] = nullptr;
@@ -440,19 +443,20 @@ void DynamicCubemaps::Irradiance(bool a_reflections)
 
 		std::uint32_t size = std::max(envTexture->desc.Width, envTexture->desc.Height) / 2;
 
-		globals::profiler->BeginPass(a_reflections ? "DynamicCubemaps::IrradianceReflections" : "DynamicCubemaps::Irradiance");
-		for (std::uint32_t level = 1; level < MIPLEVELS; level++, size /= 2) {
-			const UINT numGroups = (UINT)std::max(1u, size / 8);
+		{
+			CS_GPU_PASS(a_reflections ? "DynamicCubemaps::IrradianceReflections" : "DynamicCubemaps::Irradiance");
+			for (std::uint32_t level = 1; level < MIPLEVELS; level++, size /= 2) {
+				const UINT numGroups = (UINT)std::max(1u, size / 8);
 
-			const SpecularMapFilterSettingsCB spmapConstants = { level * delta_roughness };
-			spmapCB->Update(spmapConstants);
+				const SpecularMapFilterSettingsCB spmapConstants = { level * delta_roughness };
+				spmapCB->Update(spmapConstants);
 
-			auto uav = a_reflections ? uavReflectionsArray[level - 1] : uavArray[level - 1];
+				auto uav = a_reflections ? uavReflectionsArray[level - 1] : uavArray[level - 1];
 
-			context->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
-			context->Dispatch(numGroups, numGroups, 6);
+				context->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
+				context->Dispatch(numGroups, numGroups, 6);
+			}
 		}
-		globals::profiler->EndPass();
 	}
 
 	ID3D11ShaderResourceView* nullSRV = { nullptr };
@@ -487,26 +491,27 @@ void DynamicCubemaps::CompressToBC6H(bool a_reflections)
 
 	std::uint32_t mipDim = std::max(envTexture->desc.Width, envTexture->desc.Height);
 
-	globals::profiler->BeginPass(a_reflections ? "DynamicCubemaps::BC6HReflections" : "DynamicCubemaps::BC6H");
-	for (std::uint32_t level = 0; level < bc6hMipLevels; ++level) {
-		std::uint32_t srcWidth = std::max(1u, mipDim >> level);
-		std::uint32_t srcHeight = std::max(1u, mipDim >> level);
-		std::uint32_t blocksX = std::max(1u, srcWidth / 4);
-		std::uint32_t blocksY = std::max(1u, srcHeight / 4);
+	{
+		CS_GPU_PASS(a_reflections ? "DynamicCubemaps::BC6HReflections" : "DynamicCubemaps::BC6H");
+		for (std::uint32_t level = 0; level < bc6hMipLevels; ++level) {
+			std::uint32_t srcWidth = std::max(1u, mipDim >> level);
+			std::uint32_t srcHeight = std::max(1u, mipDim >> level);
+			std::uint32_t blocksX = std::max(1u, srcWidth / 4);
+			std::uint32_t blocksY = std::max(1u, srcHeight / 4);
 
-		BC6HEncodeCB cbData{};
-		cbData.TextureSizeInBlocksX = blocksX;
-		cbData.TextureSizeInBlocksY = blocksY;
-		cbData.MipLevel = level;
-		bc6hEncodeCB->Update(cbData);
+			BC6HEncodeCB cbData{};
+			cbData.TextureSizeInBlocksX = blocksX;
+			cbData.TextureSizeInBlocksY = blocksY;
+			cbData.MipLevel = level;
+			bc6hEncodeCB->Update(cbData);
 
-		context->CSSetUnorderedAccessViews(0, 1, &bc6hScratchUAVs[level], nullptr);
+			context->CSSetUnorderedAccessViews(0, 1, &bc6hScratchUAVs[level], nullptr);
 
-		std::uint32_t dispatchX = std::max(1u, (blocksX + 7) / 8);
-		std::uint32_t dispatchY = std::max(1u, (blocksY + 7) / 8);
-		context->Dispatch(dispatchX, dispatchY, 6);
+			std::uint32_t dispatchX = std::max(1u, (blocksX + 7) / 8);
+			std::uint32_t dispatchY = std::max(1u, (blocksY + 7) / 8);
+			context->Dispatch(dispatchX, dispatchY, 6);
+		}
 	}
-	globals::profiler->EndPass();
 
 	{
 		ID3D11ShaderResourceView* nullSRV = nullptr;
@@ -528,7 +533,7 @@ void DynamicCubemaps::CompressToBC6H(bool a_reflections)
 void DynamicCubemaps::UpdateCubemap()
 {
 	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "Cubemap Update");
+	CS_GPU_PASS("DynamicCubemaps::UpdateCubemap");
 
 	// Reset capture when game time jumps (wait menu, timescale changes, console commands)
 	if (auto calendar = globals::game::calendar) {

--- a/src/Features/GrassCollision.cpp
+++ b/src/Features/GrassCollision.cpp
@@ -1,8 +1,8 @@
 #include "GrassCollision.h"
 
 #include "Globals.h"
+#include "GpuPass.h"
 #include "I18n/I18n.h"
-#include "State.h"
 #include "Utils/ActorUtils.h"
 #include "Utils/D3D.h"
 
@@ -400,9 +400,8 @@ void GrassCollision::UpdateCollisionTexture()
 		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
 
 		context->CSSetShader(GetCollisionUpdateCS(), nullptr, 0);
-		globals::profiler->BeginPass("GrassCollision::CollisionUpdate");
+		CS_GPU_PASS("GrassCollision::CollisionUpdate");
 		context->Dispatch(512 / 8, 512 / 8, 1);
-		globals::profiler->EndPass();
 	}
 
 	context->CSSetShader(nullptr, nullptr, 0);

--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -1178,7 +1178,6 @@ void HDRDisplay::ApplyHDR()
 	auto& upscaling = globals::features::upscaling;
 
 	auto context = globals::d3d::context;
-	auto state = globals::state;
 	auto renderer = globals::game::renderer;
 
 	// Update constant buffer before applying HDR
@@ -1491,7 +1490,6 @@ void HDRDisplay::ScaleUIBrightnessForFG()
 	CS_GPU_PASS("HDRDisplay::UIBrightness");
 
 	auto context = globals::d3d::context;
-	auto state = globals::state;
 
 	// Update constant buffer with current settings
 	UpdateHDRData();

--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -1,4 +1,5 @@
 #include "HDRDisplay.h"
+#include "GpuPass.h"
 
 #include "PCH.h"
 
@@ -1167,13 +1168,12 @@ void HDRDisplay::ClearUIBuffer()
 
 void HDRDisplay::ApplyHDR()
 {
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "HDR Processing");
-
 	std::lock_guard<std::mutex> lock(settingsMutex);
 
 	if (!hdrDataCB || !hdrTexture || !outputTexture)
 		return;
+
+	CS_GPU_PASS("HDRDisplay::HDROutput");
 
 	auto& upscaling = globals::features::upscaling;
 
@@ -1183,8 +1183,6 @@ void HDRDisplay::ApplyHDR()
 
 	// Update constant buffer before applying HDR
 	UpdateHDRData();
-
-	state->BeginPerfEvent("HDR Processing");
 
 	{
 		auto dispatchCount = Util::GetScreenDispatchCount(false);
@@ -1256,14 +1254,11 @@ void HDRDisplay::ApplyHDR()
 				}
 			}
 
-			state->EndPerfEvent();
 			return;
 		}
 
 		context->CSSetShader(computeShader, nullptr, 0);
-		globals::profiler->BeginPass("HDRDisplay::HDROutput");
 		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
-		globals::profiler->EndPass();
 
 		views[0] = nullptr;
 		views[1] = nullptr;
@@ -1297,8 +1292,6 @@ void HDRDisplay::ApplyHDR()
 			backBuffer->Release();
 		}
 	}
-
-	state->EndPerfEvent();
 }
 
 void HDRDisplay::DestroyResources()
@@ -1484,9 +1477,6 @@ ID3D11ComputeShader* HDRDisplay::GetUIBrightnessCS()
 
 void HDRDisplay::ScaleUIBrightnessForFG()
 {
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "UI Brightness Scale");
-
 	auto& upscaling = globals::features::upscaling;
 	// FG merges PQ UI from this pass; paused UI stays gamma for HDROutput.
 	if (!IsFGCompositingThisFrame())
@@ -1498,10 +1488,10 @@ void HDRDisplay::ScaleUIBrightnessForFG()
 	if (!hdrDataCB || !upscaling.dx12SwapChain.uiBufferWrapped || !upscaling.dx12SwapChain.uiBufferWrapped->uav)
 		return;
 
+	CS_GPU_PASS("HDRDisplay::UIBrightness");
+
 	auto context = globals::d3d::context;
 	auto state = globals::state;
-
-	state->BeginPerfEvent("UI Brightness Scale");
 
 	// Update constant buffer with current settings
 	UpdateHDRData();
@@ -1517,9 +1507,7 @@ void HDRDisplay::ScaleUIBrightnessForFG()
 	auto computeShader = GetUIBrightnessCS();
 	if (computeShader) {
 		context->CSSetShader(computeShader, nullptr, 0);
-		globals::profiler->BeginPass("HDRDisplay::UIBrightness");
 		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
-		globals::profiler->EndPass();
 	}
 
 	// Cleanup
@@ -1528,8 +1516,6 @@ void HDRDisplay::ScaleUIBrightnessForFG()
 	cbs[0] = nullptr;
 	context->CSSetConstantBuffers(0, 1, cbs);
 	context->CSSetShader(nullptr, nullptr, 0);
-
-	state->EndPerfEvent();
 }
 
 float HDRDisplay::GetDisplayMaxLuminance() const

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -7,6 +7,7 @@
 #include "WeatherVariableRegistry.h"
 
 #include "../I18n/I18n.h"
+#include "GpuPass.h"
 #include <DDSTextureLoader.h>
 #include <DirectXTex.h>
 
@@ -236,9 +237,10 @@ void IBL::Prepass()
 		context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
 		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
 		context->CSSetShader(GetDiffuseIBLCS(), nullptr, 0);
-		globals::profiler->BeginPass("IBL::EnvDiffuseIBL");
-		context->Dispatch(1, 1, 1);
-		globals::profiler->EndPass();
+		{
+			CS_GPU_PASS("IBL::EnvDiffuseIBL");
+			context->Dispatch(1, 1, 1);
+		}
 	} else {
 		// Still need to set sampler and shader for sky IBL dispatch below
 		context->CSSetSamplers(0, (uint)samplers.size(), samplers.data());
@@ -254,9 +256,10 @@ void IBL::Prepass()
 
 		context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
 		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
-		globals::profiler->BeginPass("IBL::SkyDiffuseIBL");
-		context->Dispatch(1, 1, 1);
-		globals::profiler->EndPass();
+		{
+			CS_GPU_PASS("IBL::SkyDiffuseIBL");
+			context->Dispatch(1, 1, 1);
+		}
 	}
 
 	// Reset

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -3,6 +3,7 @@
 #include "Features/LightLimitFix/SettingsSanitize.h"
 #include "Features/LightLimitFix/ShadowCasterMath.h"
 #include "Globals.h"
+#include "GpuPass.h"
 #include "I18n/I18n.h"
 #include "InverseSquareLighting.h"
 #include "LinearLighting.h"
@@ -811,13 +812,10 @@ void LightLimitFix::ApplyJsonPlacedLightIntensityScale(
 
 void LightLimitFix::Prepass()
 {
+	CS_GPU_PASS("LightLimitFix::Prepass");
+
 	auto context = globals::d3d::context;
 
-	auto state = globals::state;
-
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "LightLimitFix Prepass");
-	state->BeginPerfEvent("LightLimitFix Prepass");
 	ShadowCasterManager::Update(settings.ShadowSettings, globals::game::smState->shadowSceneNode[0], nullptr);
 	UpdateLights();
 
@@ -826,8 +824,6 @@ void LightLimitFix::Prepass()
 	views[1] = lightIndexList->srv.get();
 	views[2] = lightGrid->srv.get();
 	context->PSSetShaderResources(35, ARRAYSIZE(views), views);
-
-	state->EndPerfEvent();
 }
 
 bool LightLimitFix::IsValidLight(RE::BSLight* a_light)
@@ -1179,7 +1175,7 @@ void LightLimitFix::UpdateStructure()
 	clusterSize[2] = 32;
 
 	{
-		TracyD3D11Zone(globals::state->tracyCtx, "LightLimitFix Cluster Build");
+		CS_GPU_PASS("LightLimitFix::ClusterBuild");
 		LightBuildingCB updateData{};
 		updateData.LightsNear = lightsNear;
 		updateData.LightsFar = lightsFar;
@@ -1194,16 +1190,14 @@ void LightLimitFix::UpdateStructure()
 		context->CSSetUnorderedAccessViews(0, 1, &clusters_uav, nullptr);
 
 		context->CSSetShader(clusterBuildingCS, nullptr, 0);
-		globals::profiler->BeginPass("LightLimitFix::ClusterBuild");
 		context->Dispatch(clusterSize[0], clusterSize[1], clusterSize[2]);
-		globals::profiler->EndPass();
 
 		ID3D11UnorderedAccessView* null_uav = nullptr;
 		context->CSSetUnorderedAccessViews(0, 1, &null_uav, nullptr);
 	}
 
 	{
-		TracyD3D11Zone(globals::state->tracyCtx, "LightLimitFix Cluster Cull");
+		CS_GPU_PASS("LightLimitFix::ClusterCull");
 		LightCullingCB updateData{};
 		updateData.LightCount = lightCount;
 		std::copy(clusterSize, clusterSize + 3, updateData.ClusterSize);
@@ -1223,9 +1217,7 @@ void LightLimitFix::UpdateStructure()
 		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
 
 		context->CSSetShader(clusterCullingCS, nullptr, 0);
-		globals::profiler->BeginPass("LightLimitFix::ClusterCull");
 		context->Dispatch((clusterSize[0] + 15) / 16, (clusterSize[1] + 15) / 16, (clusterSize[2] + 3) / 4);
-		globals::profiler->EndPass();
 	}
 
 	context->CSSetShader(nullptr, nullptr, 0);

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -9,6 +9,7 @@
 #include "ShadowCasterManager.h"
 #include "../../Deferred.h"
 #include "../../Globals.h"
+#include "../../GpuPass.h"
 #include "../../State.h"
 #include "../../Utils/Game.h"
 #include "../../Utils/UI.h"
@@ -2875,11 +2876,7 @@ namespace ShadowCasterManager
 		}
 
 		ZoneScopedN("SCM::RenderScheduledShadowLights");
-		auto* state = globals::state;
-		state->BeginPerfEvent("SCM::RenderScheduledShadowLights");
-#ifdef TRACY_ENABLE
-		TracyD3D11Zone(state->tracyCtx, "SCM::RenderScheduledShadowLights");
-#endif
+		CS_GPU_PASS("SCM::RenderScheduledShadowLights");
 
 		s_budget.Begin(1);
 
@@ -2893,9 +2890,7 @@ namespace ShadowCasterManager
 		// and exterior scenes render with no sun shadow.
 		if (s_lights.Sun && s_lights.Lights[0].Light) {
 			ZoneNamedN(zSun, "SCM::Render::Sun", true);
-#ifdef TRACY_ENABLE
-			TracyD3D11Zone(state->tracyCtx, "SCM::Render::Sun");
-#endif
+			CS_GPU_PASS("SCM::Render::Sun");
 			s_budget.BeginLight(s_lights.Lights[0].Light, 1);
 			s_lights.Lights[0].Light->Render(tmp);
 			s_budget.EndLight(s_lights.Lights[0].Light, 1);
@@ -2906,9 +2901,7 @@ namespace ShadowCasterManager
 		// highest point-light slot when Sun=true.
 		{
 			ZoneNamedN(zPoint, "SCM::Render::PointLights", true);
-#ifdef TRACY_ENABLE
-			TracyD3D11Zone(state->tracyCtx, "SCM::Render::PointLights");
-#endif
+			CS_GPU_PASS("SCM::Render::PointLights");
 			for (int i = s_lights.PointLightFirst(); i < s_lights.PointLightEnd(s_settings.ShadowLightCount); i++) {
 				auto& e = s_lights.Lights[i];
 				if (!e.Light || !e.RedrawFrame)
@@ -2918,8 +2911,6 @@ namespace ShadowCasterManager
 				s_budget.EndLight(e.Light, 1);
 			}
 		}
-
-		state->EndPerfEvent();
 
 		if (globals::game::isVR)
 			*globals::game::drawStereo = savedStereo;

--- a/src/Features/LightLimitFix/ShadowRenderer.cpp
+++ b/src/Features/LightLimitFix/ShadowRenderer.cpp
@@ -3,6 +3,7 @@
 
 #include "../LightLimitFix.h"
 #include "Deferred.h"
+#include "GpuPass.h"
 #include "I18n/I18n.h"
 #include "Menu/ThemeManager.h"
 #include "State.h"
@@ -39,18 +40,13 @@ static bool SetShadowParameters(T& lightData, Deferred::ShadowLightData& sd)
 
 void LightLimitFix::EarlyPrepass()
 {
-	auto state = globals::state;
-	state->BeginPerfEvent("LLF CopyShadowLightData");
 	CopyShadowLightData();
-	state->EndPerfEvent();
 }
 
 void LightLimitFix::CopyShadowLightData()
 {
 	ZoneScoped;
-#ifdef TRACY_ENABLE
-	TracyD3D11Zone(globals::state->tracyCtx, "LLF CopyShadowLightData");
-#endif
+	CS_GPU_PASS("LightLimitFix::CopyShadowLightData");
 
 	uint32_t slots = ShadowCasterManager::GetInstalledSlotCount();
 	if (slots == 0) {

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -786,194 +786,195 @@ void ScreenSpaceGI::DrawSSGI()
 	}
 
 	// fetch radiance and disocclusion
-	CS_GPU_PASS("ScreenSpaceGI::RadianceDisocc");
-
-	resetViews();
-	srvs.at(0) = rts[deferred->forwardRenderTargets[0]].SRV;
-	srvs.at(1) = texWorkingDepth->srv.get();
-	srvs.at(2) = rts[NORMALROUGHNESS].SRV;
-	srvs.at(3) = texPrevGeo->srv.get();
-	srvs.at(4) = rts[RE::RENDER_TARGET::kMOTION_VECTOR].SRV;
-	srvs.at(5) = texAccumFrames[lastFrameAccumTexIdx]->srv.get();
-	srvs.at(6) = texAo[inputAoTexIdx]->srv.get();
-	srvs.at(7) = texIlY[inputGITexIdx]->srv.get();
-	srvs.at(8) = texIlCoCg[inputGITexIdx]->srv.get();
-	srvs.at(9) = texGiSpecular[inputAoTexIdx]->srv.get();
-	srvs.at(10) = nullptr;
-
-	uavs.at(0) = texRadianceTemp->uav.get();
-	uavs.at(1) = texAccumFrames[!lastFrameAccumTexIdx]->uav.get();
-	uavs.at(2) = texAo[!inputAoTexIdx]->uav.get();
-	uavs.at(3) = texIlY[!inputGITexIdx]->uav.get();
-	uavs.at(4) = texIlCoCg[!inputGITexIdx]->uav.get();
-	uavs.at(5) = texGiSpecular[!inputAoTexIdx]->uav.get();
-
-	context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
-	context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
-	context->CSSetShader(radianceDisoccCompute.get(), nullptr, 0);
-	context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
-
-	// Prefilter radiance texture instead of using GenerateMips for proper dynamic resolution handling.
-	// radianceDisocc wrote mip 0 directly to texRadianceTemp above, so we can bind it
-	// as SRV input here without an intermediate CopySubresourceRegion.
 	{
-		CS_GPU_PASS("ScreenSpaceGI::PrefilterRadiance");
+		CS_GPU_PASS("ScreenSpaceGI::RadianceDisocc");
 
 		resetViews();
-		srvs.at(0) = texRadianceTemp->srv.get();
-		uavs.at(0) = uavRadiance[0].get();  // Mip 0
-		uavs.at(1) = uavRadiance[1].get();  // Mip 1
-		uavs.at(2) = uavRadiance[2].get();  // Mip 2
-		uavs.at(3) = uavRadiance[3].get();  // Mip 3
-		uavs.at(4) = uavRadiance[4].get();  // Mip 4
+		srvs.at(0) = rts[deferred->forwardRenderTargets[0]].SRV;
+		srvs.at(1) = texWorkingDepth->srv.get();
+		srvs.at(2) = rts[NORMALROUGHNESS].SRV;
+		srvs.at(3) = texPrevGeo->srv.get();
+		srvs.at(4) = rts[RE::RENDER_TARGET::kMOTION_VECTOR].SRV;
+		srvs.at(5) = texAccumFrames[lastFrameAccumTexIdx]->srv.get();
+		srvs.at(6) = texAo[inputAoTexIdx]->srv.get();
+		srvs.at(7) = texIlY[inputGITexIdx]->srv.get();
+		srvs.at(8) = texIlCoCg[inputGITexIdx]->srv.get();
+		srvs.at(9) = texGiSpecular[inputAoTexIdx]->srv.get();
+		srvs.at(10) = nullptr;
+
+		uavs.at(0) = texRadianceTemp->uav.get();
+		uavs.at(1) = texAccumFrames[!lastFrameAccumTexIdx]->uav.get();
+		uavs.at(2) = texAo[!inputAoTexIdx]->uav.get();
+		uavs.at(3) = texIlY[!inputGITexIdx]->uav.get();
+		uavs.at(4) = texIlCoCg[!inputGITexIdx]->uav.get();
+		uavs.at(5) = texGiSpecular[!inputAoTexIdx]->uav.get();
+
+		context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
+		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
+		context->CSSetShader(radianceDisoccCompute.get(), nullptr, 0);
+		context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
+
+		// Prefilter radiance texture instead of using GenerateMips for proper dynamic resolution handling.
+		// radianceDisocc wrote mip 0 directly to texRadianceTemp above, so we can bind it
+		// as SRV input here without an intermediate CopySubresourceRegion.
+		{
+			CS_GPU_PASS("ScreenSpaceGI::PrefilterRadiance");
+
+			resetViews();
+			srvs.at(0) = texRadianceTemp->srv.get();
+			uavs.at(0) = uavRadiance[0].get();  // Mip 0
+			uavs.at(1) = uavRadiance[1].get();  // Mip 1
+			uavs.at(2) = uavRadiance[2].get();  // Mip 2
+			uavs.at(3) = uavRadiance[3].get();  // Mip 3
+			uavs.at(4) = uavRadiance[4].get();  // Mip 4
+
+			context->CSSetShaderResources(0, 1, srvs.data());
+			context->CSSetUnorderedAccessViews(0, 5, uavs.data(), nullptr);
+			context->CSSetShader(prefilterRadianceCompute.get(), nullptr, 0);
+			context->Dispatch((internalRes[0] + 15u) >> 4, (internalRes[1] + 15u) >> 4, 1);
+		}
+
+		inputAoTexIdx = !inputAoTexIdx;
+		inputGITexIdx = !inputGITexIdx;
+		lastFrameAccumTexIdx = !lastFrameAccumTexIdx;
+	}
+
+	// Prefilter normals
+	{
+		CS_GPU_PASS("ScreenSpaceGI::PrefilterNormals");
+
+		resetViews();
+		srvs.at(0) = rts[NORMALROUGHNESS].SRV;
+		uavs.at(0) = uavNormal[0].get();
+		uavs.at(1) = uavNormal[1].get();
+		uavs.at(2) = uavNormal[2].get();
+		uavs.at(3) = uavNormal[3].get();
+		uavs.at(4) = uavNormal[4].get();
 
 		context->CSSetShaderResources(0, 1, srvs.data());
 		context->CSSetUnorderedAccessViews(0, 5, uavs.data(), nullptr);
-		context->CSSetShader(prefilterRadianceCompute.get(), nullptr, 0);
+		context->CSSetShader(prefilterNormalCompute.get(), nullptr, 0);
 		context->Dispatch((internalRes[0] + 15u) >> 4, (internalRes[1] + 15u) >> 4, 1);
 	}
 
-	inputAoTexIdx = !inputAoTexIdx;
-	inputGITexIdx = !inputGITexIdx;
-	lastFrameAccumTexIdx = !lastFrameAccumTexIdx;
-}
+	// GI
+	{
+		CS_GPU_PASS("ScreenSpaceGI::GI");
 
-// Prefilter normals
-{
-	CS_GPU_PASS("ScreenSpaceGI::PrefilterNormals");
+		resetViews();
+		srvs.at(0) = texWorkingDepth->srv.get();
+		srvs.at(1) = rts[NORMALROUGHNESS].SRV;
+		srvs.at(2) = texRadiance->srv.get();
+		srvs.at(3) = texNoise->srv.get();
+		srvs.at(4) = texAccumFrames[lastFrameAccumTexIdx]->srv.get();
+		srvs.at(5) = texIlY[inputGITexIdx]->srv.get();
+		srvs.at(6) = texIlCoCg[inputGITexIdx]->srv.get();
+		srvs.at(7) = texGiSpecular[inputAoTexIdx]->srv.get();
+		srvs.at(8) = texNormal->srv.get();
 
+		uavs.at(0) = texAo[!inputAoTexIdx]->uav.get();
+		uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
+		uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
+		uavs.at(3) = texGiSpecular[!inputAoTexIdx]->uav.get();
+		uavs.at(4) = texPrevGeo->uav.get();
+
+		context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
+		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
+		context->CSSetShader(giCompute.get(), nullptr, 0);
+		context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
+
+		inputAoTexIdx = !inputAoTexIdx;
+		inputGITexIdx = !inputGITexIdx;
+		lastFrameGITexIdx = inputGITexIdx;
+		lastFrameAoTexIdx = inputAoTexIdx;
+	}
+
+	// blur
+	if (settings.EnableBlur) {
+		CS_GPU_PASS("ScreenSpaceGI::Blur");
+
+		resetViews();
+		srvs.at(0) = texWorkingDepth->srv.get();
+		srvs.at(1) = rts[NORMALROUGHNESS].SRV;
+		srvs.at(2) = texAccumFrames[lastFrameAccumTexIdx]->srv.get();
+		srvs.at(3) = texIlY[inputGITexIdx]->srv.get();
+		srvs.at(4) = texIlCoCg[inputGITexIdx]->srv.get();
+
+		uavs.at(0) = texAccumFrames[!lastFrameAccumTexIdx]->uav.get();
+		uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
+		uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
+
+		context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
+		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
+		context->CSSetShader(blurCompute.get(), nullptr, 0);
+		context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
+
+		inputGITexIdx = !inputGITexIdx;
+		lastFrameGITexIdx = inputGITexIdx;
+		lastFrameAccumTexIdx = !lastFrameAccumTexIdx;
+	}
+
+	// VR stereo sync: bilateral blend of SSGI buffers between eyes
+	// Shi, Billeter, Eisemann 2022, "Stereo-consistent screen-space ambient occlusion"
+	if (globals::game::isVR && stereoSyncCompute) {
+		CS_GPU_PASS("ScreenSpaceGI::StereoSync");
+
+		resetViews();
+		srvs.at(0) = texWorkingDepth->srv.get();
+		srvs.at(1) = texAo[inputAoTexIdx]->srv.get();
+		srvs.at(2) = texIlY[inputGITexIdx]->srv.get();
+		srvs.at(3) = texIlCoCg[inputGITexIdx]->srv.get();
+
+		uavs.at(0) = texAo[!inputAoTexIdx]->uav.get();
+		uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
+		uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
+
+		context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
+		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
+		context->CSSetShader(stereoSyncCompute.get(), nullptr, 0);
+		context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
+
+		inputAoTexIdx = !inputAoTexIdx;
+		inputGITexIdx = !inputGITexIdx;
+	}
+
+	// upsample
+	if (settings.ResolutionMode != 0) {
+		CS_GPU_PASS("ScreenSpaceGI::Upsample");
+
+		resetViews();
+		srvs.at(0) = texWorkingDepth->srv.get();
+		srvs.at(1) = texAo[inputAoTexIdx]->srv.get();
+		srvs.at(2) = texIlY[inputGITexIdx]->srv.get();
+		srvs.at(3) = texIlCoCg[inputGITexIdx]->srv.get();
+		srvs.at(4) = texGiSpecular[inputAoTexIdx]->srv.get();
+
+		uavs.at(0) = texAo[!inputAoTexIdx]->uav.get();
+		uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
+		uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
+		uavs.at(3) = texGiSpecular[!inputAoTexIdx]->uav.get();
+
+		context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
+		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
+		context->CSSetShader(upsampleCompute.get(), nullptr, 0);
+		context->Dispatch((resolution[0] + 7u) >> 3, (resolution[1] + 7u) >> 3, 1);
+
+		inputAoTexIdx = !inputAoTexIdx;
+		inputGITexIdx = !inputGITexIdx;
+	}
+
+	outputAoIdx = inputAoTexIdx;
+	outputIlIdx = inputGITexIdx;
+
+	// cleanup
 	resetViews();
-	srvs.at(0) = rts[NORMALROUGHNESS].SRV;
-	uavs.at(0) = uavNormal[0].get();
-	uavs.at(1) = uavNormal[1].get();
-	uavs.at(2) = uavNormal[2].get();
-	uavs.at(3) = uavNormal[3].get();
-	uavs.at(4) = uavNormal[4].get();
 
-	context->CSSetShaderResources(0, 1, srvs.data());
-	context->CSSetUnorderedAccessViews(0, 5, uavs.data(), nullptr);
-	context->CSSetShader(prefilterNormalCompute.get(), nullptr, 0);
-	context->Dispatch((internalRes[0] + 15u) >> 4, (internalRes[1] + 15u) >> 4, 1);
-}
+	samplers.fill(nullptr);
+	cb = nullptr;
 
-// GI
-{
-	CS_GPU_PASS("ScreenSpaceGI::GI");
-
-	resetViews();
-	srvs.at(0) = texWorkingDepth->srv.get();
-	srvs.at(1) = rts[NORMALROUGHNESS].SRV;
-	srvs.at(2) = texRadiance->srv.get();
-	srvs.at(3) = texNoise->srv.get();
-	srvs.at(4) = texAccumFrames[lastFrameAccumTexIdx]->srv.get();
-	srvs.at(5) = texIlY[inputGITexIdx]->srv.get();
-	srvs.at(6) = texIlCoCg[inputGITexIdx]->srv.get();
-	srvs.at(7) = texGiSpecular[inputAoTexIdx]->srv.get();
-	srvs.at(8) = texNormal->srv.get();
-
-	uavs.at(0) = texAo[!inputAoTexIdx]->uav.get();
-	uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
-	uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
-	uavs.at(3) = texGiSpecular[!inputAoTexIdx]->uav.get();
-	uavs.at(4) = texPrevGeo->uav.get();
-
-	context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
-	context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
-	context->CSSetShader(giCompute.get(), nullptr, 0);
-	context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
-
-	inputAoTexIdx = !inputAoTexIdx;
-	inputGITexIdx = !inputGITexIdx;
-	lastFrameGITexIdx = inputGITexIdx;
-	lastFrameAoTexIdx = inputAoTexIdx;
-}
-
-// blur
-if (settings.EnableBlur) {
-	CS_GPU_PASS("ScreenSpaceGI::Blur");
-
-	resetViews();
-	srvs.at(0) = texWorkingDepth->srv.get();
-	srvs.at(1) = rts[NORMALROUGHNESS].SRV;
-	srvs.at(2) = texAccumFrames[lastFrameAccumTexIdx]->srv.get();
-	srvs.at(3) = texIlY[inputGITexIdx]->srv.get();
-	srvs.at(4) = texIlCoCg[inputGITexIdx]->srv.get();
-
-	uavs.at(0) = texAccumFrames[!lastFrameAccumTexIdx]->uav.get();
-	uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
-	uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
-
-	context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
-	context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
-	context->CSSetShader(blurCompute.get(), nullptr, 0);
-	context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
-
-	inputGITexIdx = !inputGITexIdx;
-	lastFrameGITexIdx = inputGITexIdx;
-	lastFrameAccumTexIdx = !lastFrameAccumTexIdx;
-}
-
-// VR stereo sync: bilateral blend of SSGI buffers between eyes
-// Shi, Billeter, Eisemann 2022, "Stereo-consistent screen-space ambient occlusion"
-if (globals::game::isVR && stereoSyncCompute) {
-	CS_GPU_PASS("ScreenSpaceGI::StereoSync");
-
-	resetViews();
-	srvs.at(0) = texWorkingDepth->srv.get();
-	srvs.at(1) = texAo[inputAoTexIdx]->srv.get();
-	srvs.at(2) = texIlY[inputGITexIdx]->srv.get();
-	srvs.at(3) = texIlCoCg[inputGITexIdx]->srv.get();
-
-	uavs.at(0) = texAo[!inputAoTexIdx]->uav.get();
-	uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
-	uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
-
-	context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
-	context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
-	context->CSSetShader(stereoSyncCompute.get(), nullptr, 0);
-	context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
-
-	inputAoTexIdx = !inputAoTexIdx;
-	inputGITexIdx = !inputGITexIdx;
-}
-
-// upsample
-if (settings.ResolutionMode != 0) {
-	CS_GPU_PASS("ScreenSpaceGI::Upsample");
-
-	resetViews();
-	srvs.at(0) = texWorkingDepth->srv.get();
-	srvs.at(1) = texAo[inputAoTexIdx]->srv.get();
-	srvs.at(2) = texIlY[inputGITexIdx]->srv.get();
-	srvs.at(3) = texIlCoCg[inputGITexIdx]->srv.get();
-	srvs.at(4) = texGiSpecular[inputAoTexIdx]->srv.get();
-
-	uavs.at(0) = texAo[!inputAoTexIdx]->uav.get();
-	uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
-	uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
-	uavs.at(3) = texGiSpecular[!inputAoTexIdx]->uav.get();
-
-	context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
-	context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
-	context->CSSetShader(upsampleCompute.get(), nullptr, 0);
-	context->Dispatch((resolution[0] + 7u) >> 3, (resolution[1] + 7u) >> 3, 1);
-
-	inputAoTexIdx = !inputAoTexIdx;
-	inputGITexIdx = !inputGITexIdx;
-}
-
-outputAoIdx = inputAoTexIdx;
-outputIlIdx = inputGITexIdx;
-
-// cleanup
-resetViews();
-
-samplers.fill(nullptr);
-cb = nullptr;
-
-context->CSSetConstantBuffers(1, 1, &cb);
-context->CSSetSamplers(0, (uint)samplers.size(), samplers.data());
-context->CSSetShader(nullptr, nullptr, 0);
+	context->CSSetConstantBuffers(1, 1, &cb);
+	context->CSSetSamplers(0, (uint)samplers.size(), samplers.data());
+	context->CSSetShader(nullptr, nullptr, 0);
 }
 
 #undef I18N_KEY_PREFIX

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -1,4 +1,5 @@
 #include "ScreenSpaceGI.h"
+#include "GpuPass.h"
 
 #include <DirectXTex.h>
 
@@ -722,8 +723,7 @@ void ScreenSpaceGI::DrawSSGI()
 		return;
 	}
 
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "SSGI");
+	CS_GPU_PASS("ScreenSpaceGI::SSGI");
 
 	static uint lastFrameAoTexIdx = 0;
 	static uint lastFrameGITexIdx = 0;
@@ -773,7 +773,7 @@ void ScreenSpaceGI::DrawSSGI()
 
 	// prefilter depths
 	{
-		TracyD3D11Zone(globals::state->tracyCtx, "SSGI - Prefilter Depths");
+		CS_GPU_PASS("ScreenSpaceGI::PrefilterDepths");
 
 		srvs.at(0) = Util::GetCurrentSceneDepthSRV();
 		for (int i = 0; i < 5; ++i)
@@ -782,217 +782,198 @@ void ScreenSpaceGI::DrawSSGI()
 		context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
 		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
 		context->CSSetShader(prefilterDepthsCompute.get(), nullptr, 0);
-		globals::profiler->BeginPass("ScreenSpaceGI::PrefilterDepths");
 		context->Dispatch((resolution[0] + 15) >> 4, (resolution[1] + 15) >> 4, 1);
-		globals::profiler->EndPass();
 	}
 
 	// fetch radiance and disocclusion
+	CS_GPU_PASS("ScreenSpaceGI::RadianceDisocc");
+
+	resetViews();
+	srvs.at(0) = rts[deferred->forwardRenderTargets[0]].SRV;
+	srvs.at(1) = texWorkingDepth->srv.get();
+	srvs.at(2) = rts[NORMALROUGHNESS].SRV;
+	srvs.at(3) = texPrevGeo->srv.get();
+	srvs.at(4) = rts[RE::RENDER_TARGET::kMOTION_VECTOR].SRV;
+	srvs.at(5) = texAccumFrames[lastFrameAccumTexIdx]->srv.get();
+	srvs.at(6) = texAo[inputAoTexIdx]->srv.get();
+	srvs.at(7) = texIlY[inputGITexIdx]->srv.get();
+	srvs.at(8) = texIlCoCg[inputGITexIdx]->srv.get();
+	srvs.at(9) = texGiSpecular[inputAoTexIdx]->srv.get();
+	srvs.at(10) = nullptr;
+
+	uavs.at(0) = texRadianceTemp->uav.get();
+	uavs.at(1) = texAccumFrames[!lastFrameAccumTexIdx]->uav.get();
+	uavs.at(2) = texAo[!inputAoTexIdx]->uav.get();
+	uavs.at(3) = texIlY[!inputGITexIdx]->uav.get();
+	uavs.at(4) = texIlCoCg[!inputGITexIdx]->uav.get();
+	uavs.at(5) = texGiSpecular[!inputAoTexIdx]->uav.get();
+
+	context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
+	context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
+	context->CSSetShader(radianceDisoccCompute.get(), nullptr, 0);
+	context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
+
+	// Prefilter radiance texture instead of using GenerateMips for proper dynamic resolution handling.
+	// radianceDisocc wrote mip 0 directly to texRadianceTemp above, so we can bind it
+	// as SRV input here without an intermediate CopySubresourceRegion.
 	{
-		TracyD3D11Zone(globals::state->tracyCtx, "SSGI - Radiance Disocc");
+		CS_GPU_PASS("ScreenSpaceGI::PrefilterRadiance");
 
 		resetViews();
-		srvs.at(0) = rts[deferred->forwardRenderTargets[0]].SRV;
-		srvs.at(1) = texWorkingDepth->srv.get();
-		srvs.at(2) = rts[NORMALROUGHNESS].SRV;
-		srvs.at(3) = texPrevGeo->srv.get();
-		srvs.at(4) = rts[RE::RENDER_TARGET::kMOTION_VECTOR].SRV;
-		srvs.at(5) = texAccumFrames[lastFrameAccumTexIdx]->srv.get();
-		srvs.at(6) = texAo[inputAoTexIdx]->srv.get();
-		srvs.at(7) = texIlY[inputGITexIdx]->srv.get();
-		srvs.at(8) = texIlCoCg[inputGITexIdx]->srv.get();
-		srvs.at(9) = texGiSpecular[inputAoTexIdx]->srv.get();
-		srvs.at(10) = nullptr;
-
-		uavs.at(0) = texRadianceTemp->uav.get();
-		uavs.at(1) = texAccumFrames[!lastFrameAccumTexIdx]->uav.get();
-		uavs.at(2) = texAo[!inputAoTexIdx]->uav.get();
-		uavs.at(3) = texIlY[!inputGITexIdx]->uav.get();
-		uavs.at(4) = texIlCoCg[!inputGITexIdx]->uav.get();
-		uavs.at(5) = texGiSpecular[!inputAoTexIdx]->uav.get();
-
-		context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
-		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
-		context->CSSetShader(radianceDisoccCompute.get(), nullptr, 0);
-		globals::profiler->BeginPass("ScreenSpaceGI::RadianceDisocc");
-		context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
-		globals::profiler->EndPass();
-
-		// Prefilter radiance texture instead of using GenerateMips for proper dynamic resolution handling.
-		// radianceDisocc wrote mip 0 directly to texRadianceTemp above, so we can bind it
-		// as SRV input here without an intermediate CopySubresourceRegion.
-		{
-			TracyD3D11Zone(globals::state->tracyCtx, "SSGI - Prefilter Radiance");
-
-			resetViews();
-			srvs.at(0) = texRadianceTemp->srv.get();
-			uavs.at(0) = uavRadiance[0].get();  // Mip 0
-			uavs.at(1) = uavRadiance[1].get();  // Mip 1
-			uavs.at(2) = uavRadiance[2].get();  // Mip 2
-			uavs.at(3) = uavRadiance[3].get();  // Mip 3
-			uavs.at(4) = uavRadiance[4].get();  // Mip 4
-
-			context->CSSetShaderResources(0, 1, srvs.data());
-			context->CSSetUnorderedAccessViews(0, 5, uavs.data(), nullptr);
-			context->CSSetShader(prefilterRadianceCompute.get(), nullptr, 0);
-			globals::profiler->BeginPass("ScreenSpaceGI::PrefilterRadiance");
-			context->Dispatch((internalRes[0] + 15u) >> 4, (internalRes[1] + 15u) >> 4, 1);
-			globals::profiler->EndPass();
-		}
-
-		inputAoTexIdx = !inputAoTexIdx;
-		inputGITexIdx = !inputGITexIdx;
-		lastFrameAccumTexIdx = !lastFrameAccumTexIdx;
-	}
-
-	// Prefilter normals
-	{
-		TracyD3D11Zone(globals::state->tracyCtx, "SSGI - Prefilter Normals");
-
-		resetViews();
-		srvs.at(0) = rts[NORMALROUGHNESS].SRV;
-		uavs.at(0) = uavNormal[0].get();
-		uavs.at(1) = uavNormal[1].get();
-		uavs.at(2) = uavNormal[2].get();
-		uavs.at(3) = uavNormal[3].get();
-		uavs.at(4) = uavNormal[4].get();
+		srvs.at(0) = texRadianceTemp->srv.get();
+		uavs.at(0) = uavRadiance[0].get();  // Mip 0
+		uavs.at(1) = uavRadiance[1].get();  // Mip 1
+		uavs.at(2) = uavRadiance[2].get();  // Mip 2
+		uavs.at(3) = uavRadiance[3].get();  // Mip 3
+		uavs.at(4) = uavRadiance[4].get();  // Mip 4
 
 		context->CSSetShaderResources(0, 1, srvs.data());
 		context->CSSetUnorderedAccessViews(0, 5, uavs.data(), nullptr);
-		context->CSSetShader(prefilterNormalCompute.get(), nullptr, 0);
-		globals::profiler->BeginPass("ScreenSpaceGI::PrefilterNormals");
+		context->CSSetShader(prefilterRadianceCompute.get(), nullptr, 0);
 		context->Dispatch((internalRes[0] + 15u) >> 4, (internalRes[1] + 15u) >> 4, 1);
-		globals::profiler->EndPass();
 	}
 
-	// GI
-	{
-		TracyD3D11Zone(globals::state->tracyCtx, "SSGI - GI");
+	inputAoTexIdx = !inputAoTexIdx;
+	inputGITexIdx = !inputGITexIdx;
+	lastFrameAccumTexIdx = !lastFrameAccumTexIdx;
+}
 
-		resetViews();
-		srvs.at(0) = texWorkingDepth->srv.get();
-		srvs.at(1) = rts[NORMALROUGHNESS].SRV;
-		srvs.at(2) = texRadiance->srv.get();
-		srvs.at(3) = texNoise->srv.get();
-		srvs.at(4) = texAccumFrames[lastFrameAccumTexIdx]->srv.get();
-		srvs.at(5) = texIlY[inputGITexIdx]->srv.get();
-		srvs.at(6) = texIlCoCg[inputGITexIdx]->srv.get();
-		srvs.at(7) = texGiSpecular[inputAoTexIdx]->srv.get();
-		srvs.at(8) = texNormal->srv.get();
+// Prefilter normals
+{
+	CS_GPU_PASS("ScreenSpaceGI::PrefilterNormals");
 
-		uavs.at(0) = texAo[!inputAoTexIdx]->uav.get();
-		uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
-		uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
-		uavs.at(3) = texGiSpecular[!inputAoTexIdx]->uav.get();
-		uavs.at(4) = texPrevGeo->uav.get();
-
-		context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
-		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
-		context->CSSetShader(giCompute.get(), nullptr, 0);
-		globals::profiler->BeginPass("ScreenSpaceGI::GI");
-		context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
-		globals::profiler->EndPass();
-
-		inputAoTexIdx = !inputAoTexIdx;
-		inputGITexIdx = !inputGITexIdx;
-		lastFrameGITexIdx = inputGITexIdx;
-		lastFrameAoTexIdx = inputAoTexIdx;
-	}
-
-	// blur
-	if (settings.EnableBlur) {
-		TracyD3D11Zone(globals::state->tracyCtx, "SSGI - Diffuse Blur");
-
-		resetViews();
-		srvs.at(0) = texWorkingDepth->srv.get();
-		srvs.at(1) = rts[NORMALROUGHNESS].SRV;
-		srvs.at(2) = texAccumFrames[lastFrameAccumTexIdx]->srv.get();
-		srvs.at(3) = texIlY[inputGITexIdx]->srv.get();
-		srvs.at(4) = texIlCoCg[inputGITexIdx]->srv.get();
-
-		uavs.at(0) = texAccumFrames[!lastFrameAccumTexIdx]->uav.get();
-		uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
-		uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
-
-		context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
-		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
-		context->CSSetShader(blurCompute.get(), nullptr, 0);
-		globals::profiler->BeginPass("ScreenSpaceGI::Blur");
-		context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
-		globals::profiler->EndPass();
-
-		inputGITexIdx = !inputGITexIdx;
-		lastFrameGITexIdx = inputGITexIdx;
-		lastFrameAccumTexIdx = !lastFrameAccumTexIdx;
-	}
-
-	// VR stereo sync: bilateral blend of SSGI buffers between eyes
-	// Shi, Billeter, Eisemann 2022, "Stereo-consistent screen-space ambient occlusion"
-	if (globals::game::isVR && stereoSyncCompute) {
-		TracyD3D11Zone(globals::state->tracyCtx, "SSGI - Stereo Sync");
-
-		if (globals::state->frameAnnotations)
-			globals::state->BeginPerfEvent("SSGI - Stereo Sync");
-
-		resetViews();
-		srvs.at(0) = texWorkingDepth->srv.get();
-		srvs.at(1) = texAo[inputAoTexIdx]->srv.get();
-		srvs.at(2) = texIlY[inputGITexIdx]->srv.get();
-		srvs.at(3) = texIlCoCg[inputGITexIdx]->srv.get();
-
-		uavs.at(0) = texAo[!inputAoTexIdx]->uav.get();
-		uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
-		uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
-
-		context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
-		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
-		context->CSSetShader(stereoSyncCompute.get(), nullptr, 0);
-		context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
-
-		inputAoTexIdx = !inputAoTexIdx;
-		inputGITexIdx = !inputGITexIdx;
-
-		if (globals::state->frameAnnotations)
-			globals::state->EndPerfEvent();
-	}
-
-	// upsample
-	if (settings.ResolutionMode != 0) {
-		resetViews();
-		srvs.at(0) = texWorkingDepth->srv.get();
-		srvs.at(1) = texAo[inputAoTexIdx]->srv.get();
-		srvs.at(2) = texIlY[inputGITexIdx]->srv.get();
-		srvs.at(3) = texIlCoCg[inputGITexIdx]->srv.get();
-		srvs.at(4) = texGiSpecular[inputAoTexIdx]->srv.get();
-
-		uavs.at(0) = texAo[!inputAoTexIdx]->uav.get();
-		uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
-		uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
-		uavs.at(3) = texGiSpecular[!inputAoTexIdx]->uav.get();
-
-		context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
-		context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
-		context->CSSetShader(upsampleCompute.get(), nullptr, 0);
-		globals::profiler->BeginPass("ScreenSpaceGI::Upsample");
-		context->Dispatch((resolution[0] + 7u) >> 3, (resolution[1] + 7u) >> 3, 1);
-		globals::profiler->EndPass();
-
-		inputAoTexIdx = !inputAoTexIdx;
-		inputGITexIdx = !inputGITexIdx;
-	}
-
-	outputAoIdx = inputAoTexIdx;
-	outputIlIdx = inputGITexIdx;
-
-	// cleanup
 	resetViews();
+	srvs.at(0) = rts[NORMALROUGHNESS].SRV;
+	uavs.at(0) = uavNormal[0].get();
+	uavs.at(1) = uavNormal[1].get();
+	uavs.at(2) = uavNormal[2].get();
+	uavs.at(3) = uavNormal[3].get();
+	uavs.at(4) = uavNormal[4].get();
 
-	samplers.fill(nullptr);
-	cb = nullptr;
+	context->CSSetShaderResources(0, 1, srvs.data());
+	context->CSSetUnorderedAccessViews(0, 5, uavs.data(), nullptr);
+	context->CSSetShader(prefilterNormalCompute.get(), nullptr, 0);
+	context->Dispatch((internalRes[0] + 15u) >> 4, (internalRes[1] + 15u) >> 4, 1);
+}
 
-	context->CSSetConstantBuffers(1, 1, &cb);
-	context->CSSetSamplers(0, (uint)samplers.size(), samplers.data());
-	context->CSSetShader(nullptr, nullptr, 0);
+// GI
+{
+	CS_GPU_PASS("ScreenSpaceGI::GI");
+
+	resetViews();
+	srvs.at(0) = texWorkingDepth->srv.get();
+	srvs.at(1) = rts[NORMALROUGHNESS].SRV;
+	srvs.at(2) = texRadiance->srv.get();
+	srvs.at(3) = texNoise->srv.get();
+	srvs.at(4) = texAccumFrames[lastFrameAccumTexIdx]->srv.get();
+	srvs.at(5) = texIlY[inputGITexIdx]->srv.get();
+	srvs.at(6) = texIlCoCg[inputGITexIdx]->srv.get();
+	srvs.at(7) = texGiSpecular[inputAoTexIdx]->srv.get();
+	srvs.at(8) = texNormal->srv.get();
+
+	uavs.at(0) = texAo[!inputAoTexIdx]->uav.get();
+	uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
+	uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
+	uavs.at(3) = texGiSpecular[!inputAoTexIdx]->uav.get();
+	uavs.at(4) = texPrevGeo->uav.get();
+
+	context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
+	context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
+	context->CSSetShader(giCompute.get(), nullptr, 0);
+	context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
+
+	inputAoTexIdx = !inputAoTexIdx;
+	inputGITexIdx = !inputGITexIdx;
+	lastFrameGITexIdx = inputGITexIdx;
+	lastFrameAoTexIdx = inputAoTexIdx;
+}
+
+// blur
+if (settings.EnableBlur) {
+	CS_GPU_PASS("ScreenSpaceGI::Blur");
+
+	resetViews();
+	srvs.at(0) = texWorkingDepth->srv.get();
+	srvs.at(1) = rts[NORMALROUGHNESS].SRV;
+	srvs.at(2) = texAccumFrames[lastFrameAccumTexIdx]->srv.get();
+	srvs.at(3) = texIlY[inputGITexIdx]->srv.get();
+	srvs.at(4) = texIlCoCg[inputGITexIdx]->srv.get();
+
+	uavs.at(0) = texAccumFrames[!lastFrameAccumTexIdx]->uav.get();
+	uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
+	uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
+
+	context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
+	context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
+	context->CSSetShader(blurCompute.get(), nullptr, 0);
+	context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
+
+	inputGITexIdx = !inputGITexIdx;
+	lastFrameGITexIdx = inputGITexIdx;
+	lastFrameAccumTexIdx = !lastFrameAccumTexIdx;
+}
+
+// VR stereo sync: bilateral blend of SSGI buffers between eyes
+// Shi, Billeter, Eisemann 2022, "Stereo-consistent screen-space ambient occlusion"
+if (globals::game::isVR && stereoSyncCompute) {
+	CS_GPU_PASS("ScreenSpaceGI::StereoSync");
+
+	resetViews();
+	srvs.at(0) = texWorkingDepth->srv.get();
+	srvs.at(1) = texAo[inputAoTexIdx]->srv.get();
+	srvs.at(2) = texIlY[inputGITexIdx]->srv.get();
+	srvs.at(3) = texIlCoCg[inputGITexIdx]->srv.get();
+
+	uavs.at(0) = texAo[!inputAoTexIdx]->uav.get();
+	uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
+	uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
+
+	context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
+	context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
+	context->CSSetShader(stereoSyncCompute.get(), nullptr, 0);
+	context->Dispatch((internalRes[0] + 7u) >> 3, (internalRes[1] + 7u) >> 3, 1);
+
+	inputAoTexIdx = !inputAoTexIdx;
+	inputGITexIdx = !inputGITexIdx;
+}
+
+// upsample
+if (settings.ResolutionMode != 0) {
+	CS_GPU_PASS("ScreenSpaceGI::Upsample");
+
+	resetViews();
+	srvs.at(0) = texWorkingDepth->srv.get();
+	srvs.at(1) = texAo[inputAoTexIdx]->srv.get();
+	srvs.at(2) = texIlY[inputGITexIdx]->srv.get();
+	srvs.at(3) = texIlCoCg[inputGITexIdx]->srv.get();
+	srvs.at(4) = texGiSpecular[inputAoTexIdx]->srv.get();
+
+	uavs.at(0) = texAo[!inputAoTexIdx]->uav.get();
+	uavs.at(1) = texIlY[!inputGITexIdx]->uav.get();
+	uavs.at(2) = texIlCoCg[!inputGITexIdx]->uav.get();
+	uavs.at(3) = texGiSpecular[!inputAoTexIdx]->uav.get();
+
+	context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
+	context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
+	context->CSSetShader(upsampleCompute.get(), nullptr, 0);
+	context->Dispatch((resolution[0] + 7u) >> 3, (resolution[1] + 7u) >> 3, 1);
+
+	inputAoTexIdx = !inputAoTexIdx;
+	inputGITexIdx = !inputGITexIdx;
+}
+
+outputAoIdx = inputAoTexIdx;
+outputIlIdx = inputGITexIdx;
+
+// cleanup
+resetViews();
+
+samplers.fill(nullptr);
+cb = nullptr;
+
+context->CSSetConstantBuffers(1, 1, &cb);
+context->CSSetSamplers(0, (uint)samplers.size(), samplers.data());
+context->CSSetShader(nullptr, nullptr, 0);
 }
 
 #undef I18N_KEY_PREFIX

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -165,7 +165,7 @@ void ScreenSpaceShadows::DrawShadows()
 
 	auto lightProjectionF = CalculateLightProjection(0);
 
-	float2 renderSize = Util::ConvertToDynamic(state->screenSize);
+	float2 renderSize = Util::ConvertToDynamic(globals::state->screenSize);
 	int viewportSize[2] = { (int)renderSize.x, (int)renderSize.y };
 
 	if (globals::game::isVR)
@@ -238,41 +238,40 @@ void ScreenSpaceShadows::DrawShadows()
 				context->Dispatch(dispatchData.WaveCount[0], dispatchData.WaveCount[1], dispatchData.WaveCount[2]);
 			}
 		}
+	};
+
+	float InvTexSizeX = 1.0f / (float)viewportSize[0];
+	float InvTexSizeY = 1.0f / (float)viewportSize[1];
+
+	if (!globals::game::isVR) {
+		DispatchEye(nullptr, GetComputeRaymarch(), lightProjectionF.data(), InvTexSizeX, InvTexSizeY);
+	} else {
+		{
+			CS_GPU_PASS("SSS::LeftEye");
+			DispatchEye("Left Eye", GetComputeRaymarch(), lightProjectionF.data(), InvTexSizeX, InvTexSizeY);
+		}
+
+		// Calculate light projection for right eye
+		auto lightProjectionRightF = CalculateLightProjection(1);
+		{
+			CS_GPU_PASS("SSS::RightEye");
+			DispatchEye("Right Eye", GetComputeRaymarchRight(), lightProjectionRightF.data(), InvTexSizeX, InvTexSizeY);
+		}
 	}
-};
 
-float InvTexSizeX = 1.0f / (float)viewportSize[0];
-float InvTexSizeY = 1.0f / (float)viewportSize[1];
+	ID3D11ShaderResourceView* views[1]{ nullptr };
+	context->CSSetShaderResources(0, 1, views);
 
-if (!globals::game::isVR) {
-	DispatchEye(nullptr, GetComputeRaymarch(), lightProjectionF.data(), InvTexSizeX, InvTexSizeY);
-} else {
-	{
-		CS_GPU_PASS("SSS::LeftEye");
-		DispatchEye("Left Eye", GetComputeRaymarch(), lightProjectionF.data(), InvTexSizeX, InvTexSizeY);
-	}
+	ID3D11UnorderedAccessView* uavs[1]{ nullptr };
+	context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
 
-	// Calculate light projection for right eye
-	auto lightProjectionRightF = CalculateLightProjection(1);
-	{
-		CS_GPU_PASS("SSS::RightEye");
-		DispatchEye("Right Eye", GetComputeRaymarchRight(), lightProjectionRightF.data(), InvTexSizeX, InvTexSizeY);
-	}
-}
+	context->CSSetShader(nullptr, nullptr, 0);
 
-ID3D11ShaderResourceView* views[1]{ nullptr };
-context->CSSetShaderResources(0, 1, views);
+	ID3D11SamplerState* sampler = nullptr;
+	context->CSSetSamplers(0, 1, &sampler);
 
-ID3D11UnorderedAccessView* uavs[1]{ nullptr };
-context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
-
-context->CSSetShader(nullptr, nullptr, 0);
-
-ID3D11SamplerState* sampler = nullptr;
-context->CSSetSamplers(0, 1, &sampler);
-
-buffer = nullptr;
-context->CSSetConstantBuffers(1, 1, &buffer);
+	buffer = nullptr;
+	context->CSSetConstantBuffers(1, 1, &buffer);
 }
 
 void ScreenSpaceShadows::DrawStereoSync()

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -1,6 +1,7 @@
 #include "ScreenSpaceShadows.h"
 
 #include "Features/TerrainBlending.h"
+#include "GpuPass.h"
 #include "I18n/I18n.h"
 #include "State.h"
 #include "Utils/D3D.h"
@@ -143,8 +144,7 @@ ID3D11ComputeShader* ScreenSpaceShadows::GetComputeRaymarchRight()
 void ScreenSpaceShadows::DrawShadows()
 {
 	ZoneScopedS(8);
-	auto state = globals::state;
-	TracyD3D11Zone(state->tracyCtx, "Screen Space Shadows");
+	CS_GPU_PASS("ScreenSpaceShadows::DrawShadows");
 
 	auto context = globals::d3d::context;
 
@@ -199,14 +199,7 @@ void ScreenSpaceShadows::DrawShadows()
 	auto DispatchEye = [&](const char* eyeName, ID3D11ComputeShader* shader, const float* lightProj,
 						   float invTexSizeX, float invTexSizeY) {
 		std::string timerName = eyeName ? std::format("ScreenSpaceShadows::RayMarch({})", eyeName) : "ScreenSpaceShadows::RayMarch";
-		globals::profiler->BeginPass(timerName);
-
-		if (globals::state->frameAnnotations && eyeName) {
-			std::string eventName = std::format("SSS - Ray March ({})", eyeName);
-			globals::state->BeginPerfEvent(eventName);
-		} else if (globals::state->frameAnnotations) {
-			globals::state->BeginPerfEvent("SSS - Ray March");
-		}
+		CS_GPU_PASS(timerName);
 
 		context->CSSetShader(shader, nullptr, 0);
 
@@ -216,7 +209,7 @@ void ScreenSpaceShadows::DrawShadows()
 			auto dispatchData = dispatchList.Dispatch[i];
 
 			{
-				TracyD3D11Zone(globals::state->tracyCtx, "SSS - DispatchEye CB");
+				CS_GPU_PASS("SSS::RayMarch::DispatchEyeCB");
 
 				RaymarchCB data{};
 				data.LightCoordinate[0] = dispatchList.LightCoordinate_Shader[0];
@@ -241,50 +234,45 @@ void ScreenSpaceShadows::DrawShadows()
 			}
 
 			{
-				TracyD3D11Zone(globals::state->tracyCtx, "SSS - DispatchEye Sweep");
+				CS_GPU_PASS("SSS::RayMarch::DispatchEyeSweep");
 				context->Dispatch(dispatchData.WaveCount[0], dispatchData.WaveCount[1], dispatchData.WaveCount[2]);
 			}
 		}
+	}
+};
 
-		if (globals::state->frameAnnotations) {
-			globals::state->EndPerfEvent();
-		}
+float InvTexSizeX = 1.0f / (float)viewportSize[0];
+float InvTexSizeY = 1.0f / (float)viewportSize[1];
 
-		globals::profiler->EndPass();
-	};
-
-	float InvTexSizeX = 1.0f / (float)viewportSize[0];
-	float InvTexSizeY = 1.0f / (float)viewportSize[1];
-
-	if (!globals::game::isVR) {
-		DispatchEye(nullptr, GetComputeRaymarch(), lightProjectionF.data(), InvTexSizeX, InvTexSizeY);
-	} else {
-		{
-			TracyD3D11Zone(globals::state->tracyCtx, "SSS - Left Eye");
-			DispatchEye("Left Eye", GetComputeRaymarch(), lightProjectionF.data(), InvTexSizeX, InvTexSizeY);
-		}
-
-		// Calculate light projection for right eye
-		auto lightProjectionRightF = CalculateLightProjection(1);
-		{
-			TracyD3D11Zone(globals::state->tracyCtx, "SSS - Right Eye");
-			DispatchEye("Right Eye", GetComputeRaymarchRight(), lightProjectionRightF.data(), InvTexSizeX, InvTexSizeY);
-		}
+if (!globals::game::isVR) {
+	DispatchEye(nullptr, GetComputeRaymarch(), lightProjectionF.data(), InvTexSizeX, InvTexSizeY);
+} else {
+	{
+		CS_GPU_PASS("SSS::LeftEye");
+		DispatchEye("Left Eye", GetComputeRaymarch(), lightProjectionF.data(), InvTexSizeX, InvTexSizeY);
 	}
 
-	ID3D11ShaderResourceView* views[1]{ nullptr };
-	context->CSSetShaderResources(0, 1, views);
+	// Calculate light projection for right eye
+	auto lightProjectionRightF = CalculateLightProjection(1);
+	{
+		CS_GPU_PASS("SSS::RightEye");
+		DispatchEye("Right Eye", GetComputeRaymarchRight(), lightProjectionRightF.data(), InvTexSizeX, InvTexSizeY);
+	}
+}
 
-	ID3D11UnorderedAccessView* uavs[1]{ nullptr };
-	context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
+ID3D11ShaderResourceView* views[1]{ nullptr };
+context->CSSetShaderResources(0, 1, views);
 
-	context->CSSetShader(nullptr, nullptr, 0);
+ID3D11UnorderedAccessView* uavs[1]{ nullptr };
+context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
 
-	ID3D11SamplerState* sampler = nullptr;
-	context->CSSetSamplers(0, 1, &sampler);
+context->CSSetShader(nullptr, nullptr, 0);
 
-	buffer = nullptr;
-	context->CSSetConstantBuffers(1, 1, &buffer);
+ID3D11SamplerState* sampler = nullptr;
+context->CSSetSamplers(0, 1, &sampler);
+
+buffer = nullptr;
+context->CSSetConstantBuffers(1, 1, &buffer);
 }
 
 void ScreenSpaceShadows::DrawStereoSync()
@@ -302,14 +290,9 @@ void ScreenSpaceShadows::DrawStereoSync()
 		return;
 
 	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "SSS - Stereo Sync");
-
-	if (globals::state->frameAnnotations)
-		globals::state->BeginPerfEvent("SSS - Stereo Sync");
+	CS_GPU_PASS("ScreenSpaceShadows::StereoSync");
 
 	auto context = globals::d3d::context;
-	globals::profiler->BeginPass("ScreenSpaceShadows::StereoSync");
-
 	context->CopyResource(stereoSyncCopyTex->resource.get(), screenSpaceShadowsTexture->resource.get());
 
 	float2 resolution = Util::ConvertToDynamic(globals::state->screenSize);
@@ -347,11 +330,6 @@ void ScreenSpaceShadows::DrawStereoSync()
 	context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
 	context->CSSetConstantBuffers(1, 1, &cbPtr);
 	context->CSSetShader(nullptr, nullptr, 0);
-
-	globals::profiler->EndPass();
-
-	if (globals::state->frameAnnotations)
-		globals::state->EndPerfEvent();
 }
 
 void ScreenSpaceShadows::Prepass()

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -482,7 +482,6 @@ void Skylighting::RenderOcclusion()
 {
 	ZoneScopedS(8);
 	auto shaderCache = globals::shaderCache;
-	auto state = globals::state;
 	auto renderer = globals::game::renderer;
 	auto sky = globals::game::sky;
 

--- a/src/Features/Skylighting.cpp
+++ b/src/Features/Skylighting.cpp
@@ -1,5 +1,6 @@
 #include "Skylighting.h"
 
+#include "GpuPass.h"
 #include "I18n/I18n.h"
 #include "ShaderCache.h"
 #include "State.h"
@@ -215,7 +216,7 @@ void Skylighting::Prepass()
 	if (interior)
 		return;
 
-	TracyD3D11Zone(globals::state->tracyCtx, "Skylighting - Update Probes");
+	CS_GPU_PASS("Skylighting::ProbeUpdate");
 
 	auto context = globals::d3d::context;
 
@@ -230,9 +231,7 @@ void Skylighting::Prepass()
 			context->CSSetShaderResources(0, (uint)srvs.size(), srvs.data());
 			context->CSSetUnorderedAccessViews(0, (uint)uavs.size(), uavs.data(), nullptr);
 			context->CSSetShader(probeUpdateCompute.get(), nullptr, 0);
-			globals::profiler->BeginPass("Skylighting::ProbeUpdate");
 			context->Dispatch((probeArrayDims[0] + 7u) >> 3, (probeArrayDims[1] + 7u) >> 3, probeArrayDims[2]);
-			globals::profiler->EndPass();
 		}
 
 		// Reset
@@ -488,10 +487,10 @@ void Skylighting::RenderOcclusion()
 	auto sky = globals::game::sky;
 
 	if (!shaderCache->IsEnabled()) {
-		TracyD3D11Zone(globals::state->tracyCtx, "Precipitation Mask");
-		state->BeginPerfEvent("Precipitation Mask");
-		Main_Precipitation_RenderOcclusion::func();
-		state->EndPerfEvent();
+		{
+			CS_GPU_PASS("Skylighting::PrecipitationMask");
+			Main_Precipitation_RenderOcclusion::func();
+		}
 		return;
 	}
 
@@ -502,8 +501,7 @@ void Skylighting::RenderOcclusion()
 			auto precip = sky->precip;
 
 			{
-				TracyD3D11Zone(globals::state->tracyCtx, "Precipitation Mask");
-				state->BeginPerfEvent("Precipitation Mask");
+				CS_GPU_PASS("Skylighting::PrecipitationMask");
 
 				doPrecip = false;
 
@@ -518,17 +516,12 @@ void Skylighting::RenderOcclusion()
 					auto particleShaderProperty = netimmerse_cast<RE::BSParticleShaderProperty*>(shaderProp);
 					auto rain = (RE::BSParticleShaderRainEmitter*)(particleShaderProperty->particleEmitter);
 
-					globals::profiler->BeginPass("Skylighting::PrecipMask");
 					precip->RenderMask(rain);
-					globals::profiler->EndPass();
 				}
-
-				state->EndPerfEvent();
 			}
 
 			{
-				TracyD3D11Zone(globals::state->tracyCtx, "Skylighting Mask");
-				state->BeginPerfEvent("Skylighting Mask");
+				CS_GPU_PASS("Skylighting::SkylightingMask");
 
 				if (queuedResetSkylighting)
 					ResetSkylighting();
@@ -592,10 +585,8 @@ void Skylighting::RenderOcclusion()
 
 				BSParticleShaderRainEmitter* rain = new BSParticleShaderRainEmitter;
 				{
-					TracyD3D11Zone(state->tracyCtx, "Skylighting - Render Height Map");
-					globals::profiler->BeginPass("Skylighting::OcclusionMask");
+					CS_GPU_PASS("Skylighting::OcclusionMask");
 					precip->RenderMask((RE::BSParticleShaderRainEmitter*)rain);
-					globals::profiler->EndPass();
 				}
 				inOcclusion = false;
 
@@ -615,8 +606,6 @@ void Skylighting::RenderOcclusion()
 					ZoneScopedN("Skylighting - Restore Projection");
 					_computeProjection(precip, precip->occlusionData.camera);
 				}
-
-				state->EndPerfEvent();
 			}
 		}
 	}

--- a/src/Features/SubsurfaceScattering.cpp
+++ b/src/Features/SubsurfaceScattering.cpp
@@ -2,6 +2,7 @@
 
 #include "../I18n/I18n.h"
 #include "Deferred.h"
+#include "GpuPass.h"
 #include "ShaderCache.h"
 #include "State.h"
 
@@ -223,7 +224,7 @@ void SubsurfaceScattering::DrawSSS()
 		return;
 
 	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "Subsurface Scattering");
+	CS_GPU_PASS("SubsurfaceScattering::DrawSSS");
 
 	validMaterials = false;
 
@@ -272,7 +273,7 @@ void SubsurfaceScattering::DrawSSS()
 
 		// Pre-pass: remove albedo from diffuse, write to diffuseNoAlbedoTex
 		{
-			TracyD3D11Zone(globals::state->tracyCtx, "Subsurface Scattering - Prepass");
+			CS_GPU_PASS("SubsurfaceScattering::Prepass");
 
 			ID3D11UnorderedAccessView* uav = diffuseNoAlbedoTex->uav.get();
 			context->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
@@ -293,7 +294,7 @@ void SubsurfaceScattering::DrawSSS()
 		if (settings.SSMode == 0) {
 			// Horizontal pass: diffuseNoAlbedoTex -> blurHorizontalTemp
 			{
-				TracyD3D11Zone(globals::state->tracyCtx, "Subsurface Scattering - Horizontal");
+				CS_GPU_PASS("SubsurfaceScattering::HorizontalBlur");
 
 				ID3D11UnorderedAccessView* uav = blurHorizontalTemp->uav.get();
 				context->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
@@ -301,9 +302,7 @@ void SubsurfaceScattering::DrawSSS()
 				auto shader = GetComputeShaderHorizontalBlur();
 				context->CSSetShader(shader, nullptr, 0);
 
-				globals::profiler->BeginPass("SubsurfaceScattering::HorizontalBlur");
 				context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
-				globals::profiler->EndPass();
 
 				uav = nullptr;
 				context->CSSetUnorderedAccessViews(0, 1, &uav, nullptr);
@@ -311,7 +310,7 @@ void SubsurfaceScattering::DrawSSS()
 
 			// Vertical pass: blurHorizontalTemp -> main
 			{
-				TracyD3D11Zone(globals::state->tracyCtx, "Subsurface Scattering - Vertical");
+				CS_GPU_PASS("SubsurfaceScattering::VerticalBlur");
 
 				views[0] = blurHorizontalTemp->srv.get();
 				context->CSSetShaderResources(0, 1, views);
@@ -322,14 +321,12 @@ void SubsurfaceScattering::DrawSSS()
 				auto shader = GetComputeShaderVerticalBlur();
 				context->CSSetShader(shader, nullptr, 0);
 
-				globals::profiler->BeginPass("SubsurfaceScattering::VerticalBlur");
 				context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
-				globals::profiler->EndPass();
 			}
 		} else if (settings.SSMode == 1) {
 			// Burley pass: diffuseNoAlbedoTex -> main (SSS pixels only)
 			{
-				TracyD3D11Zone(globals::state->tracyCtx, "Subsurface Scattering - Burley");
+				CS_GPU_PASS("SubsurfaceScattering::Burley");
 
 				ID3D11UnorderedAccessView* uavs[1] = { main.UAV };
 				context->CSSetUnorderedAccessViews(0, 1, uavs, nullptr);
@@ -337,9 +334,7 @@ void SubsurfaceScattering::DrawSSS()
 				auto shader = GetComputeShaderBurley();
 				context->CSSetShader(shader, nullptr, 0);
 
-				globals::profiler->BeginPass("SubsurfaceScattering::Burley");
 				context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
-				globals::profiler->EndPass();
 			}
 		}
 	}

--- a/src/Features/TerrainBlending.cpp
+++ b/src/Features/TerrainBlending.cpp
@@ -2,6 +2,7 @@
 
 #include "Deferred.h"
 #include "Globals.h"
+#include "GpuPass.h"
 #include "I18n/I18n.h"
 #include "ShaderCache.h"
 #include "State.h"
@@ -760,7 +761,7 @@ void TerrainBlending::TerrainShaderHacks()
 
 void TerrainBlending::ResetDepth()
 {
-	TracyD3D11Zone(globals::state->tracyCtx, "Terrain Blending - Reset Depth");
+	CS_GPU_PASS("TerrainBlending::ResetDepth");
 	auto context = globals::d3d::context;
 
 	auto dsv = terrainDepth.views[0];
@@ -769,9 +770,7 @@ void TerrainBlending::ResetDepth()
 
 void TerrainBlending::ResetTerrainDepth()
 {
-	TracyD3D11Zone(globals::state->tracyCtx, "Terrain Blending - Reset Terrain Depth");
-	if (globals::state->frameAnnotations)
-		globals::state->BeginPerfEvent("Terrain Blending - Reset Terrain Depth");
+	CS_GPU_PASS("TerrainBlending::ResetTerrainDepth");
 
 	auto context = globals::d3d::context;
 
@@ -780,17 +779,12 @@ void TerrainBlending::ResetTerrainDepth()
 
 	auto currentVertexShader = *globals::game::currentVertexShader;
 	context->VSSetShader((ID3D11VertexShader*)currentVertexShader->shader, NULL, NULL);
-
-	if (globals::state->frameAnnotations)
-		globals::state->EndPerfEvent();
 }
 
 void TerrainBlending::BlendPrepassDepths()
 {
 	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "Terrain Blending - Blend Prepass Depths");
-	if (globals::state->frameAnnotations)
-		globals::state->BeginPerfEvent("Terrain Blending - Blend Prepass Depths");
+	CS_GPU_PASS("TerrainBlending::BlendPrepassDepths");
 
 	auto context = globals::d3d::context;
 	context->OMSetRenderTargets(0, nullptr, nullptr);
@@ -798,7 +792,7 @@ void TerrainBlending::BlendPrepassDepths()
 	auto dispatchCount = Util::GetScreenDispatchCount();
 
 	{
-		TracyD3D11Zone(globals::state->tracyCtx, "Terrain Blending - Depth Blend CS");
+		CS_GPU_PASS("TerrainBlending::DepthBlend");
 
 		ID3D11ShaderResourceView* views[2] = { depthSRVBackup, terrainDepth.depthSRV };
 		context->CSSetShaderResources(0, ARRAYSIZE(views), views);
@@ -809,9 +803,7 @@ void TerrainBlending::BlendPrepassDepths()
 
 		context->CSSetShader(GetDepthBlendShader(), nullptr, 0);
 
-		globals::profiler->BeginPass("TerrainBlending::DepthBlend");
 		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
-		globals::profiler->EndPass();
 	}
 
 	ID3D11ShaderResourceView* views[2] = { nullptr, nullptr };
@@ -827,9 +819,6 @@ void TerrainBlending::BlendPrepassDepths()
 	stateUpdateFlags->set(RE::BSGraphics::ShaderFlags::DIRTY_RENDERTARGET);
 	// CopyResource(terrainDepth <- mainDepth) eliminated: main depth is now written
 	// directly into mainDepthCopy (u2) by the CS above, saving a full-stereo D24S8 copy.
-
-	if (globals::state->frameAnnotations)
-		globals::state->EndPerfEvent();
 }
 
 void TerrainBlending::ClearShaderCache()
@@ -1021,9 +1010,7 @@ void TerrainBlending::RenderTerrainBlendingPasses()
 	const uint64_t noBlendPassCount = static_cast<uint64_t>(renderPasses.size());
 
 	if (terrainPassCount != 0 || noBlendPassCount != 0) {
-		TracyD3D11Zone(globals::state->tracyCtx, "Terrain Blending - Render Passes");
-		if (globals::state->frameAnnotations)
-			globals::state->BeginPerfEvent("Terrain Blending - Render Passes");
+		CS_GPU_PASS("TerrainBlending::RenderPasses");
 
 		GET_INSTANCE_MEMBER(alphaBlendMode, shadowState)
 		GET_INSTANCE_MEMBER(alphaBlendWriteMode, shadowState)
@@ -1053,9 +1040,6 @@ void TerrainBlending::RenderTerrainBlendingPasses()
 
 		terrainRenderPasses.clear();
 		renderPasses.clear();
-
-		if (globals::state->frameAnnotations)
-			globals::state->EndPerfEvent();
 	}
 
 	auto& mainDepth = renderer->GetDepthStencilData().depthStencils[RE::RENDER_TARGETS_DEPTHSTENCIL::kMAIN];

--- a/src/Features/TerrainShadows.cpp
+++ b/src/Features/TerrainShadows.cpp
@@ -3,6 +3,7 @@
 #include <DirectXTex.h>
 #include <pystring/pystring.h>
 
+#include "GpuPass.h"
 #include "I18n/I18n.h"
 #include "State.h"
 #include "Util.h"
@@ -340,7 +341,6 @@ void TerrainShadows::UpdateShadow()
 	auto sunLight = skyrim_cast<RE::NiDirectionalLight*>(shadowSceneNode->GetRuntimeData().sunLight->light.get());
 	if (!sunLight)
 		return;
-	TracyD3D11Zone(globals::state->tracyCtx, "Terrain Occlusion - Update Shadows");
 
 	/* ---- UPDATE CB ---- */
 	uint width = texHeightMap->desc.Width;
@@ -418,9 +418,10 @@ void TerrainShadows::UpdateShadow()
 	context->CSSetUnorderedAccessViews(0, ARRAYSIZE(newer.uavs), newer.uavs, nullptr);
 	context->CSSetConstantBuffers(0, 1, &newer.buffer);
 	context->CSSetShader(shadowUpdateProgram.get(), nullptr, 0);
-	globals::profiler->BeginPass("TerrainShadows::ShadowUpdate");
-	context->Dispatch(abs(shadowUpdateCBData.LightPxDir.x) >= abs(shadowUpdateCBData.LightPxDir.y) ? height : width, 1, 1);
-	globals::profiler->EndPass();
+	{
+		CS_GPU_PASS("TerrainShadows::ShadowUpdate");
+		context->Dispatch(abs(shadowUpdateCBData.LightPxDir.x) >= abs(shadowUpdateCBData.LightPxDir.y) ? height : width, 1, 1);
+	}
 
 	/* ---- RESTORE ---- */
 	context->CSSetShaderResources(0, ARRAYSIZE(old.srvs), old.srvs);

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1,4 +1,5 @@
 #include "Upscaling.h"
+#include "GpuPass.h"
 
 #include "../I18n/I18n.h"
 #include "Deferred.h"
@@ -1450,9 +1451,7 @@ void Upscaling::PreparePerEyeInputs(ID3D11Resource* colorSrc)
 	if (!globals::game::isVR)
 		return;
 
-	auto state = globals::state;
-	if (state->frameAnnotations)
-		state->BeginPerfEvent("VR Upscaling Prepare");
+	CS_GPU_PASS("Upscaling::PreparePerEyeInputs");
 
 	auto context = globals::d3d::context;
 	auto renderSize = Util::ConvertToDynamic(globals::state->screenSize);
@@ -1478,22 +1477,14 @@ void Upscaling::PreparePerEyeInputs(ID3D11Resource* colorSrc)
 		ClearHMDMask(vrIntermediateColorIn[i]->uav.get(), depthTexture.depthSRV,
 			eyeWidthIn, eyeHeightIn, depthOffset, 0);
 	}
-
-	if (state->frameAnnotations)
-		state->EndPerfEvent();
 }
 
 void Upscaling::FinalizePerEyeOutputs(ID3D11Resource* colorDst)
 {
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "VR Upscaling - Finalize Per Eye");
-
 	if (!globals::game::isVR)
 		return;
 
-	auto state = globals::state;
-	if (state->frameAnnotations)
-		state->BeginPerfEvent("VR Upscaling Finalize");
+	CS_GPU_PASS("Upscaling::FinalizePerEyeOutputs");
 
 	auto context = globals::d3d::context;
 
@@ -1501,8 +1492,6 @@ void Upscaling::FinalizePerEyeOutputs(ID3D11Resource* colorDst)
 	// Under PerfMode the state value is polluted to renderRes while the intermediates
 	// were allocated at displayRes via EnsureVRIntermediateTextures' size bridge.
 	if (!vrIntermediateColorOut[0]) {
-		if (state->frameAnnotations)
-			state->EndPerfEvent();
 		return;
 	}
 
@@ -1515,9 +1504,6 @@ void Upscaling::FinalizePerEyeOutputs(ID3D11Resource* colorDst)
 		D3D11_BOX outBox = { 0, 0, 0, eyeWidthOut, eyeHeightOut, 1 };
 		context->CopySubresourceRegion(colorDst, 0, offsetXOut, 0, 0, vrIntermediateColorOut[i]->resource.get(), 0, &outBox);
 	}
-
-	if (state->frameAnnotations)
-		state->EndPerfEvent();
 }
 
 void Upscaling::ClearHMDMask(ID3D11UnorderedAccessView* colorUAV, ID3D11ShaderResourceView* depthSRV,
@@ -1829,9 +1815,7 @@ void Upscaling::ClearShaderCache()
 
 void Upscaling::CopySharedD3D12Resources()
 {
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "Upscaling - Copy Shared D3D12 Resources");
-	globals::state->BeginPerfEvent("Copy Shared D3D12 Resources");
+	CS_GPU_PASS("Upscaling::CopySharedD3D12Resources");
 
 	auto renderer = globals::game::renderer;
 	auto context = globals::d3d::context;
@@ -1877,9 +1861,7 @@ void Upscaling::CopySharedD3D12Resources()
 
 		context->PSSetShader(copyDepthToSharedBufferPS.get(), nullptr, 0);
 
-		globals::profiler->BeginPass("Upscaling::CopyDepthD3D12");
 		context->Draw(3, 0);
-		globals::profiler->EndPass();
 	}
 
 	// Clean up
@@ -1889,8 +1871,6 @@ void Upscaling::CopySharedD3D12Resources()
 	context->OMSetRenderTargets(0, nullptr, nullptr);
 	context->PSSetShader(nullptr, nullptr, 0);
 	context->VSSetShader(nullptr, nullptr, 0);
-
-	globals::state->EndPerfEvent();
 }
 
 void UpdateCameraData()
@@ -2188,9 +2168,7 @@ void Upscaling::Upscale()
 	auto& motionVector = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMOTION_VECTOR];
 
 	{
-		globals::profiler->BeginPass("Upscaling::EncodeTextures");
-		state->BeginPerfEvent("Encode Upscaling Textures");
-		TracyD3D11Zone(globals::state->tracyCtx, "Encode Upscaling Textures");
+		CS_GPU_PASS("Upscaling::EncodeTextures");
 
 		auto& temporalAAMask = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kTEMPORAL_AA_MASK];
 		auto& normals = renderer->GetRuntimeData().renderTargets[globals::deferred->forwardRenderTargets[2]];
@@ -2246,15 +2224,10 @@ void Upscaling::Upscale()
 
 		ID3D11ComputeShader* shader = nullptr;
 		context->CSSetShader(shader, nullptr, 0);
-
-		state->EndPerfEvent();
-		globals::profiler->EndPass();
 	}
 
 	{
-		globals::profiler->BeginPass("Upscaling::Upscale");
-		state->BeginPerfEvent("Upscaling");
-		TracyD3D11Zone(globals::state->tracyCtx, "Upscaling Dispatch");
+		CS_GPU_PASS("Upscaling::Upscale");
 
 		if (upscaleMethod == UpscaleMethod::kDLSS) {
 			// VR-only workaround: a worldspace/cell transition causes ~2-3ms persistent GPU-time
@@ -2311,16 +2284,12 @@ void Upscaling::Upscale()
 			                                  nullptr;
 			fidelityFX.Upscale(main.texture, reactiveMaskTexture->resource.get(), transparencyCompositionMaskTexture->resource.get(), motionVector.texture, settings.sharpnessFSR, fsrColorOut);
 		}
-
-		state->EndPerfEvent();
-		globals::profiler->EndPass();
 	}
 }
 
 void Upscaling::PerformUpscaling()
 {
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "Upscaling");
+	CS_GPU_PASS("Upscaling::PerformUpscaling");
 	Upscale();
 	UpscaleDepth();
 
@@ -2335,8 +2304,7 @@ void Upscaling::PerformUpscaling()
 
 void Upscaling::UpscaleDepth()
 {
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "Upscaling - Depth");
+	CS_GPU_PASS("Upscaling::UpscaleDepth");
 	// Optimization overview:
 	// 1) Early validation exits before issuing GPU work.
 	// 2) Wide-kernel depth mode uses hysteresis to avoid frequent toggles.
@@ -2402,8 +2370,6 @@ void Upscaling::UpscaleDepth()
 	if (!fullscreenVS || !underwaterMaskPS || (depthUpscaleActive && !depthUpscalePS)) {
 		return;
 	}
-
-	state->BeginPerfEvent("Render Target Upscaling");
 
 	// Unbind any prior render targets before issuing CopyResource on depth/
 	// depthCopy. Upscale() does this for the standard upscale path, but
@@ -2474,7 +2440,7 @@ void Upscaling::UpscaleDepth()
 	};
 
 	if (depthUpscaleActive) {
-		TracyD3D11Zone(globals::state->tracyCtx, "Upscaling - Depth Upscale");
+		CS_GPU_PASS("Upscaling::DepthUpscale");
 
 		// Sometimes this is not already copied e.g. map menu.
 		// Skip alias copies to reduce unnecessary copy churn.
@@ -2500,17 +2466,16 @@ void Upscaling::UpscaleDepth()
 		context->OMSetRenderTargets(2, rtvs, depth.views[0]);
 
 		context->PSSetShader(depthUpscalePS, nullptr, 0);
-		globals::profiler->BeginPass("Upscaling::DepthUpscale");
 		context->Draw(3, 0);
 	} else {
-		TracyD3D11Zone(globals::state->tracyCtx, "Upscaling - Full Resolution Underwater Mask Depth Copy");
+		CS_GPU_PASS("Upscaling::FullResolutionUnderwaterMaskDepthCopy");
 
 		// Full-resolution paths only need to refresh the underwater mask depth source.
 		copyIfNonAliased(depthCopy.texture, depth.texture);
 	}
 
 	{
-		TracyD3D11Zone(globals::state->tracyCtx, "Upscaling - Underwater Mask");
+		CS_GPU_PASS("Upscaling::UnderwaterMaskUpscale");
 
 		viewport.Width = screenSize.x * 0.5f;
 		viewport.Height = screenSize.y * 0.5f;
@@ -2529,7 +2494,6 @@ void Upscaling::UpscaleDepth()
 		context->OMSetRenderTargets(ARRAYSIZE(rtvs), rtvs, nullptr);
 
 		context->PSSetShader(underwaterMaskPS, nullptr, 0);
-		globals::profiler->BeginPass("Upscaling::UnderwaterMaskUpscale");
 		context->Draw(3, 0);
 	}
 
@@ -2537,21 +2501,16 @@ void Upscaling::UpscaleDepth()
 	// it. Skipped on the full-resolution path because the else branch above
 	// already refreshed depthCopy from depth and nothing has touched it since.
 	if (isVR && depthUpscaleActive) {
-		TracyD3D11Zone(globals::state->tracyCtx, "Upscaling - Depth VR Propagate");
+		CS_GPU_PASS("Upscaling::DepthVRPropagate");
 		copyIfNonAliased(depthCopy.texture, depth.texture);
 	}
 
 	ID3D11ShaderResourceView* nullPSResources[3] = { nullptr, nullptr, nullptr };
 	context->PSSetShaderResources(0, ARRAYSIZE(nullPSResources), nullPSResources);
-
-	state->EndPerfEvent();
 }
 
 void Upscaling::RunUnderwaterMaskRepair()
 {
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "Upscaling - Underwater Mask (Standalone)");
-
 	if (!globals::game::isVR)
 		return;
 
@@ -2582,7 +2541,7 @@ void Upscaling::RunUnderwaterMaskRepair()
 		return;
 	}
 
-	state->BeginPerfEvent("Underwater Mask Repair (Standalone)");
+	CS_GPU_PASS("Upscaling::UnderwaterMaskRepairStandalone");
 
 	// Unbind RTs/DSV before the CopyResource calls below — if the caller
 	// still has depth bound as a DSV the copy is a debug-layer hazard.
@@ -2638,20 +2597,23 @@ void Upscaling::RunUnderwaterMaskRepair()
 
 	ID3D11ShaderResourceView* nullPSResources[2] = { nullptr, nullptr };
 	context->PSSetShaderResources(0, ARRAYSIZE(nullPSResources), nullPSResources);
-
-	state->EndPerfEvent();
 }
 
 void Upscaling::ApplySharpening()
 {
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "Upscaling - Sharpening");
-
 	if (settings.sharpnessDLSS <= 0.0f)
 		return;
 
 	if (!sharpenerTexture)
 		return;
+
+	auto renderer = globals::game::renderer;
+	auto& main = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
+
+	if (!main.UAV)
+		return;
+
+	CS_GPU_PASS("Upscaling::Sharpening");
 
 	float currentSharpness = (-2.0f * settings.sharpnessDLSS) + 2.0f;
 	currentSharpness = exp2(-currentSharpness);

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -2158,7 +2158,6 @@ void Upscaling::Upscale()
 	ZoneScoped;
 	auto upscaleMethod = GetUpscaleMethod();
 
-	auto state = globals::state;
 	auto context = globals::d3d::context;
 	auto renderer = globals::game::renderer;
 

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -2619,11 +2619,6 @@ void Upscaling::ApplySharpening()
 	currentSharpness = exp2(-currentSharpness);
 
 	auto context = globals::d3d::context;
-	auto renderer = globals::game::renderer;
-	auto& main = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
-
-	if (!main.UAV)
-		return;
 
 	context->OMSetRenderTargets(0, nullptr, nullptr);
 

--- a/src/Features/Upscaling/PerfMode/MenuBridge.cpp
+++ b/src/Features/Upscaling/PerfMode/MenuBridge.cpp
@@ -1,3 +1,4 @@
+#include "../../../GpuPass.h"
 #include "../PerfMode.h"
 
 #include <algorithm>
@@ -123,11 +124,7 @@ void PerfMode::MaybeBlitMenuBG(uint32_t boundRTIdx)
 	if (!dest.RTV || !dest.texture)
 		return;
 
-	ZoneScoped;
-	auto state = globals::state;
-	auto* context = globals::d3d::context;
-	state->BeginPerfEvent("PerfMode::MenuBGBlit");
-	TracyD3D11Zone(state->tracyCtx, "PerfMode::MenuBGBlit");
+	CS_GPU_PASS("PerfMode::MenuBGBlit");
 
 	globals::features::upscaling.Upscale();
 
@@ -169,7 +166,6 @@ void PerfMode::MaybeBlitMenuBG(uint32_t boundRTIdx)
 	}
 
 	blittedFrameId = currentFrame;
-	state->EndPerfEvent();
 }
 
 void PerfMode::InstallCreateRTThunks()

--- a/src/Features/Upscaling/PerfMode/MenuBridge.cpp
+++ b/src/Features/Upscaling/PerfMode/MenuBridge.cpp
@@ -119,6 +119,7 @@ void PerfMode::MaybeBlitMenuBG(uint32_t boundRTIdx)
 		return;
 
 	auto renderer = globals::game::renderer;
+	auto context = globals::d3d::context;
 	auto& rtData = renderer->GetRuntimeData();
 	auto& dest = rtData.renderTargets[boundRTIdx];
 	if (!dest.RTV || !dest.texture)

--- a/src/Features/Upscaling/PerfMode/PostIntercept.cpp
+++ b/src/Features/Upscaling/PerfMode/PostIntercept.cpp
@@ -350,7 +350,6 @@ void PerfMode::DownscaleToKMain()
 	if (!hookActive || !testTextureSRV || !boxDownscalePS || !boxDownscaleVS || !linearSampler)
 		return;
 
-	auto state = globals::state;
 	auto renderer = globals::game::renderer;
 	auto context = globals::d3d::context;
 	auto& rtData = renderer->GetRuntimeData();

--- a/src/Features/Upscaling/PerfMode/PostIntercept.cpp
+++ b/src/Features/Upscaling/PerfMode/PostIntercept.cpp
@@ -1,3 +1,4 @@
+#include "../../../GpuPass.h"
 #include "../PerfMode.h"
 
 #include <algorithm>
@@ -40,8 +41,7 @@ void PerfMode::TonemapRender_Hook::thunk(void* imageSpaceShader, RE::BSTriShape*
 		return;
 	}
 
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "PerfMode::TonemapRender");
+	CS_GPU_PASS("PerfMode::TonemapRender");
 
 	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
 	auto& rtData = renderer->GetRuntimeData();
@@ -104,8 +104,7 @@ void PerfMode::RefractionRender_Hook::thunk(void* imageSpaceShader, RE::BSTriSha
 		return;
 	}
 
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "PerfMode::RefractionRender");
+	CS_GPU_PASS("PerfMode::RefractionRender");
 
 	// --- Pass 1: engine's normal 1k refraction (untouched) ---
 	func(imageSpaceShader, shape, param);
@@ -248,8 +247,7 @@ void PerfMode::ISCopyRender_Hook::thunk(void* imageSpaceShader, RE::BSTriShape* 
 							rtDesc.Height > static_cast<UINT>(savedVP[0].Height + 1.0f));
 
 	if (needsStretch) {
-		ZoneScoped;
-		TracyD3D11Zone(globals::state->tracyCtx, "PerfMode::ISCopyStretch");
+		CS_GPU_PASS("PerfMode::ISCopyStretch");
 
 		// Replay viewport: full dest extent, preserve depth range from the
 		// original so anything sampling depth (unlikely for ISCopy but safe)
@@ -352,7 +350,6 @@ void PerfMode::DownscaleToKMain()
 	if (!hookActive || !testTextureSRV || !boxDownscalePS || !boxDownscaleVS || !linearSampler)
 		return;
 
-	ZoneScoped;
 	auto state = globals::state;
 	auto renderer = globals::game::renderer;
 	auto context = globals::d3d::context;
@@ -365,8 +362,7 @@ void PerfMode::DownscaleToKMain()
 	if (!kmain.RTV)
 		return;
 
-	state->BeginPerfEvent("PerfMode::DownscaleToKMain");
-	TracyD3D11Zone(state->tracyCtx, "PerfMode::DownscaleToKMain");
+	CS_GPU_PASS("PerfMode::DownscaleToKMain");
 
 	{
 		FullscreenPassScope stateScope(context);
@@ -405,8 +401,6 @@ void PerfMode::DownscaleToKMain()
 		context->OMSetRenderTargets(1, &rtv, nullptr);
 		context->Draw(3, 0);
 	}
-
-	state->EndPerfEvent();
 }
 
 void PerfMode::HandlePostProcessing(const std::function<void()>& enginePost)

--- a/src/Features/Upscaling/RCAS/RCAS.cpp
+++ b/src/Features/Upscaling/RCAS/RCAS.cpp
@@ -1,4 +1,5 @@
 #include "RCAS.h"
+#include "../../../GpuPass.h"
 
 #include "../../../Deferred.h"
 #include "../../../State.h"
@@ -34,19 +35,15 @@ void RCAS::CreateComputeShader()
 
 void RCAS::ApplySharpen(ID3D11ShaderResourceView* inputSRV, ID3D11UnorderedAccessView* outputUAV, float sharpness)
 {
-	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "RCAS Sharpening");
-
-	auto state = globals::state;
-	auto context = globals::d3d::context;
-
 	if (!rcasComputeShader) {
 		logger::warn("[RCAS] Compute shader not compiled");
 		return;
 	}
 
-	globals::profiler->BeginPass("Upscaling::RCAS");
-	state->BeginPerfEvent("RCAS Sharpening");
+	CS_GPU_PASS("Upscaling::RCAS");
+
+	auto state = globals::state;
+	auto context = globals::d3d::context;
 
 	uint32_t screenWidth = (uint32_t)state->screenSize.x;
 	uint32_t screenHeight = (uint32_t)state->screenSize.y;
@@ -77,7 +74,4 @@ void RCAS::ApplySharpen(ID3D11ShaderResourceView* inputSRV, ID3D11UnorderedAcces
 	context->CSSetUnorderedAccessViews(0, 1, nullUAVs, nullptr);
 
 	context->CSSetShader(nullptr, nullptr, 0);
-
-	globals::profiler->EndPass();
-	state->EndPerfEvent();
 }

--- a/src/Features/VR/StereoBlend.cpp
+++ b/src/Features/VR/StereoBlend.cpp
@@ -4,6 +4,7 @@
 #include "Features/DynamicCubemaps.h"
 #include "Features/ScreenSpaceGI.h"
 #include "Features/ScreenSpaceShadows.h"
+#include "GpuPass.h"
 #include "State.h"
 #include "Utils/D3D.h"
 
@@ -73,10 +74,7 @@ void VR::DrawStereoBlend()
 		return;
 
 	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "VR Stereo Blend");
-
-	if (globals::state->frameAnnotations)
-		globals::state->BeginPerfEvent("VR Stereo Blend");
+	CS_GPU_PASS("VR::StereoBlend");
 
 	auto context = globals::d3d::context;
 	auto renderer = globals::game::renderer;
@@ -191,11 +189,15 @@ void VR::DrawStereoBlend()
 
 	context->CSSetShader(activeCS, nullptr, 0);
 	if (isOverwriteMode) {
-		TracyD3D11Zone(globals::state->tracyCtx, "StereoBlend - Overwrite");
-		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
+		{
+			CS_GPU_PASS("StereoBlend::Overwrite");
+			context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
+		}
 	} else {
-		TracyD3D11Zone(globals::state->tracyCtx, "StereoBlend - Bilateral");
-		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
+		{
+			CS_GPU_PASS("StereoBlend::Bilateral");
+			context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
+		}
 	}
 
 	// Cleanup
@@ -222,6 +224,5 @@ void VR::DrawStereoBlend()
 		savedDSV->Release();
 	}
 
-	if (globals::state->frameAnnotations)
-		globals::state->EndPerfEvent();
+	// Done
 }

--- a/src/Features/VRStereoOptimizations.cpp
+++ b/src/Features/VRStereoOptimizations.cpp
@@ -2,6 +2,7 @@
 
 #include "ExtendedMaterials.h"
 #include "Globals.h"
+#include "GpuPass.h"
 #include "I18n/I18n.h"
 #include "Menu.h"
 #include "State.h"
@@ -332,10 +333,7 @@ void VRStereoOptimizations::DispatchStencil()
 		return;
 
 	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "VR Stereo Opt - Stencil");
-
-	if (globals::state->frameAnnotations)
-		globals::state->BeginPerfEvent("VR Stereo Opt - Stencil");
+	CS_GPU_PASS("VRStereoOpt::Stencil");
 
 	auto context = globals::d3d::context;
 
@@ -348,19 +346,14 @@ void VRStereoOptimizations::DispatchStencil()
 	auto* depthSRV = Util::GetCurrentSceneDepthSRV();
 	if (!depthSRV) {
 		logger::warn("[VRStereoOptimizations] DispatchStencil: depthSRV is null, skipping");
-		if (globals::state->frameAnnotations)
-			globals::state->EndPerfEvent();
 		return;
 	}
 
-	// Dispatch classification CS over Eye 1 region
-	// Input: t0 = depth, b1 = params CB
-	// Output: u0 = per-pixel mode texture
 	{
-		TracyD3D11Zone(globals::state->tracyCtx, "StereoOpt - Mode Classify");
+		CS_GPU_PASS("StereoOpt::ModeClassify");
 
 		{
-			TracyD3D11Zone(globals::state->tracyCtx, "StereoOpt - Mode Classify Bind");
+			CS_GPU_PASS("StereoOpt::ModeClassifyBind");
 
 			ID3D11ShaderResourceView* srvs[1]{ depthSRV };
 			ID3D11UnorderedAccessView* uavs[1]{ texPerPixelMode->uav.get() };
@@ -373,7 +366,7 @@ void VRStereoOptimizations::DispatchStencil()
 		}
 
 		{
-			TracyD3D11Zone(globals::state->tracyCtx, "StereoOpt - Mode Classify Dispatch");
+			CS_GPU_PASS("StereoOpt::ModeClassifyDispatch");
 
 			uint32_t fullWidth = texPerPixelMode->desc.Width;
 			uint32_t fullHeight = texPerPixelMode->desc.Height;
@@ -392,15 +385,12 @@ void VRStereoOptimizations::DispatchStencil()
 
 	// Transfer classification to hardware stencil buffer
 	{
-		TracyD3D11Zone(globals::state->tracyCtx, "StereoOpt - Stencil Write");
+		CS_GPU_PASS("StereoOpt::StencilWrite");
 		ExecuteStencilWritePass();
 	}
 
 	stencilActive = true;
 	stencilSwapCount = 0;
-
-	if (globals::state->frameAnnotations)
-		globals::state->EndPerfEvent();
 }
 
 void VRStereoOptimizations::ExecuteStencilWritePass()

--- a/src/Features/VolumetricShadows.cpp
+++ b/src/Features/VolumetricShadows.cpp
@@ -1,6 +1,7 @@
 #include "VolumetricShadows.h"
 
 #include "Globals.h"
+#include "GpuPass.h"
 #include "I18n/I18n.h"
 #include "State.h"
 #include "Utils/D3D.h"
@@ -78,7 +79,7 @@ void VolumetricShadows::ClearShaderCache()
 void VolumetricShadows::CopyShadowLightData()
 {
 	ZoneScoped;
-	TracyD3D11Zone(globals::state->tracyCtx, "VolumetricShadows::CopyShadowLightData");
+	CS_GPU_PASS("VolumetricShadows::CopyShadowLightData");
 
 	auto context = globals::d3d::context;
 
@@ -197,17 +198,19 @@ void VolumetricShadows::CopyShadowLightData()
 					ID3D11UnorderedAccessView* csUavs[1]{ shadowCopyMip0UAV };
 					context->CSSetUnorderedAccessViews(0, 1, csUavs, nullptr);
 					context->CSSetShader(downsampleShadowMip0CS, nullptr, 0);
-					globals::profiler->BeginPass("VolumetricShadows::DownsampleMip0");
-					context->Dispatch(dispatchSize, dispatchSize, 1);
-					globals::profiler->EndPass();
+					{
+						CS_GPU_PASS("VolumetricShadows::DownsampleMip0");
+						context->Dispatch(dispatchSize, dispatchSize, 1);
+					}
 
 					// Mip 1 (cascade 0)
 					csUavs[0] = shadowCopyMip1UAV;
 					context->CSSetUnorderedAccessViews(0, 1, csUavs, nullptr);
 					context->CSSetShader(downsampleShadowMip1CS, nullptr, 0);
-					globals::profiler->BeginPass("VolumetricShadows::DownsampleMip1");
-					context->Dispatch(dispatchSize, dispatchSize, 1);
-					globals::profiler->EndPass();
+					{
+						CS_GPU_PASS("VolumetricShadows::DownsampleMip1");
+						context->Dispatch(dispatchSize, dispatchSize, 1);
+					}
 
 					// Unbind SRVs before blur passes
 					csSrvs[0] = nullptr;
@@ -229,9 +232,10 @@ void VolumetricShadows::CopyShadowLightData()
 						csUavs[0] = shadowBlurTempMip0UAV;
 						context->CSSetUnorderedAccessViews(0, 1, csUavs, nullptr);
 						context->CSSetShader(blurShadowHorizontalCS, nullptr, 0);
-						globals::profiler->BeginPass("VolumetricShadows::BlurHMip0");
-						context->Dispatch((mip0Size + GROUP_SIZE - 1) / GROUP_SIZE, mip0Size, 1);
-						globals::profiler->EndPass();
+						{
+							CS_GPU_PASS("VolumetricShadows::BlurHMip0");
+							context->Dispatch((mip0Size + GROUP_SIZE - 1) / GROUP_SIZE, mip0Size, 1);
+						}
 
 						// Unbind for next pass
 						blurSrvs[0] = nullptr;
@@ -245,9 +249,10 @@ void VolumetricShadows::CopyShadowLightData()
 						csUavs[0] = shadowCopyMip0UAV;
 						context->CSSetUnorderedAccessViews(0, 1, csUavs, nullptr);
 						context->CSSetShader(blurShadowVerticalCS, nullptr, 0);
-						globals::profiler->BeginPass("VolumetricShadows::BlurVMip0");
-						context->Dispatch(mip0Size, (mip0Size + GROUP_SIZE - 1) / GROUP_SIZE, 1);
-						globals::profiler->EndPass();
+						{
+							CS_GPU_PASS("VolumetricShadows::BlurVMip0");
+							context->Dispatch(mip0Size, (mip0Size + GROUP_SIZE - 1) / GROUP_SIZE, 1);
+						}
 
 						// Unbind
 						blurSrvs[0] = nullptr;
@@ -266,9 +271,10 @@ void VolumetricShadows::CopyShadowLightData()
 						csUavs[0] = shadowBlurTempMip1UAV;
 						context->CSSetUnorderedAccessViews(0, 1, csUavs, nullptr);
 						context->CSSetShader(blurShadowHorizontalCS, nullptr, 0);
-						globals::profiler->BeginPass("VolumetricShadows::BlurHMip1");
-						context->Dispatch((mip1Size + GROUP_SIZE - 1) / GROUP_SIZE, mip1Size, 1);
-						globals::profiler->EndPass();
+						{
+							CS_GPU_PASS("VolumetricShadows::BlurHMip1");
+							context->Dispatch((mip1Size + GROUP_SIZE - 1) / GROUP_SIZE, mip1Size, 1);
+						}
 
 						// Unbind for next pass
 						blurSrvs[0] = nullptr;
@@ -282,9 +288,10 @@ void VolumetricShadows::CopyShadowLightData()
 						csUavs[0] = shadowCopyMip1UAV;
 						context->CSSetUnorderedAccessViews(0, 1, csUavs, nullptr);
 						context->CSSetShader(blurShadowVerticalCS, nullptr, 0);
-						globals::profiler->BeginPass("VolumetricShadows::BlurVMip1");
-						context->Dispatch(mip1Size, (mip1Size + GROUP_SIZE - 1) / GROUP_SIZE, 1);
-						globals::profiler->EndPass();
+						{
+							CS_GPU_PASS("VolumetricShadows::BlurVMip1");
+							context->Dispatch(mip1Size, (mip1Size + GROUP_SIZE - 1) / GROUP_SIZE, 1);
+						}
 
 						// Unbind
 						blurSrvs[0] = nullptr;

--- a/src/GpuPass.cpp
+++ b/src/GpuPass.cpp
@@ -1,0 +1,67 @@
+#include "GpuPass.h"
+
+#include "Globals.h"
+#include "State.h"
+
+ScopedGpuPass::ScopedGpuPass(std::string_view name)
+{
+	auto* profiler = globals::profiler;
+	auto* state = globals::state;
+
+	// 1. Internal profiler: GPU timestamp query start + always-on CPU QPC.
+	//    BeginPass also fires the legacy BeginPerfEvent callback for any
+	//    call sites that are not yet migrated to ScopedGpuPass.
+	if (profiler) {
+		profiler->BeginPass(std::string(name));
+		profilerActive = true;
+	}
+
+#ifdef TRACY_ENABLE
+	// 2. Tracy CPU zone — unconditional; not gated on frameAnnotations so
+	//    CPU profiles are available in any TRACY_SUPPORT build.
+	{
+		const auto srcloc = ___tracy_alloc_srcloc_name(
+			0,
+			"GpuPass", sizeof("GpuPass") - 1,
+			"ScopedGpuPass", sizeof("ScopedGpuPass") - 1,
+			name.data(), name.size(),
+			0);
+		cpuZoneCtx = ___tracy_emit_zone_begin_alloc(srcloc, true);
+	}
+
+	// 3. Tracy GPU zone — requires a D3D11 context from State.
+	if (state && state->tracyCtx) {
+		const auto srcloc = ___tracy_alloc_srcloc_name(
+			0,
+			"GpuPass", sizeof("GpuPass") - 1,
+			"ScopedGpuPass", sizeof("ScopedGpuPass") - 1,
+			name.data(), name.size(),
+			0);
+		gpuZone.emplace(state->tracyCtx, srcloc, 0, true);
+	}
+#endif
+
+	// 4. RenderDoc/PIX annotation — gated on frameAnnotations.
+	//    Calls BeginAnnotation (pPerf-only, no Tracy) to avoid double-emitting
+	//    the Tracy CPU zone that BeginPerfEvent would add.
+	if (state && state->frameAnnotations) {
+		state->BeginAnnotation(name);
+		annotationOpen = true;
+	}
+}
+
+ScopedGpuPass::~ScopedGpuPass()
+{
+	auto* state = globals::state;
+
+	if (annotationOpen && state)
+		state->EndAnnotation();
+
+#ifdef TRACY_ENABLE
+	gpuZone.reset();
+	TracyCZoneEnd(cpuZoneCtx);
+#endif
+
+	if (profilerActive)
+		globals::profiler->EndPass();
+}

--- a/src/GpuPass.cpp
+++ b/src/GpuPass.cpp
@@ -12,7 +12,7 @@ ScopedGpuPass::ScopedGpuPass(std::string_view name)
 	//    BeginPass also fires the legacy BeginPerfEvent callback for any
 	//    call sites that are not yet migrated to ScopedGpuPass.
 	if (profiler) {
-		profiler->BeginPass(std::string(name));
+		profiler->BeginPass(std::string(name), false);
 		profilerActive = true;
 	}
 
@@ -63,5 +63,5 @@ ScopedGpuPass::~ScopedGpuPass()
 #endif
 
 	if (profilerActive)
-		globals::profiler->EndPass();
+		globals::profiler->EndPass(false);
 }

--- a/src/GpuPass.h
+++ b/src/GpuPass.h
@@ -33,8 +33,11 @@ private:
 	bool profilerActive = false;
 };
 
+#define CS_GPU_PASS_CONCAT_IMPL(a, b) a##b
+#define CS_GPU_PASS_CONCAT(a, b) CS_GPU_PASS_CONCAT_IMPL(a, b)
+
 /// Drop a single-line GPU pass scope at render-pass entry.
 /// The variable name is mangled with __LINE__ so two CS_GPU_PASS calls in the
 /// same function cannot collide.
 #define CS_GPU_PASS(name) \
-	ScopedGpuPass cs_gpu_pass_##__LINE__ { name }
+	ScopedGpuPass CS_GPU_PASS_CONCAT(cs_gpu_pass_, __LINE__) { name }

--- a/src/GpuPass.h
+++ b/src/GpuPass.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <Tracy/TracyC.h>
+#include <Tracy/TracyD3D11.hpp>
+
+#include <optional>
+#include <string_view>
+
+/// RAII scope that fans a single pass name to all three instrumentation sinks:
+///   1. Internal profiler (GPU timestamp + CPU QPC → Profiling table)
+///   2. Tracy CPU zone (always-on when TRACY_ENABLE; not gated on frameAnnotations)
+///   3. Tracy GPU zone (always-on when TRACY_ENABLE and a D3D11 context exists)
+///   4. RenderDoc/PIX ID3DUserDefinedAnnotation (when frameAnnotations is true)
+///
+/// Use via the convenience macro at render-pass entry points:
+///   CS_GPU_PASS("Feature::PassName");
+struct ScopedGpuPass
+{
+	explicit ScopedGpuPass(std::string_view name);
+	~ScopedGpuPass();
+
+	ScopedGpuPass(const ScopedGpuPass&) = delete;
+	ScopedGpuPass& operator=(const ScopedGpuPass&) = delete;
+	ScopedGpuPass(ScopedGpuPass&&) = delete;
+	ScopedGpuPass& operator=(ScopedGpuPass&&) = delete;
+
+private:
+#ifdef TRACY_ENABLE
+	TracyCZoneCtx cpuZoneCtx{};
+	std::optional<tracy::D3D11ZoneScope> gpuZone;
+#endif
+	bool annotationOpen = false;
+	bool profilerActive = false;
+};
+
+/// Drop a single-line GPU pass scope at render-pass entry.
+/// The variable name is mangled with __LINE__ so two CS_GPU_PASS calls in the
+/// same function cannot collide.
+#define CS_GPU_PASS(name) \
+	ScopedGpuPass ___cs_gpu_pass_##__LINE__ { name }

--- a/src/GpuPass.h
+++ b/src/GpuPass.h
@@ -37,4 +37,4 @@ private:
 /// The variable name is mangled with __LINE__ so two CS_GPU_PASS calls in the
 /// same function cannot collide.
 #define CS_GPU_PASS(name) \
-	ScopedGpuPass ___cs_gpu_pass_##__LINE__ { name }
+	ScopedGpuPass cs_gpu_pass_##__LINE__ { name }

--- a/src/Profiler.cpp
+++ b/src/Profiler.cpp
@@ -94,7 +94,7 @@ void Profiler::BeginFrame()
 	context->Begin(frame.disjoint.get());
 }
 
-void Profiler::BeginPass(const std::string& name)
+void Profiler::BeginPass(const std::string& name, bool fireCallbacks)
 {
 	if (!initialized || !context)
 		return;
@@ -111,11 +111,11 @@ void Profiler::BeginPass(const std::string& name)
 	context->End(timer.begin.get());
 	QueryPerformanceCounter(&timer.cpuBegin);
 
-	if (beginPerfEvent)
+	if (fireCallbacks && beginPerfEvent)
 		beginPerfEvent(name);
 }
 
-void Profiler::EndPass()
+void Profiler::EndPass(bool fireCallbacks)
 {
 	if (!initialized || !context || !frameActive)
 		return;
@@ -133,7 +133,7 @@ void Profiler::EndPass()
 	context->End(timer.end.get());
 	frame.activeCount++;
 
-	if (endPerfEvent)
+	if (fireCallbacks && endPerfEvent)
 		endPerfEvent({});
 }
 

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -10,7 +10,7 @@
 class Profiler
 {
 public:
-	static constexpr uint32_t kMaxTimers = 128;
+	static constexpr uint32_t kMaxTimers = 256;
 	static constexpr uint32_t kFrameLatency = 3;
 	static constexpr uint32_t kHistorySize = 300;
 

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -71,8 +71,8 @@ public:
 	}
 
 	void BeginFrame();
-	void BeginPass(const std::string& name);
-	void EndPass();
+	void BeginPass(const std::string& name, bool fireCallbacks = true);
+	void EndPass(bool fireCallbacks = true);
 	void EndFrame();
 
 	const std::vector<TimerResult>& GetResults() const { return results; }

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -947,6 +947,16 @@ void State::EndPerfEvent()
 	pPerf->EndEvent();
 }
 
+void State::BeginAnnotation(std::string_view title)
+{
+	pPerf->BeginEvent(std::wstring(title.begin(), title.end()).c_str());
+}
+
+void State::EndAnnotation()
+{
+	pPerf->EndEvent();
+}
+
 void State::SetPerfMarker(std::string_view title)
 {
 	pPerf->SetMarker(std::wstring(title.begin(), title.end()).c_str());

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -931,7 +931,9 @@ void State::BeginPerfEvent(std::string_view title)
 	const TracyCZoneCtx ctx = ___tracy_emit_zone_begin_alloc(srcloc, true);
 	s_tracyPerfZones.push_back(ctx);
 #endif
-	pPerf->BeginEvent(std::wstring(title.begin(), title.end()).c_str());
+	if (pPerf) {
+		pPerf->BeginEvent(std::wstring(title.begin(), title.end()).c_str());
+	}
 }
 
 void State::EndPerfEvent()
@@ -944,22 +946,30 @@ void State::EndPerfEvent()
 		logger::warn("EndPerfEvent called without a matching BeginPerfEvent");
 	}
 #endif
-	pPerf->EndEvent();
+	if (pPerf) {
+		pPerf->EndEvent();
+	}
 }
 
 void State::BeginAnnotation(std::string_view title)
 {
-	pPerf->BeginEvent(std::wstring(title.begin(), title.end()).c_str());
+	if (pPerf) {
+		pPerf->BeginEvent(std::wstring(title.begin(), title.end()).c_str());
+	}
 }
 
 void State::EndAnnotation()
 {
-	pPerf->EndEvent();
+	if (pPerf) {
+		pPerf->EndEvent();
+	}
 }
 
 void State::SetPerfMarker(std::string_view title)
 {
-	pPerf->SetMarker(std::wstring(title.begin(), title.end()).c_str());
+	if (pPerf) {
+		pPerf->SetMarker(std::wstring(title.begin(), title.end()).c_str());
+	}
 }
 
 void State::SetAdapterDescription(const std::wstring& description)

--- a/src/State.h
+++ b/src/State.h
@@ -145,6 +145,11 @@ public:
 	void EndPerfEvent();
 	void SetPerfMarker(std::string_view title);
 
+	/// RenderDoc/PIX annotation only — no Tracy CPU zone.
+	/// Used by ScopedGpuPass which manages its own Tracy CPU zone unconditionally.
+	void BeginAnnotation(std::string_view title);
+	void EndAnnotation();
+
 	void SetAdapterDescription(const std::wstring& description);
 
 	bool frameAnnotations = false;


### PR DESCRIPTION
close #132 
Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized GPU pass instrumentation across rendering systems to unify profiling and visual performance traces.
* **New Features**
  * Added an RAII GPU-pass scope for consistent GPU/CPU zones and annotation handling.
* **Chores**
  * Increased profiler timer capacity and added annotation helpers to state/profiler APIs for improved tooling support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->