### PR TITLE
build(profiler): fix Tracy GPU zone against the bumped Tracy

### DIFF
--- a/src/GpuPass.cpp
+++ b/src/GpuPass.cpp
@@ -29,15 +29,16 @@ ScopedGpuPass::ScopedGpuPass(std::string_view name)
 		cpuZoneCtx = ___tracy_emit_zone_begin_alloc(srcloc, true);
 	}
 
-	// 3. Tracy GPU zone — requires a D3D11 context from State.
+	// 3. Tracy GPU zone — requires a D3D11 context from State. Use the raw
+	//    source-location overload for a dynamic (transient) zone name; the bundled
+	//    Tracy dropped the alloc'd-uint64-srcloc D3D11ZoneScope overload. depth=0.
 	if (state && state->tracyCtx) {
-		const auto srcloc = ___tracy_alloc_srcloc_name(
-			0,
+		gpuZone.emplace(state->tracyCtx,
+			uint32_t(0),
 			"GpuPass", sizeof("GpuPass") - 1,
 			"ScopedGpuPass", sizeof("ScopedGpuPass") - 1,
 			name.data(), name.size(),
-			0);
-		gpuZone.emplace(state->tracyCtx, srcloc, 0, true);
+			0, true);
 	}
 #endif
 


### PR DESCRIPTION
## What

`ScopedGpuPass` (the `CS_GPU_PASS` RAII, single instrumentation point for all GPU passes) constructed its `tracy::D3D11ZoneScope` from an alloc'd `uint64` source location (`___tracy_alloc_srcloc_name`). The Tracy master snapshot pinned in #26 (`0.13.3-14a1a322`) **dropped that `D3D11ZoneScope` overload** — it now takes a `SourceLocationData*` or the raw source-location components. Switched the GPU zone to the raw-string (transient) overload that the snapshot provides.

## Why it went unnoticed

`TRACY_SUPPORT` is **off by default**, so no normal or CI build compiles this path — it's been a latent break since the Tracy bump in #26 (2026-05-20). Surfaced when building `-DTRACY_SUPPORT=ON` to profile a feature.

## Scope

One file (`src/GpuPass.cpp`). The other `D3D11ZoneScope` sites (`Deferred.cpp`, `Upscaling.cpp`) already use valid overloads; `-DTRACY_SUPPORT=ON` builds clean after this. No runtime/user-facing change — build fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal GPU-zone initialization for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->