### PR TITLE
fix(vr): gate foliage normal flip

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2081,10 +2081,12 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float3x3 tbnTr = ReconstructTBN(input.WorldPosition.xyz, worldNormal, screenUV);
 #	else
 	float3 worldNormal = normalize(mul(tbn, normal.xyz));
-#		if defined(TREE_ANIM)
+#		if defined(TREE_ANIM) && !defined(VR)
 	float3 viewNormal = normalize(FrameBuffer::WorldToView(worldNormal, false, eyeIndex));
 	viewNormal = float3(viewNormal.xy, -abs(viewNormal.z));
 	worldNormal = normalize(FrameBuffer::ViewToWorld(viewNormal, false, eyeIndex));
+#		elif defined(TREE_ANIM)
+	// VR must keep tree normals eye/view independent.
 #		endif
 
 #		if defined(SPARKLE)


### PR DESCRIPTION
Issue:
The tree normal correction from #2344 rewrites foliage normals through view space. Works for flat rendering but view-dependent in VR because the transform is evaluated per eye/HMD view, which can make foliage brightness change with headset direction.

Fix:
Keep the #2344 behavior outside VR, but skip only that view-space normal rewrite for VR so tree normals remain eye-independent.

<img width="1103" height="1041" alt="dark" src="https://github.com/user-attachments/assets/af0fe9f1-cbc5-4210-aa8a-7ef4b8b2de96" />


<img width="1108" height="1097" alt="bright" src="https://github.com/user-attachments/assets/95de1506-28ff-4dca-b5cf-15fc1365740d" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed animated tree rendering in VR to correctly maintain surface normals independent of player perspective.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->