### PR TITLE
chore(tools): shader decomposition phase-0 tooling

### DIFF
--- a/docs/development/shader-decomposition-plan.md
+++ b/docs/development/shader-decomposition-plan.md
@@ -127,6 +127,13 @@ files, e.g. `Lighting.hlsl` → `LightingVS.hlsli`, `LightingLandscape.hlsli`,
 5. Forbidden: editing `Common/*.hlsli` shared by other shaders (separate,
    sequential work units if ever needed); touching `featuresIndices` /
    descriptor logic; editing more than the assigned range.
+6. Forbidden, git: any history surgery beyond creating your own section
+   commits — no `reset`, no `rebase`, no amending or dropping commits you did
+   not create in this work unit (amending your own just-made commit to absorb
+   pre-commit hook reformatting is fine, after re-running the gate). If the
+   branch contains commits or working-tree changes you don't recognize, leave
+   them untouched — they belong to the orchestrator. If that state blocks you,
+   STOP and report.
 
 Parallelization: shaders are independent (Lighting ∥ Water ∥ Effect ∥ Utility ∥
 RunGrass); **sections within one shader are sequential** (each move shifts line

--- a/docs/development/shader-decomposition-plan.md
+++ b/docs/development/shader-decomposition-plan.md
@@ -129,11 +129,14 @@ files, e.g. `Lighting.hlsl` → `LightingVS.hlsli`, `LightingLandscape.hlsli`,
    descriptor logic; editing more than the assigned range.
 6. Forbidden, git: any history surgery beyond creating your own section
    commits — no `reset`, no `rebase`, no amending or dropping commits you did
-   not create in this work unit (amending your own just-made commit to absorb
-   pre-commit hook reformatting is fine, after re-running the gate). If the
-   branch contains commits or working-tree changes you don't recognize, leave
-   them untouched — they belong to the orchestrator. If that state blocks you,
-   STOP and report.
+   not create in this work unit. Pre-commit hook handling: if the hook
+   REJECTED your `git commit` (no new commit exists — check `git log -1`
+   authorship/title first), stage the hook's reformatting, re-run the gate,
+   and run a fresh `git commit` — `--amend` here rewrites someone else's
+   HEAD. Only amend when `git log -1` shows the commit you just created. If
+   the branch contains commits or working-tree changes you don't recognize,
+   leave them untouched — they belong to the orchestrator. If that state
+   blocks you, STOP and report.
 
 Parallelization: shaders are independent (Lighting ∥ Water ∥ Effect ∥ Utility ∥
 RunGrass); **sections within one shader are sequential** (each move shifts line

--- a/docs/development/shader-decomposition-plan.md
+++ b/docs/development/shader-decomposition-plan.md
@@ -80,6 +80,29 @@ Timing measurements (not correctness) must use **release-parity flags**
 (`/O3`, no `D3DCOMPILE_DEBUG`/`SKIP_OPTIMIZATION`) — the validation config's
 debug flags make compiles artificially fast and would understate every number.
 
+### Verification cadence: batch + bisect (never per-micro-step)
+
+Verification cost must scale with the number of _failures_, not the number of
+changes. The Phase-1 retrospective: gating every section twice per stage, plus
+post-hook re-runs, burned ~an hour per shader on redundant sweeps. The protocol:
+
+1. Author a whole batch of changes (each its own commit; no gating while
+   authoring beyond compiling in your head).
+2. One gate run over the full list with `-FailFast`. IDENTICAL ⇒ done — N
+   changes verified for the price of one run.
+3. On DIFFERS the script prints the failing permutation as a **bisect probe**:
+   `git bisect run` re-testing only that one permutation
+   (`-Permutations "<failing>"`) finds the culprit commit in log₂(N) steps of
+   seconds each. Drop or fix it, then one final full-list run as the PR proof.
+4. Don't re-gate after clang-format hook reformatting — Tier 0 is
+   whitespace-immune by construction (fxc `/P` retokenizes); spot-check one
+   permutation if paranoid.
+
+The verify script is parallel (`-Jobs`, default cores−2) and caches the
+base-ref side per SHA (`build/verify-cache/`). Measured on Lighting: full
+1276-perm Tier-0 ≈ 21s cold / 10s warm (was 5–10 min); stratified Tier-1 ≈
+64s cold / 40s warm (was 10+ min).
+
 ## Phase 0 — Tooling + triage baseline (one capable agent, sequential)
 
 Deliverables, each small and testable:
@@ -118,8 +141,9 @@ files, e.g. `Lighting.hlsl` → `LightingVS.hlsli`, `LightingLandscape.hlsli`,
    leave `#include "NewSection.hlsli"` at the original site. No reordering, no
    renaming, no whitespace/comment edits, no "while I'm here" fixes. One section
    per commit.
-3. Gate: Tier 0 over the **full** permutation list (cheap). Exit 0 ⇒ commit.
-   Exit non-zero ⇒ `git checkout` the touched files, report the failure, stop.
+3. Gate: batch + bisect (see "Verification cadence" above) — commit each
+   section, gate the whole batch once with `-FailFast` at the end. On failure,
+   bisect with the printed probe permutation, drop the culprit commit, report.
    Do not retry with variations.
 4. End of shader (all sections done): one Tier-1 run over the `stratified` list
    as a belt-and-braces check (catches include-resolution surprises that /P

--- a/docs/development/shader-decomposition-plan.md
+++ b/docs/development/shader-decomposition-plan.md
@@ -1,0 +1,176 @@
+# Shader decomposition & compile-time plan
+
+Execution plan for restructuring the monolithic base shaders. Written to be executed
+by lower-capability agents: every step is mechanical, gated by a tool that returns
+a binary verdict, and has an explicit stop-and-escalate condition. No step asks the
+executing agent to judge whether a bytecode difference "looks okay."
+
+## Honest framing — what each goal can and cannot buy
+
+The request couples three goals: **maintainability**, **byte-identical**, and
+**cuts compile time**. They do not all come from the same transforms:
+
+| Transform                                                                            | Maintainability | Byte-identical                                  | Compile time                                           | Lower-model safe                    |
+| ------------------------------------------------------------------------------------ | --------------- | ----------------------------------------------- | ------------------------------------------------------ | ----------------------------------- |
+| Cut-paste decomposition into `.hlsli` sections                                       | ✅ large        | ✅ guaranteed (same preprocessed text)          | ≈0 (parse cost is noise; fxc cost is optimization)     | ✅                                  |
+| Tightening `#if` guards so permutation-dead code isn't parsed/optimized              | ➖ mild         | ✅ when the code was dead (fxc DCE'd it anyway) | ✅ modest — must be measured, not assumed              | ✅ with the gate                    |
+| Restructuring live code (register-lifetime narrowing, loop-ization, MTLand×TRUE_PBR) | ➖              | ❌ bytecode **will** differ                     | ✅ this is where the 180s permutations actually shrink | ❌ — escalate (issue #149, Phase 3) |
+
+So: Phases 1–2 below are the lower-model program — they deliver maintainability
+plus a _measured, probably modest_ compile-time win, with a hard byte-identical
+gate. The big compile-time win (MTLand×TRUE_PBR and friends) is **out of scope
+for the subagent fleet** and stays in #149 as senior/high-capability work, because
+it cannot be byte-identical and verification shifts to asm review + runtime A/B
+(`tools/taa-renderdoc-ab.py`, SE+VR in-game). Any plan claiming all three goals
+from one mechanical pass would be lying about one of them.
+
+## Measured cost surface (what to attack)
+
+The runtime emits per-permutation `[ShaderTiming]` lines (compile ms, define
+set) to `CommunityShaders.log`. A full recompile measured 2026-06-11 (SE and VR
+logs) gives the real baseline:
+
+| Shader:Class       | SE perms |        SE total | VR perms |         VR total |
+| ------------------ | -------: | --------------: | -------: | ---------------: |
+| **Lighting:Pixel** |      552 | **9550s (98%)** |      774 | **11891s (98%)** |
+| Water:Pixel        |      348 |             88s |      352 |              65s |
+| Utility:Vertex     |      340 |             57s |      372 |              65s |
+| Utility:Pixel      |      165 |             27s |      183 |              27s |
+| Effect:Pixel       |      914 |             21s |      930 |              18s |
+| everything else    |          |            <20s |          |             <20s |
+
+**Compile time is a Lighting:Pixel monoculture.** Entry counts mislead — Effect
+has 2.5× Lighting's permutations but 0.2% of its cost. Therefore: compile-time
+claims (Phase 2) target **Lighting only**; decomposition of Water/Effect/
+Utility/RunGrass is justified as maintainability only.
+
+Within Lighting:Pixel (SE): median 12.1s, max 251s.
+
+-   **LANDSCAPE/MULTI_TEXTURE: 16 perms × ~191s mean = 3063s = 32%** of the cost.
+    The slowest perm (251s) has **no TRUE_PBR** — the scheduler folklore
+    ("MTLand×TRUE_PBR ≥180s") over-credits PBR; the multi-texture landscape path
+    combined with the full feature stack (WETNESS/WATER/VOLUMETRIC_SHADOWS/SSS/…
+    common defines present in every perm) is the cost. TRUE_PBR's marginal mean
+    is +10.8s (26.5s with vs 15.7s without); ANISO_LIGHTING +6.5s; GLINT 49.4s
+    mean over 24 perms.
+-   **The long tail dominates: 351 perms at 10–60s = 5670s = 59%.** Landscape
+    fixes alone cap out at ~32%; general Lighting slimming (cutting what each
+    permutation parses/optimizes) attacks the 59%.
+
+Caveat: log timings reflect that machine's flags (developer-mode logs may add
+`D3DCOMPILE_DEBUG`); treat them as the targeting map, and re-baseline with the
+Phase-0 bench at release parity before claiming any `perf:` number.
+
+## Verification tiers (cheap → expensive)
+
+-   **Tier 0 — preprocessed-text compare**: `fxc /P` both revisions, strip `#line`
+    directives, byte-compare. Identical preprocessed text ⇒ identical bytecode at
+    every optimization level (fxc embeds no file/line info without `/Zi`). This is
+    the gate for pure cut-paste moves and runs in milliseconds per permutation, so
+    it can sweep the **full** entry list of a shader cheaply.
+-   **Tier 1 — DXBC SHA-256 compare**: `tools/verify-shader-refactor.ps1`.
+    ⚠️ Its **default sweep (VR × HDR_OUTPUT) is far too weak** for the big four —
+    it compiles a near-empty permutation. Executing agents must pass an explicit
+    `-Permutations` list generated from the validation YAML (Phase 0 tool).
+-   **Tier 2 — asm diff**: exists in the verify script, but at lower-model
+    capability the rule is absolute: **DIFFERS ⇒ revert the step and escalate.
+    Never eyeball-approve an asm diff.**
+
+Timing measurements (not correctness) must use **release-parity flags**
+(`/O3`, no `D3DCOMPILE_DEBUG`/`SKIP_OPTIMIZATION`) — the validation config's
+debug flags make compiles artificially fast and would understate every number.
+
+## Phase 0 — Tooling + triage baseline (one capable agent, sequential)
+
+Deliverables, each small and testable:
+
+1. **Permutation-list generator** (`tools/gen-verify-perms.py` or `.ps1`): reads
+   `.github/configs/shader-validation.yaml` (and the VR variant), emits per-shader
+   `-Permutations` lists for the verify script — `common_defines` minus the
+   `D3DCOMPILE_*` pseudo-defines, plus each entry's defines. Two outputs per
+   shader: `full` (every entry) and `stratified` (~20 entries: every define
+   symbol covered at least once + all scheduler-named hot combos + a fixed-seed
+   sample). Fixed seed so re-runs are reproducible.
+2. **Tier-0 mode for the verify script** (`-PreprocessOnly`): `fxc /P`, strip
+   `^#line.*$`, compare. Exit semantics unchanged (0 identical / 2 differs).
+3. **Compile-time bench** (`tools/shader-compile-bench.ps1`): for a shader and a
+   permutation list, compile at release parity, record wall-time per entry, emit
+   CSV + a ranked table. Given the measured monoculture, the `full` baseline run
+   only needs **Lighting** (others optional). This is the baseline all later
+   "compile time improved" claims diff against — without it, no `perf:` claims.
+4. **ShaderTiming log parser** (can live in the bench script as a mode): parse
+   `[ShaderTiming]` lines from a `CommunityShaders.log` into the same CSV shape,
+   so in-game recompiles double as measurements.
+5. Post the baseline table to the tracking issue.
+
+## Phase 1 — Byte-identical decomposition (parallel subagents, per work unit)
+
+Goal: each monolith becomes an orchestrating top file plus section `.hlsli`
+files, e.g. `Lighting.hlsl` → `LightingVS.hlsli`, `LightingLandscape.hlsli`,
+`LightingPBR.hlsli`, … (exact split decided per shader by reading the existing
+`#ifdef VSHADER` / `#ifdef PSHADER` / technique-block structure).
+
+**Work-unit contract** (what each subagent gets and must do):
+
+1. Input: shader file, an explicit line range constituting one section, the
+   target `.hlsli` name, the shader's `stratified` and `full` permutation lists.
+2. Transform: **pure cut-paste**. Move the lines verbatim into the new file;
+   leave `#include "NewSection.hlsli"` at the original site. No reordering, no
+   renaming, no whitespace/comment edits, no "while I'm here" fixes. One section
+   per commit.
+3. Gate: Tier 0 over the **full** permutation list (cheap). Exit 0 ⇒ commit.
+   Exit non-zero ⇒ `git checkout` the touched files, report the failure, stop.
+   Do not retry with variations.
+4. End of shader (all sections done): one Tier-1 run over the `stratified` list
+   as a belt-and-braces check (catches include-resolution surprises that /P
+   could mask), plus `hlslkit-compile` on that shader for warning parity.
+5. Forbidden: editing `Common/*.hlsli` shared by other shaders (separate,
+   sequential work units if ever needed); touching `featuresIndices` /
+   descriptor logic; editing more than the assigned range.
+
+Parallelization: shaders are independent (Lighting ∥ Water ∥ Effect ∥ Utility ∥
+RunGrass); **sections within one shader are sequential** (each move shifts line
+numbers). One subagent per shader, sections in order, is the right shape.
+
+Expected outcome stated honestly: maintainability only. Compile time unchanged
+(±noise) — say so in the PR rather than implying a perf win. Type: `refactor:`.
+
+## Phase 2 — Byte-identical permutation slimming (parallel, gated)
+
+After decomposition, wrap each section include in the preprocessor condition
+under which its code can contribute at all (most sections already sit under
+technique/flag `#if`s — this phase tightens the leaks: declarations, helpers,
+and feature blocks that are referenced by nothing in a given permutation).
+
+-   Gate per change: **Tier 1 over the full list** (Tier 0 cannot pass here —
+    preprocessed text legitimately shrinks; bytecode must not change). DIFFERS on
+    any entry ⇒ revert + escalate; the code wasn't dead.
+-   Measure: re-run the Phase-0 bench on the shader; report delta vs baseline.
+    If the win is <5% — report that honestly and stop slimming that shader; do
+    not chase noise.
+-   This is the only lower-model phase that can legitimately claim compile-time
+    improvement, and only with the bench numbers attached (`perf:` rules in
+    CLAUDE.md apply; normalize to what users feel: boot/recompile wall time).
+
+## Phase 3 — Hot-permutation restructuring (escalation only — NOT fleet work)
+
+MTLand×TRUE_PBR lifetime-narrowing, accumulate-and-discard layer blending, any
+`Texture2DArray`/loop-ization (issue #149 Levels A/B). Bytecode **will** differ;
+verification is Tier-2 asm review + runtime A/B on SE and VR landscape scenes +
+senior review. A lower-capability agent reaching a DIFFERS verdict in Phases 1–2
+hands the case here; it never self-approves.
+
+## Sequencing & risk notes
+
+-   Phase 0 → Phase 1 strictly; Phase 2 needs both (the bench for measurement,
+    the decomposition for clean guard points).
+-   Land per shader, smallest first (`RunGrass` or `Utility`) to shake out the
+    tooling before `Lighting`.
+-   Every PR: `refactor(shaders): …` (Phase 1) or `perf(shaders): …` with bench
+    numbers (Phase 2); note in the description that DXBC was verified identical
+    and over which permutation list.
+-   Cache interaction: byte-identical refactors still bump the source `.hlsl`
+    mtime ⇒ users recompile once per landed PR. Batch sections per shader into
+    one PR to avoid repeated mass recompiles (see issue #148 for the cache half).
+-   VR: the same gate covers VR — the generated lists include the VR validation
+    config's entries; no separate VR pass needed in Phases 1–2.

--- a/docs/development/shader-decomposition-plan.md
+++ b/docs/development/shader-decomposition-plan.md
@@ -94,9 +94,13 @@ post-hook re-runs, burned ~an hour per shader on redundant sweeps. The protocol:
    `git bisect run` re-testing only that one permutation
    (`-Permutations "<failing>"`) finds the culprit commit in log₂(N) steps of
    seconds each. Drop or fix it, then one final full-list run as the PR proof.
-4. Don't re-gate after clang-format hook reformatting — Tier 0 is
-   whitespace-immune by construction (fxc `/P` retokenizes); spot-check one
-   permutation if paranoid.
+4. ALWAYS re-gate after the clang-format hook touches a file. The hook is NOT
+   whitespace-only: it sorts adjacent `#include` lines (it once swapped
+   `LightingPS_Resources` after `_Helpers`, putting functions before the
+   declarations they use — caught only because Tier 0 hashes are
+   order-sensitive). When two includes must keep a semantic order, separate
+   them with a comment line so the sorter sees two blocks. The re-gate costs
+   seconds with the parallel cached gate, so there is no reason to skip it.
 
 The verify script is parallel (`-Jobs`, default cores−2) and caches the
 base-ref side per SHA (`build/verify-cache/`). Measured on Lighting: full

--- a/tools/gen-verify-perms.py
+++ b/tools/gen-verify-perms.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Generate permutation lists for verify-shader-refactor.ps1 / shader-compile-bench.ps1.
+
+Reads the shader-validation YAML configs (the game-log-derived permutation matrix)
+and emits, per shader and stage, plain-text permutation files: one space-separated
+define set per line. These feed the verify script's -PermutationsFile (Tier 0/1
+gates) and the bench script -- the verify script's built-in default sweep
+(VR x HDR_OUTPUT) is far too weak for the big shaders.
+
+Outputs per shader+stage:
+  <out>/<Shader>.<STAGE>.full.txt        every entry from every config (deduped)
+  <out>/<Shader>.<STAGE>.stratified.txt  small reproducible subset: every define
+                                         symbol covered + known-hot combos + a
+                                         fixed-seed sample
+
+D3DCOMPILE_* pseudo-defines (hlslkit compile *flags*, not preprocessor defines)
+are stripped. Pass the produced file to fxc-based tools with the matching
+profile (PSHADER->ps_5_0, VSHADER->vs_5_0, CSHADER->cs_5_0), entry "main".
+
+Usage:
+  python tools/gen-verify-perms.py [--shader Lighting.hlsl] [--out build/verify-perms]
+         [--config <yaml> ...] [--stratified-size 24]
+"""
+
+import argparse
+import random
+import sys
+from pathlib import Path
+
+import yaml
+
+# Define groups that dominate compile cost (measured via [ShaderTiming] log data,
+# see docs/development/shader-decomposition-plan.md). Every stratified list must
+# cover each hot symbol that appears anywhere in the shader's full list.
+HOT_SYMBOLS = [
+    "MULTI_TEXTURE",
+    "LANDSCAPE",
+    "LOD_LAND_BLEND",
+    "TRUE_PBR",
+    "ANISO_LIGHTING",
+    "GLINT",
+    "DEFERRED",
+]
+
+
+def strip_pseudo(defines):
+    return [d for d in defines if not d.startswith("D3DCOMPILE_")]
+
+
+def load_perms(config_paths, shader_file):
+    """Return {stage: [frozenset(defines), ...]} merged across configs, order-preserving."""
+    perms = {}
+    seen = {}
+    for cfg_path in config_paths:
+        cfg = yaml.safe_load(open(cfg_path, encoding="utf-8"))
+        for shader in cfg.get("shaders", []):
+            if shader["file"] != shader_file:
+                continue
+            for stage, scfg in (shader.get("configs") or {}).items():
+                common = strip_pseudo(scfg.get("common_defines") or [])
+                for e in scfg.get("entries") or []:
+                    defs = frozenset(common) | frozenset(strip_pseudo(e.get("defines") or []))
+                    if defs not in seen.setdefault(stage, set()):
+                        seen[stage].add(defs)
+                        perms.setdefault(stage, []).append(defs)
+    return perms
+
+
+def symbol(define):
+    return define.split("=", 1)[0]
+
+
+def stratify(full, size, seed=0):
+    """Greedy cover of every define symbol, then hot combos, then a seeded sample."""
+    picked = []
+    covered = set()
+    all_symbols = {symbol(d) for p in full for d in p}
+
+    # 1) Hot symbols first: take the LARGEST perm containing each (worst-case cost).
+    for hot in HOT_SYMBOLS:
+        if hot not in all_symbols:
+            continue
+        candidates = [p for p in full if any(symbol(d) == hot for d in p) and p not in picked]
+        if candidates:
+            best = max(candidates, key=len)
+            picked.append(best)
+            covered |= {symbol(d) for d in best}
+
+    # 2) Greedy set-cover for the remaining symbols.
+    while covered < all_symbols and len(picked) < size:
+        best = max(
+            (p for p in full if p not in picked),
+            key=lambda p: len({symbol(d) for d in p} - covered),
+            default=None,
+        )
+        if best is None or not ({symbol(d) for d in best} - covered):
+            break
+        picked.append(best)
+        covered |= {symbol(d) for d in best}
+
+    # 3) Fixed-seed fill so re-runs are reproducible.
+    rng = random.Random(seed)
+    pool = [p for p in full if p not in picked]
+    rng.shuffle(pool)
+    picked.extend(pool[: max(0, size - len(picked))])
+    return picked
+
+
+def fmt(perm):
+    return " ".join(sorted(perm))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--shader", action="append", help="shader file name(s), e.g. Lighting.hlsl; default: all")
+    ap.add_argument(
+        "--config",
+        action="append",
+        help="validation YAML(s); default: .github/configs/shader-validation.yaml + -vr.yaml",
+    )
+    ap.add_argument("--out", default="build/verify-perms", help="output directory")
+    ap.add_argument("--stratified-size", type=int, default=24)
+    args = ap.parse_args()
+
+    repo = Path(__file__).resolve().parent.parent
+    configs = args.config or [
+        str(repo / ".github/configs/shader-validation.yaml"),
+        str(repo / ".github/configs/shader-validation-vr.yaml"),
+    ]
+
+    shader_files = args.shader
+    if not shader_files:
+        names = set()
+        for c in configs:
+            for s in yaml.safe_load(open(c, encoding="utf-8")).get("shaders", []):
+                names.add(s["file"])
+        shader_files = sorted(names)
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    wrote = 0
+    for sf in shader_files:
+        perms = load_perms(configs, sf)
+        if not perms:
+            print(f"WARN: no entries for {sf} in {configs}", file=sys.stderr)
+            continue
+        stem = Path(sf).stem
+        for stage, full in perms.items():
+            strat = stratify(full, args.stratified_size)
+            for kind, plist in (("full", full), ("stratified", strat)):
+                path = out_dir / f"{stem}.{stage}.{kind}.txt"
+                path.write_text("\n".join(fmt(p) for p in plist) + "\n", encoding="utf-8")
+                wrote += 1
+            print(f"{stem}.{stage}: full={len(full)} stratified={len(strat)}")
+    if not wrote:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/shader-compile-bench.ps1
+++ b/tools/shader-compile-bench.ps1
@@ -1,0 +1,153 @@
+<#
+.SYNOPSIS
+    Measure shader compile times: offline fxc bench or CommunityShaders.log parse.
+
+.DESCRIPTION
+    Two modes, one CSV shape (shader,stage,ms,defines) so in-game recompiles and
+    offline benches are directly comparable:
+
+    1) Bench mode (-Shader + -PermutationsFile): compiles each permutation with
+       fxc at RELEASE PARITY (/O3, no debug flags) -- matching the game's runtime
+       compile for users -- and records wall-time per permutation. This is the
+       baseline that perf claims for compile-time refactors must diff against;
+       the validation configs' D3DCOMPILE_DEBUG/SKIP_OPTIMIZATION flags make
+       compiles artificially fast and must not be used for timing.
+
+    2) Log mode (-FromLog): parses [ShaderTiming] lines emitted by the runtime
+       into the same CSV, so any in-game recompile doubles as a measurement run.
+
+.PARAMETER Shader
+    Path to the .hlsl file (bench mode).
+
+.PARAMETER PermutationsFile
+    One space-separated define set per line (tools/gen-verify-perms.py output).
+
+.PARAMETER FromLog
+    Path to a CommunityShaders.log containing [ShaderTiming] lines (log mode).
+
+.PARAMETER OutCsv
+    CSV output path. Default: shader-bench.csv (bench) / <log>.timing.csv (log).
+
+.PARAMETER Profile
+    fxc target profile (bench mode). Default: auto (cs_5_0 for *CS.hlsl, else
+    ps_5_0; pass vs_5_0 explicitly for VSHADER permutation lists).
+
+.PARAMETER Top
+    How many slowest entries to print in the summary. Default 15.
+
+.EXAMPLE
+    pwsh tools/shader-compile-bench.ps1 -Shader package/Shaders/Lighting.hlsl `
+        -PermutationsFile build/verify-perms/Lighting.PSHADER.full.txt
+
+.EXAMPLE
+    pwsh tools/shader-compile-bench.ps1 -FromLog "$env:USERPROFILE\Documents\My Games\Skyrim Special Edition\SKSE\CommunityShaders.log"
+#>
+[CmdletBinding(DefaultParameterSetName = "Bench")]
+param(
+    [Parameter(ParameterSetName = "Bench", Mandatory = $true)]
+    [string]$Shader,
+    [Parameter(ParameterSetName = "Bench", Mandatory = $true)]
+    [string]$PermutationsFile,
+    [Parameter(ParameterSetName = "Log", Mandatory = $true)]
+    [string]$FromLog,
+    [string]$OutCsv,
+    [string]$IncludeDir = "package/Shaders",
+    [string]$Entry = "main",
+    [string]$Profile,
+    [string]$Fxc,
+    [int]$Top = 15
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Summary([object[]]$rows, [string]$csv) {
+    $rows | Export-Csv -NoTypeInformation -Encoding UTF8 $csv
+    $total = ($rows | Measure-Object ms -Sum).Sum
+    Write-Host ("rows={0}  total={1:N0}s  csv={2}" -f $rows.Count, ($total / 1000), $csv)
+    Write-Host "-- by shader:stage --"
+    $rows | Group-Object { "$($_.shader):$($_.stage)" } | ForEach-Object {
+        [pscustomobject]@{ key = $_.Name; n = $_.Count; totalS = [math]::Round((($_.Group | Measure-Object ms -Sum).Sum) / 1000, 1) }
+    } | Sort-Object totalS -Descending | Format-Table -AutoSize | Out-String | Write-Host
+    Write-Host "-- slowest $Top --"
+    $rows | Sort-Object ms -Descending | Select-Object -First $Top |
+        ForEach-Object { Write-Host ("{0,9:N1}s  {1}:{2}  {3}" -f ($_.ms / 1000), $_.shader, $_.stage, $_.defines.Substring(0, [Math]::Min(110, $_.defines.Length))) }
+}
+
+if ($PSCmdlet.ParameterSetName -eq "Log") {
+    if (-not (Test-Path $FromLog)) { throw "Log '$FromLog' not found." }
+    if (-not $OutCsv) { $OutCsv = "$FromLog.timing.csv" }
+    $pat = [regex]'\[ShaderTiming\] (\d+)ms \|.*?\| (\S+?):(\S+?):(.*)$'
+    $rows = foreach ($line in [IO.File]::ReadLines($FromLog)) {
+        $m = $pat.Match($line)
+        if ($m.Success) {
+            [pscustomobject]@{
+                shader  = $m.Groups[2].Value
+                stage   = $m.Groups[3].Value
+                ms      = [int]$m.Groups[1].Value
+                defines = $m.Groups[4].Value.Trim()
+            }
+        }
+    }
+    if (-not $rows) { throw "No [ShaderTiming] lines found in '$FromLog' (debug logging must be enabled)." }
+    Write-Summary $rows $OutCsv
+    exit 0
+}
+
+# ---- bench mode ----
+function Resolve-Fxc {
+    if ($Fxc -and (Test-Path $Fxc)) { return $Fxc }
+    $cmd = Get-Command fxc.exe -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+    $roots = @("${env:ProgramFiles(x86)}\Windows Kits\10\bin", "${env:ProgramFiles}\Windows Kits\10\bin")
+    $found = foreach ($r in $roots) {
+        if (Test-Path $r) {
+            Get-ChildItem -Path $r -Recurse -Filter fxc.exe -ErrorAction SilentlyContinue |
+                Where-Object { $_.FullName -match "x64" }
+        }
+    }
+    $pick = $found | Sort-Object FullName -Descending | Select-Object -First 1
+    if (-not $pick) { throw "fxc.exe not found. Install the Windows 10/11 SDK or pass -Fxc." }
+    return $pick.FullName
+}
+
+$fxcPath = Resolve-Fxc
+if (-not (Test-Path $Shader)) { throw "Shader '$Shader' not found." }
+if (-not (Test-Path $PermutationsFile)) { throw "Permutations file '$PermutationsFile' not found." }
+if (-not $Profile) { $Profile = if ($Shader -match 'CS\.hlsl$') { "cs_5_0" } else { "ps_5_0" } }
+if (-not $OutCsv) { $OutCsv = "shader-bench.csv" }
+
+$shaderName = [IO.Path]::GetFileNameWithoutExtension($Shader)
+$stage = switch -Wildcard ($Profile) { "cs_*" { "Compute" } "vs_*" { "Vertex" } default { "Pixel" } }
+$perms = @(Get-Content $PermutationsFile | ForEach-Object { $_.Trim() } |
+        Where-Object { $_ -and -not $_.StartsWith('#') })
+if (-not $perms) { throw "No permutations in '$PermutationsFile'." }
+
+$tmp = Join-Path ([IO.Path]::GetTempPath()) ("shaderbench_" + [Guid]::NewGuid().ToString("N") + ".cso")
+Write-Host "Bench: $Shader  profile=$Profile  perms=$($perms.Count)  flags=/O3 (release parity)"
+$rows = New-Object System.Collections.Generic.List[object]
+$i = 0
+try {
+    foreach ($perm in $perms) {
+        $i++
+        $defArgs = @()
+        foreach ($d in ($perm -split '\s+' | Where-Object { $_ })) {
+            $defArgs += "/D"
+            $defArgs += $(if ($d -like '*=*') { $d } else { "$d=1" })
+        }
+        $sw = [Diagnostics.Stopwatch]::StartNew()
+        $null = & $fxcPath /nologo /O3 /T $Profile /E $Entry @defArgs /I $IncludeDir $Shader /Fo $tmp 2>&1
+        $sw.Stop()
+        $ok = ($LASTEXITCODE -eq 0)
+        $rows.Add([pscustomobject]@{
+                shader  = $shaderName
+                stage   = $stage
+                ms      = [int]$sw.ElapsedMilliseconds
+                defines = $perm + $(if (-not $ok) { " [COMPILE-ERROR]" })
+            })
+        Write-Host ("[{0}/{1}] {2,8:N1}s {3} {4}" -f $i, $perms.Count, ($sw.ElapsedMilliseconds / 1000), $(if ($ok) { "ok " } else { "ERR" }), $perm.Substring(0, [Math]::Min(90, $perm.Length)))
+    }
+}
+finally {
+    Remove-Item $tmp -ErrorAction SilentlyContinue
+}
+Write-Summary $rows.ToArray() $OutCsv

--- a/tools/shader-compile-bench.ps1
+++ b/tools/shader-compile-bench.ps1
@@ -51,7 +51,7 @@ param(
     [Parameter(ParameterSetName = "Log", Mandatory = $true)]
     [string]$FromLog,
     [string]$OutCsv,
-    [string]$IncludeDir = "package/Shaders",
+    [string[]]$IncludeDir,
     [string]$Entry = "main",
     [string]$Profile,
     [string]$Fxc,
@@ -112,6 +112,14 @@ function Resolve-Fxc {
 
 $fxcPath = Resolve-Fxc
 if (-not (Test-Path $Shader)) { throw "Shader '$Shader' not found." }
+# The game compiles against the MERGED tree (package/Shaders + every feature's
+# Shaders dir deployed together), so feature includes like
+# "WaterEffects/WaterCaustics.hlsli" need each features/*/Shaders as a root.
+if (-not $IncludeDir) {
+    $IncludeDir = @("package/Shaders") + @(Get-ChildItem -Directory "features" -ErrorAction SilentlyContinue |
+            ForEach-Object { Join-Path $_.FullName "Shaders" } | Where-Object { Test-Path $_ })
+}
+$incArgs = @(); foreach ($d in $IncludeDir) { $incArgs += "/I"; $incArgs += $d }
 if (-not (Test-Path $PermutationsFile)) { throw "Permutations file '$PermutationsFile' not found." }
 if (-not $Profile) { $Profile = if ($Shader -match 'CS\.hlsl$') { "cs_5_0" } else { "ps_5_0" } }
 if (-not $OutCsv) { $OutCsv = "shader-bench.csv" }
@@ -135,7 +143,12 @@ try {
             $defArgs += $(if ($d -like '*=*') { $d } else { "$d=1" })
         }
         $sw = [Diagnostics.Stopwatch]::StartNew()
-        $null = & $fxcPath /nologo /O3 /T $Profile /E $Entry @defArgs /I $IncludeDir $Shader /Fo $tmp 2>&1
+        # PS 5.1 wraps native stderr in ErrorRecords when redirected; under
+        # ErrorActionPreference=Stop that aborts the run instead of logging the row.
+        $prevEap = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
+        $null = & $fxcPath /nologo /O3 /T $Profile /E $Entry @defArgs @incArgs $Shader /Fo $tmp 2>&1
+        $ErrorActionPreference = $prevEap
         $sw.Stop()
         $ok = ($LASTEXITCODE -eq 0)
         $rows.Add([pscustomobject]@{

--- a/tools/verify-shader-refactor.ps1
+++ b/tools/verify-shader-refactor.ps1
@@ -314,6 +314,18 @@ try {
                 Write-Host ("    [{0}] {1}" -f $mark, $_.InputObject)
             }
             if (@($d).Count -gt 30) { Write-Host ("    ... (+{0} more lines)" -f (@($d).Count - 30)) }
+        } elseif ($PreprocessOnly) {
+            # Compare-Object is multiset-based: a pure line REORDER (e.g. clang-format
+            # sorting adjacent #includes) yields an empty diff. Show first order divergence.
+            $bl = @($rb.Lines); $wl = @($rw.Lines)
+            for ($i = 0; $i -lt [Math]::Min($bl.Count, $wl.Count); $i++) {
+                if ($bl[$i] -cne $wl[$i]) {
+                    Write-Host "    (same lines, different ORDER — first divergence:)" -ForegroundColor Yellow
+                    Write-Host ("    [base@{0}] {1}" -f $i, $bl[$i])
+                    Write-Host ("    [work@{0}] {1}" -f $i, $wl[$i])
+                    break
+                }
+            }
         }
     }
 

--- a/tools/verify-shader-refactor.ps1
+++ b/tools/verify-shader-refactor.ps1
@@ -27,7 +27,9 @@
     Git ref to treat as "before". Default: merge-base of HEAD and origin/dev.
 
 .PARAMETER IncludeDir
-    Shader include root passed to fxc /I. Default: package/Shaders.
+    Shader include root(s) passed to fxc /I. Default: package/Shaders plus every
+    features/*/Shaders dir, mirroring the merged tree the game compiles against
+    (Lighting and friends include feature .hlsli files).
 
 .PARAMETER Permutations
     Optional explicit permutation list; each entry is a space-separated define set,
@@ -63,7 +65,7 @@ param(
     [Parameter(Mandatory = $true, Position = 0)]
     [string]$Shader,
     [string]$BaseRef,
-    [string]$IncludeDir = "package/Shaders",
+    [string[]]$IncludeDir,
     [string[]]$Permutations,
     [string]$PermutationsFile,
     [switch]$PreprocessOnly,
@@ -114,6 +116,15 @@ try {
         if (-not $BaseRef) { $BaseRef = "HEAD" }
     }
 
+    # The game compiles against the MERGED tree (package/Shaders + every feature's
+    # Shaders dir deployed together), so feature includes like
+    # "WaterEffects/WaterCaustics.hlsli" need each features/*/Shaders as a root.
+    if (-not $IncludeDir) {
+        $IncludeDir = @("package/Shaders") + @(Get-ChildItem -Directory "features" -ErrorAction SilentlyContinue |
+                ForEach-Object { "features/$($_.Name)/Shaders" } | Where-Object { Test-Path $_ })
+    }
+    $IncludeDir = @($IncludeDir | ForEach-Object { $_.Replace('\', '/').TrimEnd('/') })
+
     if (-not $Profile) {
         $Profile = if ($relPath -match 'CS\.hlsl$') { "cs_5_0" } else { "ps_5_0" }
     }
@@ -146,14 +157,14 @@ try {
     $baseRoot = Join-Path $work "base"
     New-Item -ItemType Directory -Force $baseRoot | Out-Null
     $tar = Join-Path $work "base.tar"
-    git archive --format=tar -o $tar $BaseRef -- $IncludeDir $relPath 2>$null
+    git archive --format=tar -o $tar $BaseRef -- @IncludeDir $relPath 2>$null
     if ($LASTEXITCODE -ne 0 -or -not (Test-Path $tar)) {
-        throw "git archive failed for '$BaseRef' (paths: $IncludeDir, $relPath)."
+        throw "git archive failed for '$BaseRef' (paths: $($IncludeDir -join ', '), $relPath)."
     }
     tar -xf $tar -C $baseRoot
     if ($LASTEXITCODE -ne 0) { throw "Failed to extract base archive." }
     $baseFile = Join-Path $baseRoot $relPath
-    $baseInclude = Join-Path $baseRoot $IncludeDir
+    $baseInclude = @($IncludeDir | ForEach-Object { Join-Path $baseRoot $_ })
     if (-not (Test-Path $baseFile)) { throw "'$relPath' not found at '$BaseRef'." }
 
     function DefineArgs([string]$defs) {
@@ -166,19 +177,27 @@ try {
         return $defArgs
     }
 
-    function Compile([string]$src, [string]$incDir, [string]$defs, [string]$outFile, [switch]$Asm) {
+    function IncludeArgs([string[]]$incDirs) {
+        $incArgs = @()
+        foreach ($d in $incDirs) { $incArgs += "/I"; $incArgs += $d }
+        return $incArgs
+    }
+
+    function Compile([string]$src, [string[]]$incDirs, [string]$defs, [string]$outFile, [switch]$Asm) {
         $defArgs = DefineArgs $defs
+        $incArgs = IncludeArgs $incDirs
         $fmt = if ($Asm) { "/Fc" } else { "/Fo" }
-        $out = & $fxcPath /nologo /T $Profile /E $Entry @defArgs /I $incDir $src $fmt $outFile 2>&1
+        $out = & $fxcPath /nologo /T $Profile /E $Entry @defArgs @incArgs $src $fmt $outFile 2>&1
         return @{ Code = $LASTEXITCODE; Out = $out }
     }
 
     # Tier 0: preprocessed text with #line directives stripped. Identical text =>
     # identical DXBC at any optimization level (fxc embeds no file/line without /Zi),
     # so cut-paste moves between files verify in milliseconds per permutation.
-    function PreprocessLines([string]$src, [string]$incDir, [string]$defs, [string]$outFile) {
+    function PreprocessLines([string]$src, [string[]]$incDirs, [string]$defs, [string]$outFile) {
         $defArgs = DefineArgs $defs
-        $out = & $fxcPath /nologo /P $outFile @defArgs /I $incDir $src 2>&1
+        $incArgs = IncludeArgs $incDirs
+        $out = & $fxcPath /nologo /P $outFile @defArgs @incArgs $src 2>&1
         if ($LASTEXITCODE -ne 0) { return @{ Code = $LASTEXITCODE; Out = $out } }
         # Also drop blank lines and trailing whitespace: include-boundary expansion
         # shifts them, and neither can affect tokenization (no line-splices survive /P).
@@ -190,7 +209,7 @@ try {
     Write-Host "Shader   : $relPath"
     Write-Host "Base ref : $BaseRef  (full include tree materialized)"
     Write-Host "Profile  : $Profile  (entry $Entry)"
-    Write-Host "Include  : $IncludeDir"
+    Write-Host "Include  : $($IncludeDir.Count) roots (package/Shaders + features/*/Shaders)"
     Write-Host ("-" * 60)
 
     $allIdentical = $true

--- a/tools/verify-shader-refactor.ps1
+++ b/tools/verify-shader-refactor.ps1
@@ -320,7 +320,7 @@ try {
             $bl = @($rb.Lines); $wl = @($rw.Lines)
             for ($i = 0; $i -lt [Math]::Min($bl.Count, $wl.Count); $i++) {
                 if ($bl[$i] -cne $wl[$i]) {
-                    Write-Host "    (same lines, different ORDER — first divergence:)" -ForegroundColor Yellow
+                    Write-Host "    (same lines, different ORDER - first divergence:)" -ForegroundColor Yellow
                     Write-Host ("    [base@{0}] {1}" -f $i, $bl[$i])
                     Write-Host ("    [work@{0}] {1}" -f $i, $wl[$i])
                     break

--- a/tools/verify-shader-refactor.ps1
+++ b/tools/verify-shader-refactor.ps1
@@ -18,7 +18,14 @@
 
     A refactor that is Tier-1 IDENTICAL on the swept permutations needs no further proof.
     Note: the default sweep (VR x HDR_OUTPUT) is strong evidence, not the full build
-    matrix from shader-validation.yaml. Pass -Permutations for exotic define combos.
+    matrix from shader-validation.yaml. Pass -PermutationsFile for the real matrix.
+
+    Batch + bisect workflow (the efficient cadence for many changes): apply a whole
+    batch of commits, run this once with -FailFast. On DIFFERS it prints the failing
+    permutation; use `git bisect run` with that single permutation (-Permutations
+    "<failing>") as the probe -- seconds per bisect step -- then one final full-list
+    run on the clean batch. Base-side compile results are cached per base SHA under
+    build/verify-cache/, so repeat runs only pay for the work side.
 
 .PARAMETER Shader
     Path to the .hlsl file (repo-relative or absolute).
@@ -41,12 +48,25 @@
     sweep. Use this for the big shaders -- the default sweep is far too weak there.
 
 .PARAMETER PreprocessOnly
-    Tier-0 gate: compare fxc /P preprocessed output (with #line directives
-    stripped) instead of compiled DXBC. Identical preprocessed text proves
-    identical bytecode at every optimization level, and runs in milliseconds per
-    permutation, so it can sweep a full permutation list cheaply. Only valid for
-    refactors that don't change the preprocessed text (pure cut-paste moves);
-    a legitimate guard-tightening change must use the default DXBC compare.
+    Tier-0 gate: compare fxc /P preprocessed output (with #line directives and
+    blank lines stripped) instead of compiled DXBC. Identical preprocessed text
+    proves identical bytecode at every optimization level, and runs in milliseconds
+    per permutation. Only valid for refactors that don't change the preprocessed
+    text (pure cut-paste moves); a guard-tightening change must use the DXBC compare.
+
+.PARAMETER Jobs
+    Parallel fxc workers. Default 0 = auto (logical cores - 2, min 1). fxc is
+    CPU-bound and independent per permutation, so this scales nearly linearly.
+
+.PARAMETER FailFast
+    Stop at the first DIFFERS/error and print the failing permutation in a
+    re-invokable form (the bisect probe). Without it, all permutations run and
+    the first few mismatches get detail diffs.
+
+.PARAMETER NoCache
+    Skip the base-side result cache (build/verify-cache/). The cache is keyed by
+    base SHA + shader + mode + profile + entry, so it is safe by construction;
+    use this only when debugging the tool itself.
 
 .PARAMETER Entry
     Shader entry point. Default: main.
@@ -58,7 +78,8 @@
     pwsh tools/verify-shader-refactor.ps1 package/Shaders/ISTemporalAA.hlsl
 
 .EXAMPLE
-    pwsh tools/verify-shader-refactor.ps1 package/Shaders/Foo.hlsl -BaseRef HEAD~1
+    pwsh tools/verify-shader-refactor.ps1 package/Shaders/Lighting.hlsl `
+        -PermutationsFile build/verify-perms/Lighting.PSHADER.full.txt -FailFast
 #>
 [CmdletBinding()]
 param(
@@ -69,6 +90,9 @@ param(
     [string[]]$Permutations,
     [string]$PermutationsFile,
     [switch]$PreprocessOnly,
+    [int]$Jobs = 0,
+    [switch]$FailFast,
+    [switch]$NoCache,
     [string]$Entry = "main",
     [string]$Profile,
     [string]$Fxc
@@ -94,11 +118,52 @@ function Resolve-Fxc {
     return $pick.FullName
 }
 
+# Self-contained worker (runspaces do not inherit function scope). Compiles or
+# preprocesses one permutation and returns its content hash.
+$workerScript = {
+    param($fxc, $mode, $profile, $entry, $defs, $incDirs, $src, $outFile)
+    $defArgs = @()
+    foreach ($d in ($defs -split '\s+' | Where-Object { $_ })) {
+        $defArgs += "/D"
+        $defArgs += $(if ($d -like '*=*') { $d } else { "$d=1" })
+    }
+    $incArgs = @()
+    foreach ($i in $incDirs) { $incArgs += "/I"; $incArgs += $i }
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        if ($mode -eq 'P') {
+            $out = & $fxc /nologo /P $outFile @defArgs @incArgs $src 2>&1
+            if ($LASTEXITCODE -ne 0) { return @{ Ok = $false; Err = (($out | Out-String)) } }
+            # Strip #line directives, blank lines, trailing whitespace: none can affect
+            # tokenization (fxc embeds no file/line info without /Zi; /P retokenizes).
+            $sb = New-Object System.Text.StringBuilder
+            foreach ($line in [System.IO.File]::ReadLines($outFile)) {
+                $t = $line.TrimEnd()
+                if ($t -and $t -notmatch '^\s*#line') { [void]$sb.AppendLine($t) }
+            }
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes($sb.ToString())
+            return @{ Ok = $true; Hash = (-join ($sha.ComputeHash($bytes) | ForEach-Object { $_.ToString("x2") })) }
+        } else {
+            $out = & $fxc /nologo /T $profile /E $entry @defArgs @incArgs $src /Fo $outFile 2>&1
+            if ($LASTEXITCODE -ne 0) { return @{ Ok = $false; Err = (($out | Out-String)) } }
+            $fs = [System.IO.File]::OpenRead($outFile)
+            try { $hash = -join ($sha.ComputeHash($fs) | ForEach-Object { $_.ToString("x2") }) }
+            finally { $fs.Close() }
+            return @{ Ok = $true; Hash = $hash }
+        }
+    }
+    finally {
+        Remove-Item $outFile -ErrorAction SilentlyContinue
+        $sha.Dispose()
+    }
+}
+
 # Resolve repo root so the script works from any cwd.
 $repoRoot = (git rev-parse --show-toplevel 2>$null)
 if (-not $repoRoot) { throw "Not inside a git repository." }
 Push-Location $repoRoot
 $work = $null
+$pool = $null
 try {
     $fxcPath = Resolve-Fxc
 
@@ -115,6 +180,8 @@ try {
         $BaseRef = (git merge-base HEAD origin/dev 2>$null)
         if (-not $BaseRef) { $BaseRef = "HEAD" }
     }
+    $baseSha = (git rev-parse $BaseRef 2>$null)
+    if (-not $baseSha) { throw "Cannot resolve base ref '$BaseRef'." }
 
     # The game compiles against the MERGED tree (package/Shaders + every feature's
     # Shaders dir deployed together), so feature includes like
@@ -149,26 +216,52 @@ try {
         )
     }
 
-    # Materialize the base revision's FULL include tree (not just the target shader) so a
-    # refactor that also touches a shared .hlsli is compared correctly: base compiles against
-    # base-ref headers, work compiles against working-tree headers. git archive -> tar (via a
-    # file, never a PS pipeline, which would corrupt the binary tar).
-    $work = Join-Path ([IO.Path]::GetTempPath()) ("shaderverify_" + [Guid]::NewGuid().ToString("N"))
-    $baseRoot = Join-Path $work "base"
-    New-Item -ItemType Directory -Force $baseRoot | Out-Null
-    $tar = Join-Path $work "base.tar"
-    git archive --format=tar -o $tar $BaseRef -- @IncludeDir $relPath 2>$null
-    if ($LASTEXITCODE -ne 0 -or -not (Test-Path $tar)) {
-        throw "git archive failed for '$BaseRef' (paths: $($IncludeDir -join ', '), $relPath)."
+    if ($Jobs -le 0) { $Jobs = [Math]::Max(1, [Environment]::ProcessorCount - 2) }
+    $mode = if ($PreprocessOnly) { 'P' } else { 'O' }
+
+    # Base-side cache: the base ref is immutable, so its per-permutation hashes are
+    # reusable across runs -- repeat runs only pay for the work side.
+    $cache = @{}
+    $cacheFile = $null
+    if (-not $NoCache) {
+        $cacheDir = Join-Path $repoRoot "build/verify-cache"
+        New-Item -ItemType Directory -Force $cacheDir | Out-Null
+        $stem = [IO.Path]::GetFileNameWithoutExtension($relPath)
+        $cacheFile = Join-Path $cacheDir ("{0}.{1}.{2}.{3}.{4}.json" -f $stem, $mode, $Profile, $Entry, $baseSha.Substring(0, 12))
+        if (Test-Path $cacheFile) {
+            $json = Get-Content $cacheFile -Raw | ConvertFrom-Json
+            foreach ($p in $json.PSObject.Properties) { $cache[$p.Name] = $p.Value }
+        }
     }
-    tar -xf $tar -C $baseRoot
-    if ($LASTEXITCODE -ne 0) { throw "Failed to extract base archive." }
-    $baseFile = Join-Path $baseRoot $relPath
-    $baseInclude = @($IncludeDir | ForEach-Object { Join-Path $baseRoot $_ })
-    if (-not (Test-Path $baseFile)) { throw "'$relPath' not found at '$BaseRef'." }
+
+    $work = Join-Path ([IO.Path]::GetTempPath()) ("shaderverify_" + [Guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Force $work | Out-Null
+
+    # Materialize the base revision's FULL include tree lazily (skipped entirely when
+    # every base hash is cached). git archive -> tar via a file, never a PS pipeline,
+    # which would corrupt the binary tar.
+    $script:baseFile = $null
+    $script:baseInclude = $null
+    function Ensure-BaseTree {
+        if ($script:baseFile) { return }
+        $baseRoot = Join-Path $work "base"
+        New-Item -ItemType Directory -Force $baseRoot | Out-Null
+        $tar = Join-Path $work "base.tar"
+        git archive --format=tar -o $tar $baseSha -- @IncludeDir $relPath 2>$null
+        if ($LASTEXITCODE -ne 0 -or -not (Test-Path $tar)) {
+            throw "git archive failed for '$BaseRef' (paths: $($IncludeDir -join ', '), $relPath)."
+        }
+        tar -xf $tar -C $baseRoot
+        if ($LASTEXITCODE -ne 0) { throw "Failed to extract base archive." }
+        $script:baseFile = Join-Path $baseRoot $relPath
+        $script:baseInclude = @($IncludeDir | ForEach-Object { Join-Path $baseRoot $_ })
+        if (-not (Test-Path $script:baseFile)) { throw "'$relPath' not found at '$BaseRef'." }
+    }
+
+    $uncached = @($Permutations | Where-Object { -not $cache.ContainsKey($_) })
+    if ($uncached.Count -gt 0) { Ensure-BaseTree }
 
     function DefineArgs([string]$defs) {
-        # Preserve explicit-valued defines (e.g. SHADOWFILTER=0); only bare names get =1.
         $defArgs = @()
         foreach ($d in ($defs -split '\s+' | Where-Object { $_ })) {
             $defArgs += "/D"
@@ -176,13 +269,14 @@ try {
         }
         return $defArgs
     }
-
     function IncludeArgs([string[]]$incDirs) {
         $incArgs = @()
         foreach ($d in $incDirs) { $incArgs += "/I"; $incArgs += $d }
         return $incArgs
     }
 
+    # Sequential detail helpers, used only on mismatch (the parallel pass trades
+    # line-level detail for speed; detail is recomputed for the few failures).
     function Compile([string]$src, [string[]]$incDirs, [string]$defs, [string]$outFile, [switch]$Asm) {
         $defArgs = DefineArgs $defs
         $incArgs = IncludeArgs $incDirs
@@ -190,104 +284,137 @@ try {
         $out = & $fxcPath /nologo /T $Profile /E $Entry @defArgs @incArgs $src $fmt $outFile 2>&1
         return @{ Code = $LASTEXITCODE; Out = $out }
     }
-
-    # Tier 0: preprocessed text with #line directives stripped. Identical text =>
-    # identical DXBC at any optimization level (fxc embeds no file/line without /Zi),
-    # so cut-paste moves between files verify in milliseconds per permutation.
     function PreprocessLines([string]$src, [string[]]$incDirs, [string]$defs, [string]$outFile) {
         $defArgs = DefineArgs $defs
         $incArgs = IncludeArgs $incDirs
         $out = & $fxcPath /nologo /P $outFile @defArgs @incArgs $src 2>&1
         if ($LASTEXITCODE -ne 0) { return @{ Code = $LASTEXITCODE; Out = $out } }
-        # Also drop blank lines and trailing whitespace: include-boundary expansion
-        # shifts them, and neither can affect tokenization (no line-splices survive /P).
         $lines = @(Get-Content $outFile | ForEach-Object { $_.TrimEnd() } |
                 Where-Object { $_ -and $_ -notmatch '^\s*#line' })
         return @{ Code = 0; Lines = $lines }
     }
 
-    Write-Host "Shader   : $relPath"
-    Write-Host "Base ref : $BaseRef  (full include tree materialized)"
-    Write-Host "Profile  : $Profile  (entry $Entry)"
-    Write-Host "Include  : $($IncludeDir.Count) roots (package/Shaders + features/*/Shaders)"
-    Write-Host ("-" * 60)
-
-    $allIdentical = $true
-    $anyError = $false
-
-    foreach ($perm in $Permutations) {
-        $tag = $perm
-
+    function Show-Detail([string]$perm) {
+        Ensure-BaseTree
         if ($PreprocessOnly) {
-            $rb = PreprocessLines $baseFile $baseInclude $perm (Join-Path $work "base.i")
-            $rw = PreprocessLines $shaderFull $IncludeDir $perm (Join-Path $work "work.i")
-            if ($rb.Code -ne 0 -or $rw.Code -ne 0) {
-                $anyError = $true
-                $which = if ($rb.Code -ne 0) { "BASE" } else { "WORK" }
-                Write-Host "[$tag] PREPROCESS-ERROR ($which)" -ForegroundColor Red
-                ($(if ($rb.Code -ne 0) { $rb.Out } else { $rw.Out }) | Where-Object { $_ -match 'error|warning' } | Select-Object -First 6) |
-                    ForEach-Object { Write-Host "    $_" }
-                continue
-            }
+            $rb = PreprocessLines $script:baseFile $script:baseInclude $perm (Join-Path $work "dbase.i")
+            $rw = PreprocessLines $shaderFull $IncludeDir $perm (Join-Path $work "dwork.i")
+            if ($rb.Code -ne 0 -or $rw.Code -ne 0) { return }
             $d = Compare-Object $rb.Lines $rw.Lines
-            if (-not $d) {
-                Write-Host "[$tag] IDENTICAL (preprocessed)" -ForegroundColor Green
-            } else {
-                $allIdentical = $false
-                Write-Host "[$tag] DIFFERS (preprocessed text)" -ForegroundColor Yellow
-                $d | Select-Object -First 20 | ForEach-Object {
-                    $mark = if ($_.SideIndicator -eq '=>') { 'work' } else { 'base' }
-                    Write-Host ("    [{0}] {1}" -f $mark, $_.InputObject)
-                }
-                if (@($d).Count -gt 20) { Write-Host ("    ... (+{0} more lines)" -f (@($d).Count - 20)) }
-            }
-            continue
-        }
-
-        $baseCso = Join-Path $work "base.cso"
-        $workCso = Join-Path $work "work.cso"
-        $rb = Compile $baseFile $baseInclude $perm $baseCso
-        $rw = Compile $shaderFull $IncludeDir $perm $workCso
-
-        if ($rb.Code -ne 0 -or $rw.Code -ne 0) {
-            $anyError = $true
-            $which = if ($rb.Code -ne 0) { "BASE" } else { "WORK" }
-            Write-Host "[$tag] COMPILE-ERROR ($which)" -ForegroundColor Red
-            ($(if ($rb.Code -ne 0) { $rb.Out } else { $rw.Out }) | Where-Object { $_ -match 'error|warning' } | Select-Object -First 6) |
-                ForEach-Object { Write-Host "    $_" }
-            continue
-        }
-
-        $hb = (Get-FileHash $baseCso -Algorithm SHA256).Hash
-        $hw = (Get-FileHash $workCso -Algorithm SHA256).Hash
-        if ($hb -eq $hw) {
-            Write-Host "[$tag] IDENTICAL" -ForegroundColor Green
         } else {
-            $allIdentical = $false
-            Write-Host "[$tag] DIFFERS  base=$($hb.Substring(0,12)) work=$($hw.Substring(0,12))" -ForegroundColor Yellow
-            # Tier 2: assembly diff for inspection (Compare-Object avoids git's CRLF/exit noise).
-            $baseAsm = Join-Path $work "base.asm"; $workAsm = Join-Path $work "work.asm"
-            Compile $baseFile $baseInclude $perm $baseAsm -Asm | Out-Null
+            $baseAsm = Join-Path $work "dbase.asm"; $workAsm = Join-Path $work "dwork.asm"
+            Compile $script:baseFile $script:baseInclude $perm $baseAsm -Asm | Out-Null
             Compile $shaderFull $IncludeDir $perm $workAsm -Asm | Out-Null
+            if (-not (Test-Path $baseAsm) -or -not (Test-Path $workAsm)) { return }
             $d = Compare-Object (Get-Content $baseAsm) (Get-Content $workAsm)
-            if ($d) {
-                $d | Select-Object -First 40 | ForEach-Object {
-                    $mark = if ($_.SideIndicator -eq '=>') { 'work' } else { 'base' }
-                    Write-Host ("    [{0}] {1}" -f $mark, $_.InputObject)
-                }
-                if (@($d).Count -gt 40) { Write-Host ("    ... (+{0} more asm lines)" -f (@($d).Count - 40)) }
+        }
+        if ($d) {
+            $d | Select-Object -First 30 | ForEach-Object {
+                $mark = if ($_.SideIndicator -eq '=>') { 'work' } else { 'base' }
+                Write-Host ("    [{0}] {1}" -f $mark, $_.InputObject)
             }
+            if (@($d).Count -gt 30) { Write-Host ("    ... (+{0} more lines)" -f (@($d).Count - 30)) }
         }
     }
 
+    Write-Host "Shader   : $relPath"
+    Write-Host "Base ref : $BaseRef ($($baseSha.Substring(0,12)))  cached=$($Permutations.Count - $uncached.Count)/$($Permutations.Count)"
+    Write-Host "Profile  : $Profile  (entry $Entry)  mode=$(if ($PreprocessOnly) { 'preprocess (Tier 0)' } else { 'DXBC (Tier 1)' })  jobs=$Jobs"
+    Write-Host "Include  : $($IncludeDir.Count) roots (package/Shaders + features/*/Shaders)"
     Write-Host ("-" * 60)
+
+    $pool = [runspacefactory]::CreateRunspacePool(1, $Jobs)
+    $pool.Open()
+    $tasks = New-Object System.Collections.Generic.List[object]
+    $idx = 0
+    foreach ($perm in $Permutations) {
+        $pair = @{ Perm = $perm }
+        if (-not $cache.ContainsKey($perm)) {
+            $ps = [powershell]::Create()
+            $ps.RunspacePool = $pool
+            [void]$ps.AddScript($workerScript)
+            [void]$ps.AddArgument($fxcPath); [void]$ps.AddArgument($mode); [void]$ps.AddArgument($Profile); [void]$ps.AddArgument($Entry)
+            [void]$ps.AddArgument($perm); [void]$ps.AddArgument($script:baseInclude); [void]$ps.AddArgument($script:baseFile)
+            [void]$ps.AddArgument((Join-Path $work "b$idx.tmp"))
+            $pair.BasePs = $ps
+            $pair.BaseHandle = $ps.BeginInvoke()
+        }
+        $ps2 = [powershell]::Create()
+        $ps2.RunspacePool = $pool
+        [void]$ps2.AddScript($workerScript)
+        [void]$ps2.AddArgument($fxcPath); [void]$ps2.AddArgument($mode); [void]$ps2.AddArgument($Profile); [void]$ps2.AddArgument($Entry)
+        [void]$ps2.AddArgument($perm); [void]$ps2.AddArgument($IncludeDir); [void]$ps2.AddArgument($shaderFull)
+        [void]$ps2.AddArgument((Join-Path $work "w$idx.tmp"))
+        $pair.WorkPs = $ps2
+        $pair.WorkHandle = $ps2.BeginInvoke()
+        $tasks.Add($pair)
+        $idx++
+    }
+
+    $allIdentical = $true
+    $anyError = $false
+    $detailShown = 0
+    $stopped = $false
+    $newBaseHashes = $false
+
+    foreach ($t in $tasks) {
+        if ($stopped) {
+            # FailFast already tripped: cancel outstanding compiles.
+            if ($t.BasePs) { $t.BasePs.Stop(); $t.BasePs.Dispose() }
+            $t.WorkPs.Stop(); $t.WorkPs.Dispose()
+            continue
+        }
+        $perm = $t.Perm
+        $baseHash = $null
+        $baseErr = $null
+        if ($t.BasePs) {
+            $rb = $t.BasePs.EndInvoke($t.BaseHandle)[0]
+            $t.BasePs.Dispose()
+            if ($rb.Ok) { $baseHash = $rb.Hash; $cache[$perm] = $rb.Hash; $newBaseHashes = $true }
+            else { $baseErr = $rb.Err }
+        } else {
+            $baseHash = $cache[$perm]
+        }
+        $rw = $t.WorkPs.EndInvoke($t.WorkHandle)[0]
+        $t.WorkPs.Dispose()
+
+        if ($baseErr -or -not $rw.Ok) {
+            $anyError = $true
+            $which = if ($baseErr) { "BASE" } else { "WORK" }
+            Write-Host "[$perm] $(if ($PreprocessOnly) { 'PREPROCESS' } else { 'COMPILE' })-ERROR ($which)" -ForegroundColor Red
+            (($(if ($baseErr) { $baseErr } else { $rw.Err }) -split "`r?`n") | Where-Object { $_ -match 'error|warning' } | Select-Object -First 6) |
+                ForEach-Object { Write-Host "    $_" }
+            if ($FailFast) { $script:failedPerm = $perm; $stopped = $true }
+            continue
+        }
+
+        if ($baseHash -eq $rw.Hash) {
+            Write-Host "[$perm] IDENTICAL" -ForegroundColor Green
+        } else {
+            $allIdentical = $false
+            Write-Host "[$perm] DIFFERS  base=$($baseHash.Substring(0,12)) work=$($rw.Hash.Substring(0,12))" -ForegroundColor Yellow
+            if ($detailShown -lt 3) { Show-Detail $perm; $detailShown++ }
+            if ($FailFast) { $script:failedPerm = $perm; $stopped = $true }
+        }
+    }
+
+    if ($cacheFile -and $newBaseHashes) {
+        $cache | ConvertTo-Json -Compress | Out-File -Encoding utf8 $cacheFile
+    }
+
+    Write-Host ("-" * 60)
+    if ($script:failedPerm -and $FailFast) {
+        Write-Host "FAILFAST: stopped at first failure. Bisect probe:" -ForegroundColor Yellow
+        Write-Host ("  -Permutations `"{0}`"" -f $script:failedPerm)
+    }
     if ($anyError) { Write-Host "RESULT: compile error" -ForegroundColor Red; $exit = 1 }
     elseif ($allIdentical) { Write-Host "RESULT: behavior-preserving (all permutations identical)" -ForegroundColor Green; $exit = 0 }
-    else { Write-Host "RESULT: bytecode differs - inspect asm diff above" -ForegroundColor Yellow; $exit = 2 }
+    else { Write-Host "RESULT: bytecode differs - inspect diff above" -ForegroundColor Yellow; $exit = 2 }
 
     exit $exit
 }
 finally {
+    if ($pool) { $pool.Close(); $pool.Dispose() }
     # Runs on normal exit and on throw, so the temp dir never leaks.
     if ($work -and (Test-Path $work)) { Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue }
     Pop-Location

--- a/tools/verify-shader-refactor.ps1
+++ b/tools/verify-shader-refactor.ps1
@@ -33,6 +33,19 @@
     Optional explicit permutation list; each entry is a space-separated define set,
     e.g. -Permutations "PSHADER","PSHADER VR". Overrides the auto sweep.
 
+.PARAMETER PermutationsFile
+    File with one space-separated define set per line ('#' comments allowed), as
+    produced by tools/gen-verify-perms.py. Overrides -Permutations and the auto
+    sweep. Use this for the big shaders -- the default sweep is far too weak there.
+
+.PARAMETER PreprocessOnly
+    Tier-0 gate: compare fxc /P preprocessed output (with #line directives
+    stripped) instead of compiled DXBC. Identical preprocessed text proves
+    identical bytecode at every optimization level, and runs in milliseconds per
+    permutation, so it can sweep a full permutation list cheaply. Only valid for
+    refactors that don't change the preprocessed text (pure cut-paste moves);
+    a legitimate guard-tightening change must use the default DXBC compare.
+
 .PARAMETER Entry
     Shader entry point. Default: main.
 
@@ -52,6 +65,8 @@ param(
     [string]$BaseRef,
     [string]$IncludeDir = "package/Shaders",
     [string[]]$Permutations,
+    [string]$PermutationsFile,
+    [switch]$PreprocessOnly,
     [string]$Entry = "main",
     [string]$Profile,
     [string]$Fxc
@@ -108,6 +123,12 @@ try {
         default { "PSHADER" }
     }
 
+    if ($PermutationsFile) {
+        if (-not (Test-Path $PermutationsFile)) { throw "Permutations file '$PermutationsFile' not found." }
+        $Permutations = @(Get-Content $PermutationsFile | ForEach-Object { $_.Trim() } |
+                Where-Object { $_ -and -not $_.StartsWith('#') })
+        if ($Permutations.Count -eq 0) { throw "Permutations file '$PermutationsFile' contains no define sets." }
+    }
     if (-not $Permutations -or $Permutations.Count -eq 0) {
         $Permutations = @(
             "$stageDefine",
@@ -135,16 +156,35 @@ try {
     $baseInclude = Join-Path $baseRoot $IncludeDir
     if (-not (Test-Path $baseFile)) { throw "'$relPath' not found at '$BaseRef'." }
 
-    function Compile([string]$src, [string]$incDir, [string]$defs, [string]$outFile, [switch]$Asm) {
+    function DefineArgs([string]$defs) {
         # Preserve explicit-valued defines (e.g. SHADOWFILTER=0); only bare names get =1.
         $defArgs = @()
         foreach ($d in ($defs -split '\s+' | Where-Object { $_ })) {
             $defArgs += "/D"
             $defArgs += $(if ($d -like '*=*') { $d } else { "$d=1" })
         }
+        return $defArgs
+    }
+
+    function Compile([string]$src, [string]$incDir, [string]$defs, [string]$outFile, [switch]$Asm) {
+        $defArgs = DefineArgs $defs
         $fmt = if ($Asm) { "/Fc" } else { "/Fo" }
         $out = & $fxcPath /nologo /T $Profile /E $Entry @defArgs /I $incDir $src $fmt $outFile 2>&1
         return @{ Code = $LASTEXITCODE; Out = $out }
+    }
+
+    # Tier 0: preprocessed text with #line directives stripped. Identical text =>
+    # identical DXBC at any optimization level (fxc embeds no file/line without /Zi),
+    # so cut-paste moves between files verify in milliseconds per permutation.
+    function PreprocessLines([string]$src, [string]$incDir, [string]$defs, [string]$outFile) {
+        $defArgs = DefineArgs $defs
+        $out = & $fxcPath /nologo /P $outFile @defArgs /I $incDir $src 2>&1
+        if ($LASTEXITCODE -ne 0) { return @{ Code = $LASTEXITCODE; Out = $out } }
+        # Also drop blank lines and trailing whitespace: include-boundary expansion
+        # shifts them, and neither can affect tokenization (no line-splices survive /P).
+        $lines = @(Get-Content $outFile | ForEach-Object { $_.TrimEnd() } |
+                Where-Object { $_ -and $_ -notmatch '^\s*#line' })
+        return @{ Code = 0; Lines = $lines }
     }
 
     Write-Host "Shader   : $relPath"
@@ -158,6 +198,33 @@ try {
 
     foreach ($perm in $Permutations) {
         $tag = $perm
+
+        if ($PreprocessOnly) {
+            $rb = PreprocessLines $baseFile $baseInclude $perm (Join-Path $work "base.i")
+            $rw = PreprocessLines $shaderFull $IncludeDir $perm (Join-Path $work "work.i")
+            if ($rb.Code -ne 0 -or $rw.Code -ne 0) {
+                $anyError = $true
+                $which = if ($rb.Code -ne 0) { "BASE" } else { "WORK" }
+                Write-Host "[$tag] PREPROCESS-ERROR ($which)" -ForegroundColor Red
+                ($(if ($rb.Code -ne 0) { $rb.Out } else { $rw.Out }) | Where-Object { $_ -match 'error|warning' } | Select-Object -First 6) |
+                    ForEach-Object { Write-Host "    $_" }
+                continue
+            }
+            $d = Compare-Object $rb.Lines $rw.Lines
+            if (-not $d) {
+                Write-Host "[$tag] IDENTICAL (preprocessed)" -ForegroundColor Green
+            } else {
+                $allIdentical = $false
+                Write-Host "[$tag] DIFFERS (preprocessed text)" -ForegroundColor Yellow
+                $d | Select-Object -First 20 | ForEach-Object {
+                    $mark = if ($_.SideIndicator -eq '=>') { 'work' } else { 'base' }
+                    Write-Host ("    [{0}] {1}" -f $mark, $_.InputObject)
+                }
+                if (@($d).Count -gt 20) { Write-Host ("    ... (+{0} more lines)" -f (@($d).Count - 20)) }
+            }
+            continue
+        }
+
         $baseCso = Join-Path $work "base.cso"
         $workCso = Join-Path $work "work.cso"
         $rb = Compile $baseFile $baseInclude $perm $baseCso


### PR DESCRIPTION
Phase 0 of #150 (shader decomposition & compile-time program): the gating and measurement tooling that makes byte-identical shader refactors mechanically verifiable.

## Changes

- **`tools/gen-verify-perms.py`** — emits per-shader/stage permutation lists (`full` + `stratified`) from the `shader-validation*.yaml` configs. `D3DCOMPILE_*` pseudo-defines stripped, known-hot combos always covered, fixed seed for reproducibility.
- **`tools/verify-shader-refactor.ps1`** —
  - `-PermutationsFile`: the built-in default sweep (VR × HDR_OUTPUT) is far too weak for the big shaders; this feeds the generated lists.
  - `-PreprocessOnly` (Tier 0): compares `fxc /P` output modulo `#line`/blank lines. Identical preprocessed text proves identical bytecode at any optimization level, in milliseconds per permutation — the per-commit gate for pure cut-paste decomposition. Validated both directions: a real extraction (texture block → new `.hlsli` + `#include`) verifies IDENTICAL across the full list; a one-register change reports DIFFERS with the divergent line.
- **`tools/shader-compile-bench.ps1`** — release-parity (`/O3`) compile-time bench + `-FromLog` mode parsing the runtime's `[ShaderTiming]` lines into the same CSV shape.
- **Merged-tree include roots** (both scripts): Lighting includes feature `.hlsli`s (e.g. `WaterEffects/WaterCaustics.hlsli`) that only co-exist in the deployed tree; default `/I` roots are now `package/Shaders` + every `features/*/Shaders`, and the verify script materializes all roots for the base ref.
- **`docs/development/shader-decomposition-plan.md`** — the phased plan (measured baseline, verification tiers, work-unit contract, capability split).

## Measured context (details in #150)

In-game `[ShaderTiming]` data: Lighting:Pixel is **98%** of total compile cost (9550s/9761s SE). Offline calibration: the slowest logged perm (251s in-game) compiles in **50.7s** at single-threaded `/O3` — log numbers carry ~5× contention inflation, so perf claims must diff offline bench numbers (this tooling).

No runtime/shader behavior changes — dev tooling and docs only.

Tracking: #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded a phased, measured shader-decomposition and verification plan with gating tiers, benchmarking rules, and explicit sequencing/parallelism guidance.

* **New Features**
  * Generator for full and stratified shader permutation lists.
  * Compile-benchmark tool (bench & log modes) that exports CSV summaries.

* **Improvements**
  * Verification runner: permutation-file driven, parallelized, preprocess-only option, base-result caching, richer mismatch reporting, and stricter verification/gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->