### PR TITLE
chore: sync upstream Community Shaders v1.7.0-rc.3

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -189,6 +189,13 @@ jobs:
               with:
                   name: "Community Shaders ${{ needs.build.outputs.version }} PR #${{ github.event.pull_request.number }}"
                   tag: v${{ needs.build.outputs.version }}-pr${{ github.event.pull_request.number }}
+                  # Anchor the preview tag to the PR head, not the base tip.
+                  # Without this, pull_request_target makes GITHUB_SHA the base
+                  # (dev) commit, so the tag lands in dev's history. A PR that
+                  # bumped CMake VERSION (e.g. a breaking change to 2.0.0) would
+                  # then expose a higher reachable version tag and poison
+                  # semantic-release's floor for every RC cut from dev.
+                  commit: ${{ github.event.pull_request.head.sha }}
                   prerelease: true
                   artifacts: "${{ github.workspace }}/dist/CommunityShaders_AIO-*.7z"
                   bodyFile: release-notes.md
@@ -202,6 +209,9 @@ jobs:
               with:
                   name: "Community Shaders ${{ needs.build.outputs.version }} PR #${{ github.event.pull_request.number }}"
                   tag: v${{ needs.build.outputs.version }}-pr${{ github.event.pull_request.number }}
+                  # Anchor to the PR head, not the base tip — see the custom-notes
+                  # step above for why dev-reachable preview tags break releases.
+                  commit: ${{ github.event.pull_request.head.sha }}
                   prerelease: true
                   artifacts: "${{ github.workspace }}/dist/CommunityShaders_AIO-*.7z"
                   generateReleaseNotes: true

--- a/features/HDR Display/Shaders/HDRDisplay/HDROutputCS.hlsl
+++ b/features/HDR Display/Shaders/HDRDisplay/HDROutputCS.hlsl
@@ -20,6 +20,7 @@ cbuffer PerFrame : register(b0)
 	float isSceneLinear : packoffset(c1.y);
 	float isMainOrLoadingMenu : packoffset(c1.z);
 	float fgTweenMenuMidAlphaBoost : packoffset(c1.w);  ///< TweenMenu: soften AA band when compositing here (UIBrightnessCS skips while paused)
+	float previewSDR : packoffset(c2.x);                ///< 1.0 = emit sRGB SDR (crop preview) instead of PQ HDR10
 }
 
 [numthreads(8, 8, 1)] void main(uint3 dispatchID : SV_DispatchThreadID) {
@@ -80,10 +81,15 @@ cbuffer PerFrame : register(b0)
 			compositedColorLinear = Color::GammaToLinearSafe(compositedColorGamma);
 		}
 
-		compositedColorLinear = Color::BT709ToBT2020(compositedColorLinear);
-		finalColor = Color::pq::Encode(max(0.0, compositedColorLinear), paperWhite);
+		if (previewSDR > 0.5) {
+			// Crop preview lives in the SDR menu buffer: emit sRGB instead of PQ.
+			finalColor = saturate(Color::LinearToSrgb(max(0.0, compositedColorLinear)));
+		} else {
+			compositedColorLinear = Color::BT709ToBT2020(compositedColorLinear);
+			finalColor = Color::pq::Encode(max(0.0, compositedColorLinear), paperWhite);
 
-		finalColor = saturate(finalColor);
+			finalColor = saturate(finalColor);
+		}
 	} else {
 		float3 sceneGamma = scene.rgb;
 

--- a/features/Skin/Shaders/Skin/Skin.hlsli
+++ b/features/Skin/Shaders/Skin/Skin.hlsli
@@ -80,14 +80,6 @@ namespace Skin
 		return D * G * F;
 	}
 
-	// a contact shadow approximation, totally not physically correct; a riff on "Chan 2018, "Material Advances in Call of Duty: WWII" and "The Technical Art of Uncharted 4" http://advances.realtimerendering.com/other/2016/naughty_dog/NaughtyDog_TechArt_Final.pdf (microshadowing)"
-	float ApproximateDirectOcculusion(float aoVisibility, float NdotL)
-	{
-		float aperture = rsqrt(1.0000001 - aoVisibility);
-		NdotL += 0.1;  // when using bent normals, avoids overshadowing - bent normals are just approximation anyhow
-		return saturate(NdotL * aperture);
-	}
-
 	void SkinDirectLightInput(
 		out DirectLightingOutput lightingOutput,
 		DirectContext context,
@@ -180,58 +172,6 @@ namespace Skin
 		lobeWeights.specular *= specularAO;
 
 		lobeWeights.specular *= saturate(1 - material.Curvature);
-	}
-
-	// https://blog.selfshadow.com/publications/blending-in-detail/
-	// geometric normal s, a base normal t and a secondary (or detail) normal u
-	float3 ReorientNormal(float3 u, float3 t, float3 s)
-	{
-		// Build the shortest-arc quaternion
-		float4 q = float4(cross(s, t), dot(s, t) + 1) / sqrt(2 * (dot(s, t) + 1));
-
-		// Rotate the normal
-		return u * (q.w * q.w - dot(q.xyz, q.xyz)) + 2 * q.xyz * dot(q.xyz, u) + 2 * q.w * cross(q.xyz, u);
-	}
-
-	// for when s = (0,0,1)
-	float3 ReorientNormal(float3 n1, float3 n2)
-	{
-		n1 += float3(0, 0, 1);
-		n2 *= float3(-1, -1, 1);
-
-		return n1 * dot(n1, n2) / n1.z - n2;
-	}
-
-	float3x3 ReconstructTBN(float3 worldPos, float3 worldNormal, float2 uv)
-	{
-		float3 dFdx = ddx(worldPos);
-		float3 dFdy = ddy(worldPos);
-		float2 dUVdx = ddx(uv);
-		float2 dUVdy = ddy(uv);
-		float3 tangent = normalize(dFdx * dUVdy.y - dFdy * dUVdx.y);
-		float3 bitangent = normalize(dFdy * dUVdx.x - dFdx * dUVdy.x);
-		tangent = normalize(tangent - worldNormal * dot(worldNormal, tangent));
-		bitangent = normalize(bitangent - worldNormal * dot(worldNormal, bitangent));
-
-		return float3x3(tangent, bitangent, normalize(worldNormal));
-	}
-
-	float3 CalculateNormalFromHeight(float height, float heightScale, float2 uv)
-	{
-		float dHdx = ddx(height);
-		float dHdy = ddy(height);
-		float2 dUVdx = ddx(uv);
-		float2 dUVdy = ddy(uv);
-
-		float det = dUVdx.x * dUVdy.y - dUVdx.y * dUVdy.x;
-		if (det == 0.0f) {
-			return float3(0, 0, 1);  // Avoid division by zero
-		}
-
-		float dHdx_Tex = (dHdx * dUVdy.y - dHdy * dUVdx.y) / det;
-		float dHdy_Tex = (dHdy * dUVdx.x - dHdx * dUVdy.x) / det;
-		float3 normal = float3(-dHdx_Tex, -dHdy_Tex, 0);
-		return normal * heightScale + float3(0, 0, 1);
 	}
 
 	float FBM(float2 uv, float base_scale, int octaves, float lacunarity, float persistence, float z_offset_multiplier)

--- a/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
+++ b/features/Wetness Effects/Shaders/WetnessEffects/WetnessEffects.hlsli
@@ -1,4 +1,5 @@
 #include "Common/BRDF.hlsli"
+#include "Common/Shading.hlsli"
 #include "WetnessEffects/optimized-ggx.hlsli"
 
 namespace WetnessEffects
@@ -21,26 +22,6 @@ namespace WetnessEffects
 
 		float val = lerp(1.0, 0.0, (normalised_t - rain_stay) / (1.0 - rain_stay));
 		return val * val;
-	}
-
-	// https://blog.selfshadow.com/publications/blending-in-detail/
-	// geometric normal s, a base normal t and a secondary (or detail) normal u
-	float3 ReorientNormal(float3 u, float3 t, float3 s)
-	{
-		// Build the shortest-arc quaternion
-		float4 q = float4(cross(s, t), dot(s, t) + 1) / sqrt(2 * (dot(s, t) + 1));
-
-		// Rotate the normal
-		return u * (q.w * q.w - dot(q.xyz, q.xyz)) + 2 * q.xyz * dot(q.xyz, u) + 2 * q.w * cross(q.xyz, u);
-	}
-
-	// for when s = (0,0,1)
-	float3 ReorientNormal(float3 n1, float3 n2)
-	{
-		n1 += float3(0, 0, 1);
-		n2 *= float3(-1, -1, 1);
-
-		return n1 * dot(n1, n2) / n1.z - n2;
 	}
 
 	// xyz - ripple normal, w - splotches

--- a/package/Shaders/Common/LightingCommon.hlsli
+++ b/package/Shaders/Common/LightingCommon.hlsli
@@ -108,18 +108,4 @@ float ShininessToRoughness(float shininess)
 {
 	return pow(abs(2.0 / (shininess + 2.0)), 0.25);
 }
-
-float3x3 ReconstructTBN(float3 worldPos, float3 worldNormal, float2 uv)
-{
-	float3 dFdx = ddx(worldPos);
-	float3 dFdy = ddy(worldPos);
-	float2 dUVdx = ddx(uv);
-	float2 dUVdy = ddy(uv);
-	float3 tangent = normalize(dFdx * dUVdy.y - dFdy * dUVdx.y);
-	float3 bitangent = normalize(dFdy * dUVdx.x - dFdx * dUVdy.x);
-	tangent = normalize(tangent - worldNormal * dot(worldNormal, tangent));
-	bitangent = normalize(bitangent - worldNormal * dot(worldNormal, bitangent));
-
-	return float3x3(tangent, bitangent, normalize(worldNormal));
-}
 #endif

--- a/package/Shaders/Common/Shading.hlsli
+++ b/package/Shaders/Common/Shading.hlsli
@@ -1,6 +1,8 @@
 #ifndef __SHADING_HLSLI__
 #define __SHADING_HLSLI__
 
+#include "Common/Math.hlsli"
+
 // [Jimenez et al. 2016, "Practical Realtime Strategies for Accurate Indirect Occlusion"]
 float3 MultiBounceAO(float3 baseColor, float ao)
 {
@@ -19,6 +21,66 @@ float SpecularAOLagarde(float NdotV, float ao, float roughness)
 float SpecularOcclusion(float NdotV, float alpha, float occlusion)
 {
 	return saturate(pow(abs(NdotV + occlusion), alpha) - 1.0 + occlusion);
+}
+
+// a contact shadow approximation, totally not physically correct; a riff on "Chan 2018, "Material Advances in Call of Duty: WWII" and "The Technical Art of Uncharted 4" http://advances.realtimerendering.com/other/2016/naughty_dog/NaughtyDog_TechArt_Final.pdf (microshadowing)"
+float ApproximateDirectOcculusion(float aoVisibility, float NdotL)
+{
+	float aperture = rsqrt(1.0000001 - aoVisibility);
+	NdotL += 0.1;  // when using bent normals, avoids overshadowing - bent normals are just approximation anyhow
+	return saturate(NdotL * aperture);
+}
+
+// https://blog.selfshadow.com/publications/blending-in-detail/
+// geometric normal s, a base normal t and a secondary (or detail) normal u
+float3 ReorientNormal(float3 u, float3 t, float3 s)
+{
+	// Build the shortest-arc quaternion
+	float4 q = float4(cross(s, t), dot(s, t) + 1) / sqrt(2 * (dot(s, t) + 1));
+
+	// Rotate the normal
+	return u * (q.w * q.w - dot(q.xyz, q.xyz)) + 2 * q.xyz * dot(q.xyz, u) + 2 * q.w * cross(q.xyz, u);
+}
+
+// for when s = (0,0,1)
+float3 ReorientNormal(float3 n1, float3 n2)
+{
+	n1 += float3(0, 0, 1);
+	n2 *= float3(-1, -1, 1);
+
+	return n1 * dot(n1, n2) / n1.z - n2;
+}
+
+float3x3 ReconstructTBN(float3 worldPos, float3 worldNormal, float2 uv)
+{
+	float3 dFdx = ddx(worldPos);
+	float3 dFdy = ddy(worldPos);
+	float2 dUVdx = ddx(uv);
+	float2 dUVdy = ddy(uv);
+	float3 tangent = normalize(dFdx * dUVdy.y - dFdy * dUVdx.y);
+	float3 bitangent = normalize(dFdy * dUVdx.x - dFdx * dUVdy.x);
+	tangent = normalize(tangent - worldNormal * dot(worldNormal, tangent));
+	bitangent = normalize(bitangent - worldNormal * dot(worldNormal, bitangent));
+
+	return float3x3(tangent, bitangent, normalize(worldNormal));
+}
+
+float3 CalculateNormalFromHeight(float height, float heightScale, float2 uv)
+{
+	float dHdx = ddx(height);
+	float dHdy = ddy(height);
+	float2 dUVdx = ddx(uv);
+	float2 dUVdy = ddy(uv);
+
+	float det = dUVdx.x * dUVdy.y - dUVdx.y * dUVdy.x;
+	if (det < EPSILON_DIVISION) {
+		return float3(0, 0, 1);  // Avoid division by zero
+	}
+
+	float dHdx_Tex = (dHdx * dUVdy.y - dHdy * dUVdx.y) / det;
+	float dHdy_Tex = (dHdy * dUVdx.x - dHdx * dUVdy.x) / det;
+	float3 normal = float3(-dHdx_Tex, -dHdy_Tex, 0);
+	return normal * heightScale + float3(0, 0, 1);
 }
 
 #endif  // __SHADING_HLSLI__

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -8,6 +8,7 @@
 #include "Common/MotionBlur.hlsli"
 #include "Common/Permutation.hlsli"
 #include "Common/Random.hlsli"
+#include "Common/Shading.hlsli"
 #include "Common/SharedData.hlsli"
 #include "Common/Skinned.hlsli"
 #include "Common/Triplanar.hlsli"
@@ -1816,7 +1817,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		skinWetnessSample = TexSkinWetnessSampler.Sample(SampColorSampler, uv);
 		if ((skinWetnessSample.y == 0 && skinWetnessSample.z == 0) || (skinWetnessSample.x == skinWetnessSample.y && skinWetnessSample.y == skinWetnessSample.z && skinWetnessSample.w >= 0.99f)) {
 			skinWetMask = skinWetnessSample.x;
-			skinWetnessNormal.xyz = Skin::CalculateNormalFromHeight(skinWetMask, SharedData::skinData.wetParams.w * 0.0001, uv) * 0.5 + 0.5;
+			skinWetnessNormal.xyz = CalculateNormalFromHeight(skinWetMask, SharedData::skinData.wetParams.w * 0.0001, uv) * 0.5 + 0.5;
 		} else {
 			skinWetnessNormal.xyz = skinWetnessSample.xyz;
 			skinWetMask = skinWetnessSample.w;
@@ -2010,7 +2011,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float2 detailUV = input.TexCoord0.xy * SharedData::skinData.skinDetailParams.x * SharedData::skinData.skinDetailParams.y;
 #		endif  // FACEGEN
 #		if defined(MODELSPACENORMALS)
-		const float3x3 tbnTr = Skin::ReconstructTBN(input.WorldPosition.xyz, worldNormal, screenUV);
+		const float3x3 tbnTr = ReconstructTBN(input.WorldPosition.xyz, worldNormal, screenUV);
 		const float3x3 tbn = transpose(tbnTr);
 		const float3 tangentNormal = mul(tbnTr, worldNormal.xyz);
 #		else
@@ -2019,17 +2020,16 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 		float3 detailNormal = float3(Skin::TexSkinDetailNormal.SampleBias(SampNormalSampler, detailUV, SharedData::MipBias - 1.0f).xy, 0.5f);
 		skinAO *= Skin::TexSkinDetailNormal.Sample(SampNormalSampler, detailUV).w;
 		detailNormal = (detailNormal * 2.0 - 1.0) * SharedData::skinData.skinDetailParams.z;
-		float3 combinedTangentNormal = normalize(float3(Skin::ReorientNormal(detailNormal, tangentNormal).xy, tangentNormal.z));
+		float3 combinedTangentNormal = normalize(float3(ReorientNormal(detailNormal, tangentNormal).xy, tangentNormal.z));
 		float3 combinedNormal = normalize(mul(tbn, combinedTangentNormal));
 		if (SharedData::skinData.skinDetailParams.w > 0.0f)
 			worldNormal.xyz = combinedNormal;
 #		if defined(WETNESS_EFFECTS)
 		if (skinWetness > 0.0f) {
-			float3 wetNormal = Skin::CalculateNormalFromHeight(skinWetness, SharedData::skinData.wetParams.w * 0.0005, uv);
+			float3 wetNormal = CalculateNormalFromHeight(skinWetness, SharedData::skinData.wetParams.w * 0.0005, uv);
 			if (hasSkinWetness) {
-				// float3 wetMaskNormal = Skin::CalculateNormalFromHeight(skinWetMask, SharedData::skinData.wetParams.w * 0.00005, uv);
 				float3 wetMaskNormal = (skinWetnessNormal.xyz * 2.0 - 1.0);
-				wetNormal = Skin::ReorientNormal(wetMaskNormal, wetNormal);
+				wetNormal = ReorientNormal(wetMaskNormal, wetNormal);
 			}
 			if (SharedData::skinData.skinParams2.y > 1.0f) {
 				wetNormal = lerp(wetNormal, tangentNormal, saturate(SharedData::skinData.skinParams2.y - 1.0f));
@@ -2120,7 +2120,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 #			endif  // SPECULAR
 #		endif      // SPARKLE
 
-#	endif      // SNOW
+#	endif  // SNOW
 
 #	if defined(WORLD_MAP)
 	baseColor.xyz = GetWorldMapBaseColor(rawBaseColor.xyz, baseColor.xyz, projWeight);
@@ -2513,7 +2513,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	// Apply ripple normal effects
 	float3 rippleNormal = normalize(lerp(float3(0, 0, 1), raindropInfo.xyz, lerp(flatnessAmount, 1.0, 0.5)));
-	wetnessNormal = WetnessEffects::ReorientNormal(rippleNormal, wetnessNormal);
+	wetnessNormal = ReorientNormal(rippleNormal, wetnessNormal);
 
 #		if defined(SKIN) && defined(CS_SKIN)
 	if (skinEnabled && (skinWetness > 0.0f)) {

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -47,6 +47,7 @@ PS_OUTPUT main(PS_INPUT input)
 #	include "Common/MotionBlur.hlsli"
 #	include "Common/Permutation.hlsli"
 #	include "Common/Random.hlsli"
+#	include "Common/Shading.hlsli"
 #	include "Common/Color.hlsli"
 
 #	define WATER
@@ -321,8 +322,8 @@ Texture2D<float4> RawSSRReflectionTex : register(t11);
 
 cbuffer PerTechnique : register(b0)
 {
-	float4 VPOSOffset : packoffset(c0);    // inverse main render target width and height in xy, 0 in zw
-	float4 PosAdjust : packoffset(c1);  // inverse framebuffer range in w
+	float4 VPOSOffset : packoffset(c0);  // inverse main render target width and height in xy, 0 in zw
+	float4 PosAdjust : packoffset(c1);   // inverse framebuffer range in w
 	float4 CameraDataWater : packoffset(c2);
 	float4 SunDir : packoffset(c3);
 	float4 SunColor : packoffset(c4);
@@ -767,7 +768,7 @@ WaterNormalData GetWaterNormal(PS_INPUT input, float distanceFactor, float norma
 		result.rippleInfo.w = splashIntensity;
 	}
 	float3 rippleNormal = normalize(raindropInfo.xyz);
-	finalNormal = WetnessEffects::ReorientNormal(rippleNormal, finalNormal);
+	finalNormal = ReorientNormal(rippleNormal, finalNormal);
 #			endif
 
 	result.normal = finalNormal;

--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -1161,8 +1161,6 @@ void HDRDisplay::ApplyHDR()
 	state->BeginPerfEvent("HDR Processing");
 
 	{
-		auto dispatchCount = Util::GetScreenDispatchCount(false);
-
 		// When HDR is enabled, ISHDR wrote to hdrTexture (float16, values >1.0 preserved).
 		// When SDR, ISHDR wrote to kFRAMEBUFFER (UNORM, tonemapped 0-1).
 		auto& framebufferRT = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kFRAMEBUFFER];
@@ -1182,31 +1180,8 @@ void HDRDisplay::ApplyHDR()
 			uiSRV = uiTexture->srv.get();
 		}
 
-		ID3D11ShaderResourceView* views[2] = { sceneSRV, uiSRV };
-		context->CSSetShaderResources(0, ARRAYSIZE(views), views);
-
-		ID3D11UnorderedAccessView* uavs[1] = { outputTexture->uav.get() };
-		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
-
-		ID3D11Buffer* cbs[1] = { hdrDataCB->CB() };
-
-		context->CSSetConstantBuffers(0, ARRAYSIZE(cbs), cbs);
-
-		auto computeShader = GetHDROutputCS();
-		if (!computeShader) {
+		if (!GetHDROutputCS()) {
 			// Fallback: HDR shader files not present - copy kFRAMEBUFFER directly to output
-			// Cleanup any bound resources
-			views[0] = nullptr;
-			views[1] = nullptr;
-			context->CSSetShaderResources(0, ARRAYSIZE(views), views);
-
-			uavs[0] = { nullptr };
-			context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
-
-			cbs[0] = { nullptr };
-			context->CSSetConstantBuffers(0, ARRAYSIZE(cbs), cbs);
-
-			// Copy kFRAMEBUFFER directly to destination (bypassing HDR processing)
 			if (upscaling.d3d12SwapChainActive) {
 				// SetUIBuffer keeps non-FG fallback UI in kFRAMEBUFFER; FG keeps using
 				// uiBufferWrapped for FidelityFX UI composition.
@@ -1225,22 +1200,7 @@ void HDRDisplay::ApplyHDR()
 			return;
 		}
 
-		context->CSSetShader(computeShader, nullptr, 0);
-		globals::profiler->BeginPass("HDRDisplay::HDROutput");
-		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
-		globals::profiler->EndPass();
-
-		views[0] = nullptr;
-		views[1] = nullptr;
-		context->CSSetShaderResources(0, ARRAYSIZE(views), views);
-
-		uavs[0] = { nullptr };
-		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
-
-		cbs[0] = { nullptr };
-		context->CSSetConstantBuffers(0, ARRAYSIZE(cbs), cbs);
-
-		context->CSSetShader(nullptr, nullptr, 0);
+		DispatchHDROutput(sceneSRV, uiSRV, outputTexture->uav.get());
 	}
 
 	// Copy result to appropriate destination
@@ -1264,6 +1224,112 @@ void HDRDisplay::ApplyHDR()
 	}
 
 	state->EndPerfEvent();
+}
+
+void HDRDisplay::DispatchHDROutput(ID3D11ShaderResourceView* sceneSRV, ID3D11ShaderResourceView* uiSRV, ID3D11UnorderedAccessView* uav)
+{
+	auto context = globals::d3d::context;
+	auto computeShader = GetHDROutputCS();
+	if (!computeShader || !uav)
+		return;
+
+	ID3D11ShaderResourceView* views[2] = { sceneSRV, uiSRV };
+	context->CSSetShaderResources(0, ARRAYSIZE(views), views);
+
+	ID3D11UnorderedAccessView* uavs[1] = { uav };
+	context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
+
+	ID3D11Buffer* cbs[1] = { hdrDataCB->CB() };
+	context->CSSetConstantBuffers(0, ARRAYSIZE(cbs), cbs);
+
+	context->CSSetShader(computeShader, nullptr, 0);
+
+	auto dispatchCount = Util::GetScreenDispatchCount(false);
+	globals::profiler->BeginPass("HDRDisplay::HDROutput");
+	context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
+	globals::profiler->EndPass();
+
+	views[0] = nullptr;
+	views[1] = nullptr;
+	context->CSSetShaderResources(0, ARRAYSIZE(views), views);
+
+	uavs[0] = nullptr;
+	context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
+
+	cbs[0] = nullptr;
+	context->CSSetConstantBuffers(0, ARRAYSIZE(cbs), cbs);
+
+	context->CSSetShader(nullptr, nullptr, 0);
+}
+
+void HDRDisplay::SnapshotCleanScene()
+{
+	if (!hdrTexture || !hdrTexture->resource)
+		return;
+
+	const D3D11_TEXTURE2D_DESC& sceneDesc = hdrTexture->desc;
+
+	// (Re)create on first use or when the scene texture changes.
+	if (cleanSceneCapture) {
+		const D3D11_TEXTURE2D_DESC& capDesc = cleanSceneCapture->desc;
+		if (capDesc.Width != sceneDesc.Width || capDesc.Height != sceneDesc.Height || capDesc.Format != sceneDesc.Format) {
+			cleanSceneCapture->srv = nullptr;
+			cleanSceneCapture->resource = nullptr;
+			delete cleanSceneCapture;
+			cleanSceneCapture = nullptr;
+		}
+	}
+
+	if (!cleanSceneCapture) {
+		D3D11_TEXTURE2D_DESC capDesc = sceneDesc;
+		capDesc.MipLevels = 1;
+		capDesc.ArraySize = 1;
+		capDesc.SampleDesc.Count = 1;
+		capDesc.SampleDesc.Quality = 0;
+		capDesc.Usage = D3D11_USAGE_DEFAULT;
+		capDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+		capDesc.CPUAccessFlags = 0;
+		capDesc.MiscFlags = 0;
+
+		cleanSceneCapture = new Texture2D(capDesc, "HDR::CleanSceneCapture");
+
+		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc{};
+		srvDesc.Format = capDesc.Format;
+		srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
+		cleanSceneCapture->CreateSRV(srvDesc);
+	}
+
+	globals::d3d::context->CopyResource(cleanSceneCapture->resource.get(), hdrTexture->resource.get());
+	cleanSceneCaptureFrame = globals::state->frameCount;
+}
+
+bool HDRDisplay::IsCleanSceneCaptureFresh() const
+{
+	return cleanSceneCapture && cleanSceneCapture->srv && cleanSceneCaptureFrame == globals::state->frameCount;
+}
+
+ID3D11Texture2D* HDRDisplay::ComposeCleanCapture(ID3D11ShaderResourceView* sceneSRV, bool sdrPreview)
+{
+	std::lock_guard<std::mutex> lock(settingsMutex);
+
+	if (!settings.enableHDR || !sceneSRV || !hdrDataCB || !outputTexture || !outputTexture->uav || !outputTexture->resource)
+		return nullptr;
+
+	if (!GetHDROutputCS())
+		return nullptr;
+
+	// Null UI SRV (t1 samples as 0) leaves the scene alone: no UI, menu, or blur.
+	HDRDataCB data = BuildHDRData();
+	data.previewSDR = sdrPreview ? 1.f : 0.f;
+	hdrDataCB->Update(data);
+
+	DispatchHDROutput(sceneSRV, nullptr, outputTexture->uav.get());
+
+	// Restore the canonical CB for the display composite this frame.
+	UpdateHDRData();
+
+	return outputTexture->resource.get();
 }
 
 void HDRDisplay::DestroyResources()
@@ -1292,6 +1358,14 @@ void HDRDisplay::DestroyResources()
 		uiTexture->resource = nullptr;
 		delete uiTexture;
 		uiTexture = nullptr;
+	}
+
+	if (cleanSceneCapture) {
+		cleanSceneCapture->srv = nullptr;
+		cleanSceneCapture->resource = nullptr;
+		delete cleanSceneCapture;
+		cleanSceneCapture = nullptr;
+		cleanSceneCaptureFrame = UINT32_MAX;
 	}
 
 	if (hdrDataCB) {
@@ -1543,11 +1617,8 @@ float4 HDRDisplay::GetSharedDataHDR() const
 	};
 }
 
-void HDRDisplay::UpdateHDRData() const
+HDRDisplay::HDRDataCB HDRDisplay::BuildHDRData() const
 {
-	if (!hdrDataCB)
-		return;
-
 	bool isMainOrLoadingMenu = globals::state->isMainMenuOpen || globals::state->isLoadingMenuOpen;
 	auto* ui = globals::game::ui;
 	bool skipUIComposite = IsFGCompositingThisFrame();
@@ -1559,7 +1630,7 @@ void HDRDisplay::UpdateHDRData() const
 	// Use user-specified peak brightness for highlights compression
 	float effectivePeakNits = static_cast<float>(settings.hdrPeakNits);
 
-	HDRDataCB data;
+	HDRDataCB data{};
 	data.enableHDR = settings.enableHDR ? 1.f : 0.f;
 	data.paperWhite = static_cast<float>(settings.hdrPaperWhite);
 	data.peakNits = effectivePeakNits;
@@ -1569,7 +1640,16 @@ void HDRDisplay::UpdateHDRData() const
 	data.pad0 = isMainOrLoadingMenu ? 1.f : 0.f;
 	// TweenMenu = pause UI. ScaleUIBrightnessForFG skips while GameIsPaused(), so HDROutputCS applies the same mid-alpha boost when compositing gamma UI.
 	data.fgTweenMenuMidAlphaBoost = (ui && ui->IsMenuOpen(RE::TweenMenu::MENU_NAME)) ? 1.f : 0.f;
-	hdrDataCB->Update(data);
+	data.previewSDR = 0.f;
+	return data;
+}
+
+void HDRDisplay::UpdateHDRData() const
+{
+	if (!hdrDataCB)
+		return;
+
+	hdrDataCB->Update(BuildHDRData());
 }
 
 void HDRDisplay::UpdateSwapChainColorSpace() const

--- a/src/Features/HDRDisplay.h
+++ b/src/Features/HDRDisplay.h
@@ -91,6 +91,15 @@ public:
 
 	void ApplyHDR();
 
+	// Snapshot hdrTexture before the menu blur dirties it in place.
+	void SnapshotCleanScene();
+
+	// True when the snapshot was refreshed this frame; stale means hdrTexture wasn't blurred.
+	bool IsCleanSceneCaptureFresh() const;
+
+	// HDR output transform on a clean scene with no UI buffer, into outputTexture.
+	ID3D11Texture2D* ComposeCleanCapture(ID3D11ShaderResourceView* sceneSRV, bool sdrPreview);
+
 	ID3D11BlendState* GetPatchedAlphaBlendState(ID3D11BlendState* original);
 
 	// Swap-chain Present hook (installed from Hooks::InitD3D).
@@ -118,15 +127,24 @@ public:
 		float isSceneLinear;             ///< 1.0 = Linear Lighting active, scene already linear
 		float pad0;                      ///< 1.0 = main menu/loading screen active
 		float fgTweenMenuMidAlphaBoost;  ///< 1.0 = TweenMenu (pause) open — FG UIBrightnessCS mid-alpha boost only
+		float previewSDR;                ///< 1.0 = emit sRGB SDR (crop preview) instead of PQ HDR10
+		float pad1;
+		float pad2;
+		float pad3;
 	};
 
 	static_assert((sizeof(HDRDataCB) % 16) == 0, "CB size not padded correctly");
+
+	// HDR data CB contents from current settings/game state (previewSDR=0).
+	HDRDataCB BuildHDRData() const;
 
 	ConstantBuffer* hdrDataCB = nullptr;
 
 	Texture2D* hdrTexture = nullptr;
 	Texture2D* outputTexture = nullptr;
-	Texture2D* uiTexture = nullptr;  // Separate UI render target for proper compositing
+	Texture2D* uiTexture = nullptr;          // Separate UI render target for proper compositing
+	Texture2D* cleanSceneCapture = nullptr;  // Pre-blur copy of hdrTexture for clean captures
+	uint cleanSceneCaptureFrame = UINT32_MAX;  // frameCount when cleanSceneCapture was last refreshed
 
 	ID3D11ComputeShader* hdrOutputCS = nullptr;
 	ID3D11ComputeShader* GetHDROutputCS();
@@ -192,6 +210,9 @@ private:
 	};
 
 	D3D12UIBufferMode GetD3D12UIBufferMode();
+
+	// Bind scene (t0), UI (t1, may be null), UAV (u0), CB (b0); dispatch the output CS; unbind.
+	void DispatchHDROutput(ID3D11ShaderResourceView* sceneSRV, ID3D11ShaderResourceView* uiSRV, ID3D11UnorderedAccessView* uav);
 
 	// True when FFX frame generation is actively compositing UI this frame.
 	bool IsFGCompositingThisFrame() const;

--- a/src/Features/HDRDisplay.h
+++ b/src/Features/HDRDisplay.h
@@ -143,8 +143,8 @@ public:
 
 	Texture2D* hdrTexture = nullptr;
 	Texture2D* outputTexture = nullptr;
-	Texture2D* uiTexture = nullptr;          // Separate UI render target for proper compositing
-	Texture2D* cleanSceneCapture = nullptr;  // Pre-blur copy of hdrTexture for clean captures
+	Texture2D* uiTexture = nullptr;            // Separate UI render target for proper compositing
+	Texture2D* cleanSceneCapture = nullptr;    // Pre-blur copy of hdrTexture for clean captures
 	uint cleanSceneCaptureFrame = UINT32_MAX;  // frameCount when cleanSceneCapture was last refreshed
 
 	ID3D11ComputeShader* hdrOutputCS = nullptr;

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -6,7 +6,6 @@
 #include "Menu/ThemeManager.h"
 #include "Shadercache.h"
 #include "State.h"
-#include "Util.h"
 #include "Utils/ExternalEmittance.h"
 
 #define I18N_KEY_PREFIX "feature.light_limit_fix."
@@ -62,7 +61,7 @@ void LightLimitFix::DrawOverlay()
 	const float pos = ThemeManager::Constants::OVERLAY_WINDOW_POSITION * Util::GetUIScale();
 	ImGui::SetNextWindowPos(ImVec2(pos, pos), ImGuiCond_Always);
 	ImGui::Begin("##LLFDebug", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings);
-	ImGui::TextColored(ImVec4(1.0f, 0.3f, 0.3f, 1.0f), "%s", T(TKEY("debug_feature_enabled"), "DEBUG FEATURE - LIGHT LIMIT VISUALISATION ENABLED"));
+	Util::Text::Error("%s", T(TKEY("debug_feature_enabled"), "DEBUG FEATURE - LIGHT LIMIT VISUALISATION ENABLED"));
 	ImGui::End();
 }
 

--- a/src/Features/PerformanceOverlay.cpp
+++ b/src/Features/PerformanceOverlay.cpp
@@ -30,7 +30,6 @@
 #include "Utils/FileSystem.h"
 #include "Utils/Format.h"
 #include "Utils/Game.h"
-#include "Utils/UI.h"
 
 #define I18N_KEY_PREFIX "feature.perf_overlay."
 
@@ -484,7 +483,7 @@ void PerformanceOverlay::DrawFPS()
 
 		if (isFrameGenActive) {
 			// Show note that FSR uses calculated data
-			ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), "%s", T(TKEY("post_fg_calculated"), "Post-FG: Calculated timing (2x Pre-FG)"));
+			Util::Text::Warning("%s", T(TKEY("post_fg_calculated"), "Post-FG: Calculated timing (2x Pre-FG)"));
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text("AMD FSR Frame Generation uses calculated timing data (2x Pre-FG).\nNVIDIA DLSS Frame Generation provides measured timing data.");
 			}

--- a/src/Features/PerformanceOverlay/ABTesting/ABTesting.cpp
+++ b/src/Features/PerformanceOverlay/ABTesting/ABTesting.cpp
@@ -4,7 +4,6 @@
 #include "Menu/ThemeManager.h"
 #include "State.h"
 #include "Utils/FileSystem.h"
-#include "Utils/UI.h"
 #include <cmath>
 #include <fmt/format.h>
 #include <fstream>
@@ -261,13 +260,12 @@ void ABTestingManager::DrawOverlayUI()
 
 			constexpr size_t MAX_CHANGES_DISPLAYED = 10;  // Show max 10 individual changes, otherwise show count
 			if (differences.size() <= MAX_CHANGES_DISPLAYED) {
-				ImGui::TextColored(ImVec4(0.7f, 0.9f, 1.0f, 1.0f), "Changes from USER:");
+				Util::Text::Info("Changes from USER:");
 				for (const auto& diff : differences) {
 					ImGui::BulletText("%s", diff.c_str());
 				}
 			} else {
-				ImGui::TextColored(ImVec4(0.7f, 0.9f, 1.0f, 1.0f),
-					"%zu settings changed", differences.size());
+				Util::Text::Info("%zu settings changed", differences.size());
 			}
 		}
 	}

--- a/src/Features/RenderDoc.cpp
+++ b/src/Features/RenderDoc.cpp
@@ -393,7 +393,7 @@ void RenderDoc::DrawSettings()
 
 							// Push red color for failed deletions
 							if (file.deletionFailed) {
-								ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 100, 100, 255));  // Red text for failed deletions
+								ImGui::PushStyleColor(ImGuiCol_Text, Util::Colors::GetError());
 							}
 
 							if (ImGui::Selectable(file.filename.c_str(), isSelected, ImGuiSelectableFlags_AllowDoubleClick)) {

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -48,7 +48,7 @@ void ScreenSpaceGI::DrawSettings()
 	static bool showAdvanced;
 
 	if (!ShadersOK())
-		ImGui::TextColored({ 1, 0, 0, 1 }, "%s", T(TKEY("shader_compile_error"), "Compute shaders failed to compile!"));
+		Util::Text::Error("%s", T(TKEY("shader_compile_error"), "Compute shaders failed to compile!"));
 
 	///////////////////////////////
 	ImGui::SeparatorText(T(TKEY("toggles"), "Toggles"));

--- a/src/Features/ScreenshotFeature.cpp
+++ b/src/Features/ScreenshotFeature.cpp
@@ -348,9 +348,11 @@ namespace
 	}
 
 	// Picks the capture source:
-	//   HDR enabled     -> swap-chain back buffer after ApplyHDR (PQ HDR10 / PQ float).
-	//   otherwise       -> kFRAMEBUFFER (tonemapped UNORM).
-	CaptureSource SelectCaptureSource(winrt::com_ptr<ID3D11Texture2D>& holder)
+	//   HDR + CS menu open -> clean HDR composite (no UI, no menu blur).
+	//   HDR enabled        -> swap-chain back buffer after ApplyHDR (PQ HDR10 / PQ float).
+	//   otherwise          -> kFRAMEBUFFER (tonemapped UNORM).
+	// forCapture: post-blur screenshot uses the snapshot; pre-blur preview uses hdrTexture.
+	CaptureSource SelectCaptureSource(winrt::com_ptr<ID3D11Texture2D>& holder, bool forCapture)
 	{
 		CaptureSource src;
 		auto* renderer = globals::game::renderer;
@@ -360,6 +362,23 @@ namespace
 
 
 		if (IsFlatHdrScreenshotCapture()) {
+			// Recompose from the clean scene with no UI buffer.
+			auto& hdr = globals::features::hdrDisplay;
+			if (Menu::GetSingleton()->IsEnabled && hdr.outputTexture && hdr.outputTexture->srv) {
+				ID3D11ShaderResourceView* sceneSRV =
+					(forCapture && hdr.IsCleanSceneCaptureFresh()) ? hdr.cleanSceneCapture->srv.get() :
+																	 (hdr.hdrTexture ? hdr.hdrTexture->srv.get() : nullptr);
+				if (sceneSRV) {
+					if (ID3D11Texture2D* clean = hdr.ComposeCleanCapture(sceneSRV, /*sdrPreview=*/!forCapture)) {
+						src.texture = clean;
+						src.srv = hdr.outputTexture->srv.get();
+						src.needsPreviewCache = false;
+						src.description = "HDR clean composite (no UI, no menu blur)";
+						return src;
+					}
+				}
+			}
+
 			src.texture = ResolveDisplayedBackBuffer(holder);
 			src.needsPreviewCache = true;
 			src.description = "Swap chain back buffer (HDR display composite)";
@@ -385,30 +404,27 @@ namespace
 		       combo[0].GetKey() == VK_SNAPSHOT;
 	}
 
-	// Blend state used around the preview's ImGui::Image draw. Two regression
-	// risks if this is changed:
-	//   1. BlendEnable must stay FALSE - the source texture carries non-1 alpha
-	//      where Skyrim composited UI plates; default SRC_ALPHA blend lets the
-	//      host window background show through (visible on the desktop mirror).
-	//   2. WriteMask must exclude alpha (RGB only) to avoid compositing
-	//      artifacts. RGB-only writes leave the plate's pre-cleared alpha=1
-	//      in place.
-	// Paired with ImDrawCallback_ResetRenderState queued by Subrect::DrawEditor
-	// immediately after the image draw.
+	// Forces BlendEnable=FALSE and opaque alpha for the preview Image draw.
+	// Paired with ImDrawCallback_ResetRenderState queued by Subrect::DrawEditor.
 	void OpaquePreviewBlendCallback(const ImDrawList*, const ImDrawCmd*)
 	{
-		static winrt::com_ptr<ID3D11BlendState> opaqueBlend;
-		if (!opaqueBlend) {
+		const bool writeAlpha = IsFlatHdrScreenshotCapture() && Menu::GetSingleton()->IsEnabled;
+
+		static winrt::com_ptr<ID3D11BlendState> rgbBlend;
+		static winrt::com_ptr<ID3D11BlendState> rgbaBlend;
+		auto& blend = writeAlpha ? rgbaBlend : rgbBlend;
+		if (!blend) {
 			D3D11_BLEND_DESC desc{};
 			desc.RenderTarget[0].BlendEnable = FALSE;
 			desc.RenderTarget[0].RenderTargetWriteMask =
 				D3D11_COLOR_WRITE_ENABLE_RED |
 				D3D11_COLOR_WRITE_ENABLE_GREEN |
-				D3D11_COLOR_WRITE_ENABLE_BLUE;
-			globals::d3d::device->CreateBlendState(&desc, opaqueBlend.put());
+				D3D11_COLOR_WRITE_ENABLE_BLUE |
+				(writeAlpha ? D3D11_COLOR_WRITE_ENABLE_ALPHA : 0);
+			globals::d3d::device->CreateBlendState(&desc, blend.put());
 		}
-		if (opaqueBlend) {
-			globals::d3d::context->OMSetBlendState(opaqueBlend.get(), nullptr, 0xFFFFFFFF);
+		if (blend) {
+			globals::d3d::context->OMSetBlendState(blend.get(), nullptr, 0xFFFFFFFF);
 		}
 	}
 
@@ -683,7 +699,7 @@ void ScreenshotFeature::DrawSettings()
 
 	// Preview reflects what Capture() would save.
 	winrt::com_ptr<ID3D11Texture2D> previewTextureKeepAlive;
-	const auto src = SelectCaptureSource(previewTextureKeepAlive);
+	const auto src = SelectCaptureSource(previewTextureKeepAlive, /*forCapture=*/false);
 
 	ID3D11ShaderResourceView* previewView = src.srv;
 	if (src.texture && (src.needsPreviewCache || !previewView)) {
@@ -863,7 +879,7 @@ void ScreenshotFeature::Capture()
 		return;
 
 	winrt::com_ptr<ID3D11Texture2D> sourceTextureKeepAlive;
-	const auto src = SelectCaptureSource(sourceTextureKeepAlive);
+	const auto src = SelectCaptureSource(sourceTextureKeepAlive, /*forCapture=*/true);
 	logger::debug("Capturing from {}", src.description);
 
 	if (!src.texture) {

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -224,6 +224,7 @@ void SkySync::Update(const RE::Sky* sky)
 			SetSkyRotation(sky, cell);
 		if (cell && prevCell && (cell->IsInteriorCell() != prevCell->IsInteriorCell() || cell->GetRuntimeData().worldSpace != prevCell->GetRuntimeData().worldSpace))
 			shadowFader.Reset();
+			lastGameHour = -1.0f;
 	}
 
 	// Exterior worldspaces always run; interior cells require the sunlight-shadows flag.
@@ -265,7 +266,21 @@ void SkySync::Update(const RE::Sky* sky)
 	ProcessMoon(sky, Caster::Masser, directions, intensities);
 	ProcessMoon(sky, Caster::Secunda, directions, intensities);
 
-	shadowFader.Update(sky, directions, intensities, settings.ShadowTransitionDuration);
+	// Advance the shadow fade by elapsed game time so the transition stays smooth during
+	// normal play but snaps when time jumps (scrubbing, waiting, fast travel).
+	const float gameHour = sky->currentGameHour;
+	float fadeAdvance = settings.ShadowTransitionDuration;  // first frame: snap
+	if (lastGameHour >= 0.0f) {
+		float hourDelta = gameHour - lastGameHour;
+		if (hourDelta > 12.0f)
+			hourDelta -= 24.0f;
+		else if (hourDelta < -12.0f)
+			hourDelta += 24.0f;
+		fadeAdvance = std::abs(hourDelta) * SecondsPerGameHour;
+	}
+	lastGameHour = gameHour;
+
+	shadowFader.Update(sky, directions, intensities, settings.ShadowTransitionDuration, fadeAdvance);
 }
 void SkySync::SetSunAngle()
 {
@@ -415,7 +430,7 @@ void SkySync::ShadowFader::Reset()
 	transitioning = false;
 }
 
-void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration)
+void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration, float fadeAdvance)
 {
 	auto isValidDir = [](const RE::NiPoint3& d) { return d.x != 0.0f || d.y != 0.0f || d.z != 0.0f; };
 
@@ -467,10 +482,7 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		return;
 	}
 
-	float timeScale = 20.0f;
-	if (const auto calendar = globals::game::calendar)
-		timeScale = calendar->GetTimescale();
-	fadeTimer = std::min(fadeTimer + *globals::game::deltaTime * 20.0f / timeScale, fadeDuration);
+	fadeTimer = std::min(fadeTimer + fadeAdvance, fadeDuration);
 	const float t = fadeDuration > 0.0f ? fadeTimer / fadeDuration : 1.0f;
 
 	RE::NiPoint3 targetDir = dirs[static_cast<int>(target)];

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -224,7 +224,7 @@ void SkySync::Update(const RE::Sky* sky)
 			SetSkyRotation(sky, cell);
 		if (cell && prevCell && (cell->IsInteriorCell() != prevCell->IsInteriorCell() || cell->GetRuntimeData().worldSpace != prevCell->GetRuntimeData().worldSpace))
 			shadowFader.Reset();
-			lastGameHour = -1.0f;
+		lastGameHour = -1.0f;
 	}
 
 	// Exterior worldspaces always run; interior cells require the sunlight-shadows flag.

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -434,6 +434,10 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 {
 	auto isValidDir = [](const RE::NiPoint3& d) { return d.x != 0.0f || d.y != 0.0f || d.z != 0.0f; };
 
+	bool* const vlEnabled = globals::game::bEnableVolumetricLighting;
+	static bool vlSuppressed = false;
+	static bool vlSavedEnabled = true;
+
 	Caster best;
 
 	if (globals::features::skySync.currentDim <= 0.0f) {
@@ -444,6 +448,11 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 			// No valid night caster — default to directly above (shadows point down)
 			currentDir = { 0.0f, 0.0f, 1.0f };
 			SetLighting(sky, currentDir);
+			if (vlEnabled && !vlSuppressed) {
+				vlSavedEnabled = *vlEnabled;
+				*vlEnabled = false;
+				vlSuppressed = true;
+			}
 			return;
 		}
 
@@ -455,6 +464,11 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 			best = Caster::Secunda;
 	} else {
 		best = Caster::Sun;
+	}
+
+	if (vlSuppressed && vlEnabled) {
+		*vlEnabled = vlSavedEnabled;
+		vlSuppressed = false;
 	}
 
 	// If best source changed, begin a new transition

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -106,7 +106,7 @@ private:
 		float fadeTimer = 0.0f;
 		bool transitioning = false;
 
-		void Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration);
+		void Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration, float fadeAdvance);
 		static void SetLighting(const RE::Sky* sky, RE::NiPoint3 dir);
 		static void ClampDirection(RE::NiPoint3& dir);
 		void Reset();
@@ -117,6 +117,7 @@ private:
 	static constexpr float SouthernSunAngle = 90.0f - 35.0f;
 	static constexpr float NorthernSunAngle = 90.0f + 35.0f;
 	static constexpr float VanillaSunAngle = 90.0f + 5.0f;
+	static constexpr float SecondsPerGameHour = 3600.0f;
 
 	inline static RE::NiPoint3* gSunPosition = nullptr;
 
@@ -124,6 +125,7 @@ private:
 	RE::TESObjectCELL* currentCell = nullptr;
 	float sunAngle = 90.0f;
 	float currentSkyRotation = D3D11_FLOAT32_MAX;
+	float lastGameHour = -1.0f;
 
 	float4 colors[3] = {};
 	float currentDim = 1.0f;

--- a/src/Features/VolumetricLighting.cpp
+++ b/src/Features/VolumetricLighting.cpp
@@ -154,7 +154,6 @@ void VolumetricLighting::DataLoaded()
 
 void VolumetricLighting::PostPostLoad()
 {
-	bEnableVolumetricLighting = reinterpret_cast<bool*>(REL::RelocationID(527940, 414913).address());
 	gVolumetricLightingSizeLow = reinterpret_cast<TextureSize*>(REL::RelocationID(527970, 414916).address());
 	gVolumetricLightingSizeMedium = reinterpret_cast<TextureSize*>(REL::RelocationID(527973, 414919).address());
 	gVolumetricLightingSizeHigh = reinterpret_cast<TextureSize*>(REL::RelocationID(527976, 414922).address());
@@ -204,11 +203,11 @@ void VolumetricLighting::EarlyPrepass()
 void VolumetricLighting::SetupVL()
 {
 	if (inInterior) {
-		*bEnableVolumetricLighting = settings.InteriorEnabled && inInteriorWithSun;
+		*globals::game::bEnableVolumetricLighting = settings.InteriorEnabled && inInteriorWithSun;
 		*gVolumetricLightingSizeHigh = static_cast<Quality>(settings.InteriorQuality) == Quality::Custom ? settings.InteriorCustomSize : defaultSizeHigh;
 		SetVLQuality(GetVLDescriptor(), settings.InteriorQuality);
 	} else {
-		*bEnableVolumetricLighting = settings.ExteriorEnabled;
+		*globals::game::bEnableVolumetricLighting = settings.ExteriorEnabled;
 		*gVolumetricLightingSizeHigh = static_cast<Quality>(settings.ExteriorQuality) == Quality::Custom ? settings.ExteriorCustomSize : defaultSizeHigh;
 		SetVLQuality(GetVLDescriptor(), settings.ExteriorQuality);
 	}

--- a/src/Features/VolumetricLighting.h
+++ b/src/Features/VolumetricLighting.h
@@ -83,7 +83,6 @@ private:
 	TextureSize interiorSizeInUnits;
 	TextureSize defaultSizeHigh;
 
-	bool* bEnableVolumetricLighting = nullptr;
 	TextureSize* gVolumetricLightingSizeHigh = nullptr;
 	TextureSize* gVolumetricLightingSizeMedium = nullptr;
 	TextureSize* gVolumetricLightingSizeLow = nullptr;

--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -738,7 +738,7 @@ float WetnessEffects::GetRainIntensity(RE::NiPointer<RE::BSGeometry> precipObjec
 	auto maxDensity = weather->precipitationData->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kParticleDensity).f;  // Use weather particle density as authoritative source for rain intensity
 	// This provides consistent intensity scaling based on weather type (1-3 scale)
 	// Note: rain->density equals maxDensity when fully active
-	return (maxDensity > 0.0f) ? (maxDensity / MAX_RAIN_PARTICLE_DENSITY) : 0.0f;
+	return (maxDensity > 0.0f) ? std::min(1.0f, maxDensity / MAX_RAIN_PARTICLE_DENSITY) : 0.0f;
 }
 
 WetnessEffects::WeatherWetnessResult WetnessEffects::CalculateWeatherWetness(RE::TESWeather* weather, float weatherPct, bool isCurrentWeather) const

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -115,6 +115,7 @@ namespace globals
 		RE::UI* ui = nullptr;
 		RE::Calendar* calendar = nullptr;
 		RE::ImageSpaceManager* imageSpaceManager = nullptr;
+		bool* bEnableVolumetricLighting = nullptr;
 		std::atomic<bool> quitGame{ false };
 
 		RE::BSGraphics::PixelShader** currentPixelShader = nullptr;
@@ -219,6 +220,7 @@ namespace globals
 		sky = RE::Sky::GetSingleton();
 		utilityShader = RE::BSUtilityShader::GetSingleton();
 		imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
+		bEnableVolumetricLighting = reinterpret_cast<bool*>(REL::RelocationID(527940, 414913).address());
 
 		bEnableLandFade = iniSettingCollection->GetSetting("bEnableLandFade:Display");
 

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -160,6 +160,7 @@ namespace globals
 		extern RE::UI* ui;
 		extern RE::Calendar* calendar;
 		extern RE::ImageSpaceManager* imageSpaceManager;
+		extern bool* bEnableVolumetricLighting;
 		extern std::atomic<bool> quitGame;
 
 		extern RE::BSGraphics::PixelShader** currentPixelShader;

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1058,6 +1058,61 @@ void Menu::ProcessInputEventQueue()
 			const bool wasCapturingHotkey = IsCapturingHotkeyInput();
 			const bool allowSetupCloseKey = wasCapturingHotkey && HomePageRenderer::ShouldShowFirstTimeSetup() &&
 			                                (key == VK_RETURN || key == VK_ESCAPE);
+
+			// Dispatch bound hotkey actions for `key`. Combo bindings (modifier + key)
+			// fire on key-down for responsiveness; single-key bindings fire on key-up.
+			auto dispatchHotkeyActions = [this, key](bool combosOnly) {
+				struct KeyAction
+				{
+					std::vector<InputCombo>& settingKey;
+					std::function<void()> action;
+				};
+				auto shaderCache = globals::shaderCache;
+				KeyAction keyActions[] = {
+					{ settings.ToggleKey, [this]() {
+						 if (!HomePageRenderer::ShouldShowFirstTimeSetup()) {
+							 IsEnabled = !IsEnabled;
+							 if (IsEnabled)
+								 ImGui::GetIO().ClearInputKeys();  // Prevent toggle key from remaining "held" in ImGui after open.
+						 }
+					 } },
+					{ settings.SkipCompilationKey, [this, shaderCache]() { if (!ShouldSwallowInput() && shaderCache->IsCompiling()) shaderCache->backgroundCompilation = true; } },
+					{ settings.EffectToggleKey, [shaderCache]() { shaderCache->SetEnabled(!shaderCache->IsEnabled()); } },
+					{ settings.ShaderBlockPrevKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(); } },
+					{ settings.ShaderBlockNextKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(false); } },
+					{ settings.OverlayToggleKey, []() { Menu::GetSingleton()->overlayVisible = !Menu::GetSingleton()->overlayVisible; } },
+					{ settings.CSEditorToggleKey, []() {
+						 auto* ew = EditorWindow::GetSingleton();
+						 if (!ew)
+							 return;
+						 if (ew->GetPreviewMode() == EditorWindow::PreviewMode::FreeCamera) {
+							 // Flying → lock camera position for editing
+							 ew->ToggleFreeCameraLock();
+						 } else if (ew->IsInPreviewMode()) {
+							 // Locked or PlayMode → fully exit preview
+							 ew->ExitPreviewMode();
+						 } else {
+							 CSEditor::ToggleEditorWindow();
+						 }
+					 } },
+					{ settings.ScreenshotKey, []() {
+						 if (globals::features::screenshotFeature.loaded)
+							 globals::features::screenshotFeature.captureRequested = true;
+					 } },
+				};
+				// RenderDoc's capture key is a single, unmodified key; only consider it on key-up.
+				if (!combosOnly && globals::features::renderDoc.HandleCaptureHotkey(key))
+					return true;
+				for (const auto& ka : keyActions) {
+					const bool isCombo = ka.settingKey.size() > 1;
+					if (isCombo == combosOnly && InputCombo::MatchesKeyboardCombo(ka.settingKey, key)) {
+						ka.action();
+						return true;
+					}
+				}
+				return false;
+			};
+
 			if (!event.IsPressed()) {
 				// Skip key release if it was used to close the first-time setup dialog
 				if (HomePageRenderer::ShouldSkipKeyRelease(key)) {
@@ -1071,7 +1126,6 @@ void Menu::ProcessInputEventQueue()
 					bool* settingFlag;
 					std::function<void(std::vector<InputCombo>)> action;
 				};
-				auto shaderCache = globals::shaderCache;
 				HotkeyAction hotkeyActions[] = {
 					{ &settings.ToggleKey, &settingToggleKey, [this](std::vector<InputCombo> keys) {
 						 settings.ToggleKey = keys;
@@ -1132,51 +1186,11 @@ void Menu::ProcessInputEventQueue()
 					}
 				}
 				if (!handled) {
-					struct KeyAction
-					{
-						std::vector<InputCombo>& settingKey;
-						std::function<void()> action;
-					};
-					KeyAction keyActions[] = {
-						{ settings.ToggleKey, [this]() {
-							 if (!HomePageRenderer::ShouldShowFirstTimeSetup()) {
-								 IsEnabled = !IsEnabled;
-								 if (IsEnabled)
-									 ImGui::GetIO().ClearInputKeys();  // Prevent toggle key from remaining "held" in ImGui after open.
-							 }
-						 } },
-						{ settings.SkipCompilationKey, [this, shaderCache]() { if (!ShouldSwallowInput() && shaderCache->IsCompiling()) shaderCache->backgroundCompilation = true; } },
-						{ settings.EffectToggleKey, [shaderCache]() { shaderCache->SetEnabled(!shaderCache->IsEnabled()); } },
-						{ settings.ShaderBlockPrevKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(); } },
-						{ settings.ShaderBlockNextKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(false); } },
-						{ settings.OverlayToggleKey, []() { Menu::GetSingleton()->overlayVisible = !Menu::GetSingleton()->overlayVisible; } },
-						{ settings.CSEditorToggleKey, []() {
-							 auto* ew = EditorWindow::GetSingleton();
-							 if (!ew)
-								 return;
-							 if (ew->GetPreviewMode() == EditorWindow::PreviewMode::FreeCamera) {
-								 // Flying → lock camera position for editing
-								 ew->ToggleFreeCameraLock();
-							 } else if (ew->IsInPreviewMode()) {
-								 // Locked or PlayMode → fully exit preview
-								 ew->ExitPreviewMode();
-							 } else {
-								 CSEditor::ToggleEditorWindow();
-							 }
-						 } },
-						{ settings.ScreenshotKey, []() {
-							 if (globals::features::screenshotFeature.loaded)
-								 globals::features::screenshotFeature.captureRequested = true;
-						 } },
-					};
-					if (!globals::features::renderDoc.HandleCaptureHotkey(key)) {
-						for (const auto& ka : keyActions) {
-							if (InputCombo::MatchesKeyboardCombo(ka.settingKey, key)) {
-								ka.action();
-								break;
-							}
-						}
-					}
+					// Single-key hotkeys fire on key-up; combos already fired on key-down.
+					// If this key's key-down already fired a combo, suppress the single-key
+					// binding so releasing the modifier first doesn't trigger it as well.
+					if (_comboFiredKeys.erase(key) == 0)
+						dispatchHotkeyActions(false);
 				}
 
 				// Handle ESC key for menu and editor window
@@ -1190,6 +1204,12 @@ void Menu::ProcessInputEventQueue()
 						IsEnabled = false;
 					}
 				}
+			} else if (event.IsDown() && !wasCapturingHotkey) {
+				// Fire combo hotkeys on the key-down transition so they respond on
+				// press rather than release. IsDown() (not IsPressed()) ensures we
+				// trigger only once instead of every frame the key is held.
+				if (dispatchHotkeyActions(true))
+					_comboFiredKeys.insert(key);
 			}
 
 			// Don't forward hotkey events to ImGui when input is captured (prevents e.g. End key scrolling the feature list)

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <winrt/base.h>
 
@@ -511,6 +512,11 @@ private:
 	// Input event handling
 	std::vector<KeyEvent> _keyEventQueue;
 	mutable std::shared_mutex _inputEventMutex;
+
+	// Keys whose key-down already fired a combo hotkey. Their matching key-up is
+	// suppressed so a shared single-key binding (e.g. End) doesn't also fire once
+	// the modifier is released first.
+	std::unordered_set<uint32_t> _comboFiredKeys;
 
 	Menu() = default;
 

--- a/src/Menu/BackgroundBlur.cpp
+++ b/src/Menu/BackgroundBlur.cpp
@@ -654,6 +654,11 @@ namespace BackgroundBlur
 			CreateBlurTextures(texDesc.Width, texDesc.Height, texDesc.Format);
 		}
 
+		// Snapshot the clean scene before the in-place HDR blur, for clean captures.
+		if (hdrActive) {
+			hdr->SnapshotCleanScene();
+		}
+
 		// CS editor mode: single fullscreen blur pass (better perf than per-window)
 		if (csEditorActive) {
 			ImVec2 screenMin = { 0, 0 };

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -9,8 +9,6 @@
 #include "Menu.h"
 #include "Plugin.h"
 #include "State.h"
-#include "Util.h"
-#include "Utils/UI.h"
 
 // Static member definitions
 bool HomePageRenderer::isFirstTimeSetupShown = false;
@@ -268,10 +266,7 @@ void HomePageRenderer::RenderActiveConstraintsSection()
 	ImGui::Spacing();
 
 	// Use warning color for the header to draw attention
-	auto menu = Menu::GetSingleton();
-	ImVec4 warningColor = menu ? menu->GetTheme().StatusPalette.Warning : ImVec4(1.0f, 0.8f, 0.2f, 1.0f);
-
-	ImGui::PushStyleColor(ImGuiCol_Text, warningColor);
+	ImGui::PushStyleColor(ImGuiCol_Text, Util::Colors::GetWarning());
 	bool headerOpen = ImGui::CollapsingHeader(T("menu.home.active_constraints", "Active Setting Constraints"), ImGuiTreeNodeFlags_None);
 	ImGui::PopStyleColor();
 
@@ -327,9 +322,9 @@ void HomePageRenderer::RenderActiveConstraintsSection()
 
 		// Cell render -- column 2 ("Constrained By") is clickable to navigate
 		// to the first source feature's settings page.
-		auto cellRender = [warningColor](int rowIdx, int colIdx, const ConstraintRow& row) {
+		auto cellRender = [](int rowIdx, int colIdx, const ConstraintRow& row) {
 			if (colIdx == 0) {
-				Util::RenderTableCell(row.setting, "", "", nullptr, ImVec4(1, 1, 1, 1), true, warningColor);
+				Util::RenderTableCell(row.setting, "", "", nullptr, ImVec4(1, 1, 1, 1), true, Util::Colors::GetWarning());
 			} else if (colIdx == 1) {
 				Util::RenderTableCell(row.forcedTo, "", "", nullptr, ImVec4(1, 1, 1, 1), true);
 			} else if (colIdx == 2) {
@@ -535,7 +530,7 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 		if (csEditorKey.empty()) {
 			const char* warnText = T("menu.setup.cs_editor_unbound", "CS Editor hotkey unbound - chosen key uses Shift");
 			centerText(warnText);
-			ImGui::TextColored(ImVec4(1.0f, 0.75f, 0.0f, 1.0f), "%s", warnText);
+			Util::Text::Warning("%s", warnText);
 		} else {
 			std::string infoStr = I18n::GetSingleton()->Format("menu.setup.cs_editor_will_be",
 				{ { "key", Util::Input::KeyIdToString(csEditorKey) } },

--- a/src/Menu/ProfilingRenderer.cpp
+++ b/src/Menu/ProfilingRenderer.cpp
@@ -9,7 +9,6 @@
 #include "I18n/I18n.h"
 #include "Menu.h"
 #include "State.h"
-#include "Utils/UI.h"
 
 static ImU32 HslToImU32(float h, float s, float l)
 {
@@ -103,7 +102,7 @@ uint32_t ProfilingRenderer::ToLegitColor(ImU32 imColor)
 ImVec4 ProfilingRenderer::HeatColor(float value, float maxValue)
 {
 	if (maxValue <= 0.0f)
-		return ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+		return Util::Colors::GetDefault();
 
 	float x = std::clamp(value / maxValue, 0.0f, 1.0f);
 
@@ -125,7 +124,7 @@ void ProfilingRenderer::TextHeat(const char* fmt, float value, float maxValue)
 {
 	ImVec4 bg = HeatColor(value, maxValue);
 	ImGui::TableSetBgColor(ImGuiTableBgTarget_CellBg, ImGui::GetColorU32(bg));
-	ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, 1.0f), fmt, value);
+	ImGui::TextColored(Util::Colors::GetDefault(), fmt, value);
 }
 
 void ProfilingRenderer::RenderTimingModeToggle()

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -16,7 +16,6 @@
 #include "ShaderCache.h"
 #include "State.h"
 #include "ThemeManager.h"
-#include "Util.h"
 
 using json = nlohmann::json;
 
@@ -976,7 +975,7 @@ void SettingsTabRenderer::RenderFontsTab()
 		SeparatorTextWithFont(T("menu.settings.font_roles", "Font Roles"), Menu::FontRole::Subheading);
 
 		if (fontCatalog.families.empty()) {
-			ImGui::TextColored(ImVec4(0.9f, 0.6f, 0.2f, 1.0f), "%s", T("menu.settings.no_fonts_found", "No fonts found. Place .ttf files in Interface/CommunityShaders/Fonts/"));
+			Util::Text::Warning("%s", T("menu.settings.no_fonts_found", "No fonts found. Place .ttf files in Interface/CommunityShaders/Fonts/"));
 		}
 
 		for (size_t roleIndex = 0; roleIndex < Menu::FontRoleDescriptors.size(); ++roleIndex) {
@@ -1009,7 +1008,7 @@ void SettingsTabRenderer::RenderFontsTab()
 				FontRoleGuard familyComboFont(Menu::FontRole::Body);
 				if (ImGui::BeginCombo(familyLabel.c_str(), familyPreview)) {
 					if (fontCatalog.families.empty()) {
-						ImGui::TextColored(ImVec4(0.7f, 0.7f, 0.7f, 1.0f), "%s", T("menu.settings.no_font_families_available", "No font families available"));
+						Util::Text::Disabled("%s", T("menu.settings.no_font_families_available", "No font families available"));
 					} else {
 						for (int i = 0; i < static_cast<int>(fontCatalog.families.size()); ++i) {
 							bool isSelected = (i == familyIndex);
@@ -1043,7 +1042,7 @@ void SettingsTabRenderer::RenderFontsTab()
 
 			const Util::Fonts::FamilyInfo* selectedFamily = (fontCatalog.families.empty()) ? nullptr : &fontCatalog.families[familyIndex];
 			if (selectedFamily && selectedFamily->styles.empty()) {
-				ImGui::TextColored(ImVec4(0.9f, 0.6f, 0.2f, 1.0f), "%s", T("menu.settings.no_style_variants", "No style variants found for this family."));
+				Util::Text::Warning("%s", T("menu.settings.no_style_variants", "No style variants found for this family."));
 			} else if (selectedFamily) {
 				int styleIndex = 0;
 				for (size_t s = 0; s < selectedFamily->styles.size(); ++s) {

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -2183,11 +2183,11 @@ namespace Util
 					auto* weatherManager = WeatherManager::GetSingleton();
 					auto currentWeathers = weatherManager->GetCurrentWeathers();
 					ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-					ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.2f, 1.0f), "Weather Override Active");
+					Util::Text::Warning("Weather Override Active");
 					ImGui::TextWrapped("This setting is controlled by the current weather (%s).",
 						currentWeathers.currentWeather ? currentWeathers.currentWeather->GetFormEditorID() : "Unknown");
 					ImGui::Separator();
-					ImGui::TextColored(ImVec4(0.6f, 0.9f, 0.6f, 1.0f), "Click to open CS Editor");
+					Util::Text::Success("Click to open CS Editor");
 					ImGui::PopTextWrapPos();
 					ImGui::EndTooltip();
 				}
@@ -2237,11 +2237,11 @@ namespace Util
 					auto* weatherManager = WeatherManager::GetSingleton();
 					auto currentWeathers = weatherManager->GetCurrentWeathers();
 					ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-					ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.2f, 1.0f), "Weather Override Active");
+					Util::Text::Warning("Weather Override Active");
 					ImGui::TextWrapped("This setting is controlled by the current weather (%s).",
 						currentWeathers.currentWeather ? currentWeathers.currentWeather->GetFormEditorID() : "Unknown");
 					ImGui::Separator();
-					ImGui::TextColored(ImVec4(0.6f, 0.9f, 0.6f, 1.0f), "Click to open CS Editor");
+					Util::Text::Success("Click to open CS Editor");
 					ImGui::PopTextWrapPos();
 					ImGui::EndTooltip();
 				}
@@ -2288,11 +2288,11 @@ namespace Util
 					auto* weatherManager = WeatherManager::GetSingleton();
 					auto currentWeathers = weatherManager->GetCurrentWeathers();
 					ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-					ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.2f, 1.0f), "Weather Override Active");
+					Util::Text::Warning("Weather Override Active");
 					ImGui::TextWrapped("This setting is controlled by the current weather (%s).",
 						currentWeathers.currentWeather ? currentWeathers.currentWeather->GetFormEditorID() : "Unknown");
 					ImGui::Separator();
-					ImGui::TextColored(ImVec4(0.6f, 0.9f, 0.6f, 1.0f), "Click to open CS Editor");
+					Util::Text::Success("Click to open CS Editor");
 					ImGui::PopTextWrapPos();
 					ImGui::EndTooltip();
 				}
@@ -2339,11 +2339,11 @@ namespace Util
 					auto* weatherManager = WeatherManager::GetSingleton();
 					auto currentWeathers = weatherManager->GetCurrentWeathers();
 					ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-					ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.2f, 1.0f), "Weather Override Active");
+					Util::Text::Warning("Weather Override Active");
 					ImGui::TextWrapped("This setting is controlled by the current weather (%s).",
 						currentWeathers.currentWeather ? currentWeathers.currentWeather->GetFormEditorID() : "Unknown");
 					ImGui::Separator();
-					ImGui::TextColored(ImVec4(0.6f, 0.9f, 0.6f, 1.0f), "Click to open CS Editor");
+					Util::Text::Success("Click to open CS Editor");
 					ImGui::PopTextWrapPos();
 					ImGui::EndTooltip();
 				}
@@ -2432,7 +2432,7 @@ namespace Util
 
 				ImGui::BeginTooltip();
 				ImGui::PushTextWrapPos(ImGui::GetFontSize() * 35.0f);
-				ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.2f, 1.0f), "Setting Constrained");
+				Util::Text::Warning("Setting Constrained");
 				ImGui::Text("This setting is constrained by:");
 				ImGui::Spacing();
 				for (const auto& src : constraint.sources) {
@@ -2440,8 +2440,7 @@ namespace Util
 					ImGui::Indent();
 					ImGui::TextWrapped("%s", src.reason.c_str());
 					if (src.recommendDisableAtBoot) {
-						ImGui::TextColored(ImVec4(1.0f, 0.5f, 0.5f, 1.0f),
-							"Consider disabling this feature at boot for best compatibility.");
+						Util::Text::WrappedError("Consider disabling this feature at boot for best compatibility.");
 					}
 					ImGui::Unindent();
 				}


### PR DESCRIPTION
## Upstream sync: Community Shaders `v1.7.0-rc.3`

Merges the 8 commits in upstream's `v1.7.0-rc.3` that postdate `v1.7.0-rc.2` (already an ancestor). Merged **from the tag** per the fork's upstream-sync rule (never cherry-pick), so the upstream commits become ancestors once and future syncs stay clean.

> [!IMPORTANT]
> **Land this with "Create a merge commit" — do NOT squash.** Squashing collapses the merge into a fresh SHA and throws away the ancestry, which re-conflicts every future sync. (`git merge-base --is-ancestor v1.7.0-rc.3 <branch>` must keep passing after landing.)

### Incoming upstream commits
- `fix(wetness): clamp GetRainIntensity to [0, 1]` (#2507)
- `fix(skysync): hide VL when no moon present` (#2506)
- `fix(skysync): base shadow fade advance on game-time delta` (#2505)
- `fix(hdr): exclude menu blur from clean captures` (#2504)
- `chore(UI): fix hardcoded UI colours` (#2501)
- `refactor(skin): move util functions to common` (#2492)
- `fix(input): fire combo hotkeys on press not release` (#2483)
- `ci: prevent PR tags from poisoning dev` (#2500)

### Conflict resolutions (8 files)
| File | Resolution |
|---|---|
| `.github/workflows/pr-checks.yaml` | **upstream** — anchor PR preview tags to the PR head (#2500) so they don't poison dev's semantic-release floor |
| `package/Shaders/Water.hlsl` | **ours (VR)** — keep `#if !defined(VR)` / `PosAdjust[1]` stereo divergence |
| `src/Features/VolumetricLighting.cpp` | **ours (VR)** — keep VR hooks; adopt upstream's `bEnableVolumetricLighting` → `globals::game::` move and repoint all uses |
| `src/Features/HDRDisplay.cpp` | **upstream** — `DispatchHDROutput()` helper (surrounding `sceneSRV`/`uiSRV` setup already VR-aware) |
| `src/Features/LightLimitFix.cpp` | **ours** — fork already defines `DrawOverlay()` in `ShadowRenderer.cpp`; drop upstream's duplicate (it referenced a `Settings` field the fork doesn't have) |
| `src/Menu.cpp` | **upstream** — combo-fire-on-press (#2483); `dispatchHotkeyActions` already contains the fork's Overlay/CSEditor/Screenshot bindings |
| `src/Features/PerformanceOverlay/ABTesting/ABTesting.cpp` | **combine** — adopt `Util::Text::*` color helpers, keep i18n `T()/TKEY()` |
| `src/Utils/UI.cpp` | **combine** — `Util::Text::Warning/Success/WrappedError("%s", T(key, default))` across all 6 hunks |

No VR functionality lost; the VR-sensitive files (Water, VolumetricLighting) resolve in favor of the fork per the VR-maintainer rule.

### Verification
- `ALL` preset builds clean (universal SE/AE/VR binary).
- en.json in sync (`extract-i18n.py --check`).
- ⏳ Pending before merge: SE + VR in-game runtime gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SDR preview mode for HDR rendering display.

* **Improvements**
  * Enhanced HDR screenshot capture with clean scene composition.
  * Improved shadow fade timing during gameplay time progression.
  * Refined hotkey combo handling to prevent accidental duplicate triggers.
  * Updated UI text colors for visual consistency.

* **Bug Fixes**
  * Capped rain intensity to prevent overflow values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->