### PR TITLE
docs(hdr): drop future-HDR-HMD TODO

### DIFF
--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -235,15 +235,6 @@ namespace
 			// ISCopy reads kFRAMEBUFFER.SRV to distribute the frame to the HMD and
 			// companion window, so we must write the tonemapped content back into
 			// kFRAMEBUFFER before ISCopy runs.
-			//
-			// TODO (future HDR HMD support): The correct pipeline is to run the full
-			// HDR composite (PQ encode, paper white, peak nits) HERE, writing the
-			// result back to kFRAMEBUFFER so ISCopy distributes HDR-processed content
-			// to both the HMD and companion at their native sizes.  The post-Present
-			// ApplyHDR path cannot do this correctly because ISCopy has already run
-			// and the companion back buffer (1024x1024) does not match outputTexture
-			// (sized from kMAIN).  Requires hooking the ISCopy vfunc to fire
-			// HDROutputCS before distribution.
 			if (globals::game::isVR && hdr->settings.enableHDR &&
 				hdr->hdrTexture && hdr->hdrTexture->resource) {
 				auto& fb = globals::game::renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kFRAMEBUFFER];


### PR DESCRIPTION
Removes the future HDR-HMD pipeline `TODO` in `HDRDisplay.cpp`. No HDR VR HMD exists on the market, so it isn't actionable, and `alstr/todo-to-issue-action` kept regenerating issues from it (the duplicate set #146 / #162 / #164).

The current-behavior comment for the VR `kFRAMEBUFFER` copy stays; the design note lives in git history. Closes the duplicate auto-issues once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)