### PR TITLE
ci(nexus): upload prebuilt shader caches as optional files

### DIFF
--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -201,6 +201,9 @@ jobs:
                   body = release.get('body') or ''
                   body = re.sub(r'\n---\n+# Feature Version Audit\b.*', '', body, flags=re.DOTALL).strip()
                   release_ver = os.environ['RELEASE_VER']
+                  # Prebuilt shader caches are uploaded separately as OPTIONAL files via the
+                  # official Nexus action (see the upload-shader-caches job) — unex can only set
+                  # MAIN files, so they are not part of this (unex) AIO matrix.
                   row = {
                       'name': 'core',
                       'is_core': True,
@@ -209,7 +212,11 @@ jobs:
                       'mod_filename': os.environ['EFFECTIVE_FILENAME'],
                       'auto_upload': True,
                       'changelog': body,
-                      'file_description': f'Open Shaders {release_ver} AIO. See changelog for included features.',
+                      'file_description': (
+                          f'Open Shaders {release_ver} AIO. See changelog for included features. '
+                          'Optional prebuilt shader caches (SE/AE and VR) are available as separate '
+                          'files below to skip first-launch shader compilation.'
+                      ),
                   }
                   with open('nexus-matrix-raw.json', 'w') as f:
                       json.dump([row], f)
@@ -505,6 +512,71 @@ jobs:
         secrets:
             UNEX_NEXUSMODS_SESSION_COOKIE: ${{ secrets.UNEX_NEXUSMODS_SESSION_COOKIE }}
             UNEX_APIKEY: ${{ secrets.UNEX_APIKEY }}
+
+    upload-shader-caches:
+        # Prebuilt shader caches are OPTIONAL files. The unex path above only sets MAIN files,
+        # so the caches use the official Nexus action (file_category + file-group support).
+        # aio mode only; matrix (per-feature) mode does not produce these. Each cache is its own
+        # manually-minted file group on the Open Shaders page; archive_existing_file rolls the
+        # prior version into the group. The .7z come from the release assets attached by the
+        # "Release: Prebuilt Shader Cache" workflow; a runtime is skipped if its asset is absent.
+        name: Upload Prebuilt Shader Caches
+        needs: prepare-nexus-matrix
+        runs-on: ubuntu-latest
+        if: needs.prepare-nexus-matrix.outputs.mode == 'aio'
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - runtime: SE
+                      pattern: ShaderCache-SE-*.7z
+                      file_group_id: "7535987"
+                      display_name: ShaderCache SE/AE
+                    - runtime: VR
+                      pattern: ShaderCache-VR-*.7z
+                      file_group_id: "7535993"
+                      display_name: ShaderCache VR
+        steps:
+            - name: Download cache asset from release
+              id: dl
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  mkdir -p caches
+                  gh release download "${{ needs.prepare-nexus-matrix.outputs.tag }}" \
+                    --repo "$GITHUB_REPOSITORY" --pattern "${{ matrix.pattern }}" --dir caches || true
+                  file=$(find caches -maxdepth 1 -name "${{ matrix.pattern }}" | sort | head -n1)
+                  if [ -z "$file" ]; then
+                    echo "::warning::No ${{ matrix.runtime }} shader-cache asset on release ${{ needs.prepare-nexus-matrix.outputs.tag }} (pattern ${{ matrix.pattern }}); skipping."
+                    echo "found=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "Found cache asset: $file"
+                    echo "file=$file" >> "$GITHUB_OUTPUT"
+                    echo "found=true" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Report planned cache upload
+              if: steps.dl.outputs.found == 'true'
+              run: |
+                  echo "Optional shader cache: ${{ matrix.display_name }} (group ${{ matrix.file_group_id }}) v${{ needs.prepare-nexus-matrix.outputs.version }}"
+                  if [ "${{ needs.prepare-nexus-matrix.outputs.dry_run }}" = "true" ]; then
+                    echo "Dry run: skipping actual upload."
+                  fi
+
+            - name: Upload optional shader cache to Nexus
+              if: steps.dl.outputs.found == 'true' && needs.prepare-nexus-matrix.outputs.dry_run != 'true'
+              uses: Nexus-Mods/upload-action@0bf670d75d46988c176c9bfacc94ca0144e0fe3f # v1.0.0-beta.7
+              with:
+                  api_key: ${{ secrets.UNEX_APIKEY }}
+                  file_group_id: ${{ matrix.file_group_id }}
+                  filename: ${{ steps.dl.outputs.file }}
+                  display_name: ${{ matrix.display_name }}
+                  version: ${{ needs.prepare-nexus-matrix.outputs.version }}
+                  file_category: optional
+                  archive_existing_file: true
+                  description: >-
+                      Prebuilt shader cache for default AIO settings. If you install any other
+                      optional features or tweak settings, this will not help you. Must match AIO version.
 
     upload-summary:
         name: Upload Summary

--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -46,6 +46,14 @@ on:
             changelog:
                 description: "Optional release notes or changelog for Nexus"
                 required: false
+            shader_cache_uploader:
+                description: "Uploader for the optional prebuilt shader caches (aio mode). 'official' = Nexus-Mods/upload-action (sets the OPTIONAL category + file groups); 'none' = skip. unex is not offered here: it can only set MAIN files."
+                required: false
+                type: choice
+                default: "official"
+                options:
+                    - "official"
+                    - "none"
     workflow_call:
         inputs:
             mode:
@@ -80,6 +88,10 @@ on:
                 required: false
                 type: string
                 default: ""
+            shader_cache_uploader:
+                required: false
+                type: string
+                default: "official"
         secrets:
             UNEX_NEXUSMODS_SESSION_COOKIE:
                 required: false
@@ -523,7 +535,9 @@ jobs:
         name: Upload Prebuilt Shader Caches
         needs: prepare-nexus-matrix
         runs-on: ubuntu-latest
-        if: needs.prepare-nexus-matrix.outputs.mode == 'aio'
+        if: >
+            needs.prepare-nexus-matrix.outputs.mode == 'aio' &&
+            (inputs.shader_cache_uploader || 'official') == 'official'
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -527,14 +527,12 @@ jobs:
 
     upload-shader-caches:
         # Prebuilt shader caches are OPTIONAL files. The unex path above only sets MAIN files,
-        # so the caches use the official Nexus action (file_category + file-group support).
-        # aio mode only; matrix (per-feature) mode does not produce these. Each cache is its own
-        # manually-minted file group on the Open Shaders page; archive_existing_file rolls the
-        # prior version into the group. The .7z come from the release assets attached by the
-        # "Release: Prebuilt Shader Cache" workflow; a runtime is skipped if its asset is absent.
-        name: Upload Prebuilt Shader Caches
+        # so the caches use the official-action reusable workflow (file_category + file-group
+        # support). aio mode only; each cache is its own manually-minted file group on the Open
+        # Shaders page, and archive_existing_file rolls the prior version into the group. The .7z
+        # come from the release assets attached by the "Release: Prebuilt Shader Cache" workflow;
+        # a runtime is skipped (warning) if its asset is absent.
         needs: prepare-nexus-matrix
-        runs-on: ubuntu-latest
         if: >
             needs.prepare-nexus-matrix.outputs.mode == 'aio' &&
             (inputs.shader_cache_uploader || 'official') == 'official'
@@ -542,55 +540,27 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - runtime: SE
+                    - file_group_id: "7535987"
                       pattern: ShaderCache-SE-*.7z
-                      file_group_id: "7535987"
                       display_name: ShaderCache SE/AE
-                    - runtime: VR
+                    - file_group_id: "7535993"
                       pattern: ShaderCache-VR-*.7z
-                      file_group_id: "7535993"
                       display_name: ShaderCache VR
-        steps:
-            - name: Download cache asset from release
-              id: dl
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  mkdir -p caches
-                  gh release download "${{ needs.prepare-nexus-matrix.outputs.tag }}" \
-                    --repo "$GITHUB_REPOSITORY" --pattern "${{ matrix.pattern }}" --dir caches || true
-                  file=$(find caches -maxdepth 1 -name "${{ matrix.pattern }}" | sort | head -n1)
-                  if [ -z "$file" ]; then
-                    echo "::warning::No ${{ matrix.runtime }} shader-cache asset on release ${{ needs.prepare-nexus-matrix.outputs.tag }} (pattern ${{ matrix.pattern }}); skipping."
-                    echo "found=false" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "Found cache asset: $file"
-                    echo "file=$file" >> "$GITHUB_OUTPUT"
-                    echo "found=true" >> "$GITHUB_OUTPUT"
-                  fi
-
-            - name: Report planned cache upload
-              if: steps.dl.outputs.found == 'true'
-              run: |
-                  echo "Optional shader cache: ${{ matrix.display_name }} (group ${{ matrix.file_group_id }}) v${{ needs.prepare-nexus-matrix.outputs.version }}"
-                  if [ "${{ needs.prepare-nexus-matrix.outputs.dry_run }}" = "true" ]; then
-                    echo "Dry run: skipping actual upload."
-                  fi
-
-            - name: Upload optional shader cache to Nexus
-              if: steps.dl.outputs.found == 'true' && needs.prepare-nexus-matrix.outputs.dry_run != 'true'
-              uses: Nexus-Mods/upload-action@0bf670d75d46988c176c9bfacc94ca0144e0fe3f # v1.0.0-beta.7
-              with:
-                  api_key: ${{ secrets.UNEX_APIKEY }}
-                  file_group_id: ${{ matrix.file_group_id }}
-                  filename: ${{ steps.dl.outputs.file }}
-                  display_name: ${{ matrix.display_name }}
-                  version: ${{ needs.prepare-nexus-matrix.outputs.version }}
-                  file_category: optional
-                  archive_existing_file: true
-                  description: >-
-                      Prebuilt shader cache for default AIO settings. If you install any other
-                      optional features or tweak settings, this will not help you. Must match AIO version.
+        uses: alandtse/nexus-workflows/.github/workflows/upload-nexus-official.yml@main
+        with:
+            file_group_id: ${{ matrix.file_group_id }}
+            version: ${{ needs.prepare-nexus-matrix.outputs.version }}
+            tag_name: ${{ needs.prepare-nexus-matrix.outputs.tag }}
+            artifact_pattern: ${{ matrix.pattern }}
+            file_category: optional
+            display_name: ${{ matrix.display_name }}
+            archive_existing_file: true
+            dry_run: ${{ needs.prepare-nexus-matrix.outputs.dry_run == 'true' }}
+            description: >-
+                Prebuilt shader cache for default AIO settings. If you install any other
+                optional features or tweak settings, this will not help you. Must match AIO version.
+        secrets:
+            UNEX_APIKEY: ${{ secrets.UNEX_APIKEY }}
 
     upload-summary:
         name: Upload Summary


### PR DESCRIPTION
## What

Upload the prebuilt shader caches to the **Open Shaders** Nexus page as **OPTIONAL** files, version-matched to the AIO.

A new `upload-shader-caches` job in `nexus-upload.yaml` calls the reusable **[`alandtse/nexus-workflows` → `upload-nexus-official.yml`](https://github.com/alandtse/Nexus-Workflows/pull/5)** (which wraps the official `Nexus-Mods/upload-action`):

| Runtime | File group | Pattern | Category | Display name |
|---|---|---|---|---|
| SE/AE | `7535987` | `ShaderCache-SE-*.7z` | `optional` | `ShaderCache SE/AE` |
| VR | `7535993` | `ShaderCache-VR-*.7z` | `optional` | `ShaderCache VR` |

Shared description (per request):
> Prebuilt shader cache for default AIO settings. If you install any other optional features or tweak settings, this will not help you. Must match AIO version.

Behavior: `file_category: optional` + the manually-minted `file_group_id`s; `archive_existing_file: true` rolls the prior version into the group; version matches the AIO; `.7z` come from the release assets the **Release: Prebuilt Shader Cache** workflow attaches; a runtime is skipped (warning) if absent; aio mode only; dry-run reports without uploading.

## Why a reusable workflow (not unex, not an inline action)

unex (the AIO path) can only set **MAIN** files — no category control — so the caches can't ride the AIO matrix. The official action supports `file_category` + `file_group_id`; it lives in the unified `nexus-workflows` repo as a reusable workflow so other mods can use it too.

## Gating

New `shader_cache_uploader` setting (`workflow_dispatch` choice `official`/`none`, `workflow_call` string, default `official`) gates the job, so callers can opt out or pick the uploader.

## Backward compatibility

The existing unex AIO matrix and `upload-nexus.yml` are **untouched** — the official path is a separate, additive reusable workflow. No impact on other `nexus-workflows@main` consumers.

The AIO file description now points users at the optional caches.

## Depends on

- **[alandtse/Nexus-Workflows#5](https://github.com/alandtse/Nexus-Workflows/pull/5)** — the reusable `upload-nexus-official.yml`. Merge that first; this references it at `@main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
