### PR TITLE
fix(vr): gate VL dispatch on enable flag value

### DIFF
--- a/src/Features/VolumetricLighting.cpp
+++ b/src/Features/VolumetricLighting.cpp
@@ -280,7 +280,7 @@ void VolumetricLighting::RenderVolumetricLighting(VolumetricLightingDescriptor* 
 void VolumetricLighting::RenderDepth::thunk()
 {
 	func();
-	if (globals::game::bEnableVolumetricLighting)
+	if (globals::game::bEnableVolumetricLighting && *globals::game::bEnableVolumetricLighting)
 		RenderVolumetricLighting(&GetVLDescriptor(), RE::Main::WorldRootCamera(), false);
 }
 
@@ -351,7 +351,7 @@ void VolumetricLighting::CopyResource::thunk(ID3D11DeviceContext* a_this, ID3D11
 	// But, the copy might have to be done manually later after IsFullScreenVR if
 	// used in the next frame.
 
-	if (!(Util::IsDynamicResolution() && globals::game::bEnableVolumetricLighting)) {
+	if (!(Util::IsDynamicResolution() && globals::game::bEnableVolumetricLighting && *globals::game::bEnableVolumetricLighting)) {
 		a_this->CopyResource(a_renderTarget, a_renderTargetSource);
 	}
 }


### PR DESCRIPTION
## What

`VolumetricLighting::RenderDepth::thunk` (a VR-only hook) gated the VL dispatch on `if (globals::game::bEnableVolumetricLighting)` — but that symbol is a `bool*` (`RelocationID(527940, 414913)`) that is **always non-null after init**, so the branch was unconditionally taken and VL dispatched every frame regardless of whether the feature was enabled. The fix also dereferences the flag (`&& *globals::game::bEnableVolumetricLighting`). The same correction is applied to the dynamic-resolution `CopyResource` gate, which had silently collapsed to `!IsDynamicResolution()` for the same reason.

Pre-existing bug (predates the v1.7.0-rc.3 sync; the rc.3 `globals::game::` rename was behavior-preserving). Resolves the VL item in #165.

## RenderDoc verification (VR A/B)

Captured the same scene (interior `WhiterunBanneredMare`) on both builds, with the engine VL-enable global confirmed `false` in the runtime log for both (`[VL] Changing bVolumetricLightingEnabled_143232EF0 from true to false`):

| Build | enable flag | VL froxel dispatches (320×192×90) |
|---|---|---|
| **before** (`if (ptr)`) | false | **2 present** — VL renders while disabled |
| **after** (`if (ptr && *ptr)`) | false | **0** — correctly skipped |

The VL pass is the two compute dispatches writing the 320×192×90 froxel volume (matches `VolumetricLighting` InteriorCustomSize 320/192/90 in `SettingsDefault.json`). Identical scene + flag state; only the DLL differs.

## Scope / risk

VR-only behavior change (the VR `RenderDepth` thunk and the VR `CopyResource` hook are both installed only under `globals::game::isVR`). SE/AE are unaffected by this code path. Null-safe (pointer checked before deref); reuses the existing global, same pattern as `SkySync.cpp`.
