### PR TITLE
feat(llf): devbench shadow-scheduler diagnostics dump

### DIFF
--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -19,6 +19,8 @@
 
 #include <exprtk.hpp>
 
+#include <mutex>
+
 #define I18N_KEY_PREFIX "feature.light_limit_fix."
 
 namespace ShadowCasterManager
@@ -1816,6 +1818,42 @@ namespace ShadowCasterManager
 	};
 	static std::unordered_map<uintptr_t, ConvertReason> s_convertReason;
 
+	// Headless scheduling-diagnostics snapshot (devbench `inspect kind=llfshadows`).
+	// The scheduler (render thread) fills s_schedSnapshot under the mutex at pass end;
+	// RequestSchedSnapshot (devbench listener thread) reads it under the same mutex.
+	// s_schedDumpFrames latches a short window of passes to keep filling it after a
+	// request, so polling returns fresh data even while the menu is closed.
+	static std::mutex s_schedSnapshotMutex;
+	static SchedSnapshot s_schedSnapshot;
+	static std::atomic<int> s_schedDumpFrames{ 0 };
+
+	const char* SchedReasonName(uint8_t a_reason)
+	{
+		switch (static_cast<ConvertReason>(a_reason)) {
+		case ConvertReason::Portal:
+			return "portal";
+		case ConvertReason::FrustumDistance:
+			return "frustum";
+		case ConvertReason::LodFaded:
+			return "lod";
+		case ConvertReason::Excess:
+			return "excess";
+		case ConvertReason::CameraOther:
+			return "other";
+		default:
+			return "none";
+		}
+	}
+
+	SchedSnapshot RequestSchedSnapshot()
+	{
+		// Prime ~2s of scheduling passes so repeated polls return fresh data even with
+		// the menu closed; hand back the latest snapshot under the lock.
+		s_schedDumpFrames.store(120, std::memory_order_relaxed);
+		std::scoped_lock lock(s_schedSnapshotMutex);
+		return s_schedSnapshot;
+	}
+
 	static const char* ConvertReasonText(uintptr_t a_key)
 	{
 		auto it = s_convertReason.find(a_key);
@@ -1865,6 +1903,12 @@ namespace ShadowCasterManager
 		// pass runs UpdateCamera (which reads the cached square). No-op unless
 		// MatchShadowToLightFade is enabled.
 		ApplyShadowToLightFadeMatch();
+
+		// Maintain the demotion diagnostics this pass only when something can read them:
+		// the open settings menu (Conv tooltip) or a recent devbench dump request. Keeps
+		// the per-light hash churn + snapshot copy off the hot path otherwise.
+		const bool wantDiag = Menu::GetSingleton()->IsEnabled ||
+		                      s_schedDumpFrames.load(std::memory_order_relaxed) > 0;
 
 		// Read the engine's per-frame focus-shadow actor count and reserve
 		// matching pool slots. Eject any point lights that occupy a slot the
@@ -2093,11 +2137,9 @@ namespace ShadowCasterManager
 			// Tracy candidate breakdown: emits per-frame so a capture can be
 			// queried alongside the per-action counters to verify the math
 			// (chosen + excess + invalid_camera + invalid_portal == total).
-			// The demotion map is read only by the shadow-table Conv tooltip, so
-			// maintain it only while the settings menu is open -- skip the per-frame
-			// hash churn on the scheduler hot path when nothing can display it.
-			const bool wantConvertReason = Menu::GetSingleton()->IsEnabled;
-			if (wantConvertReason)
+			// Populate the demotion map only when wantDiag (menu open or a devbench
+			// dump was requested) -- skip the per-frame hash churn otherwise.
+			if (wantDiag)
 				s_convertReason.clear();
 			for (auto& c : candidates) {
 				s_schedDiag.candidates_total++;
@@ -2109,7 +2151,7 @@ namespace ShadowCasterManager
 				// Capture why a non-chosen light is demoted, for the shadow table.
 				// Portal wins (distinct disable path), then frustum/distance, LOD,
 				// excess -- matching the atomic loop's branch precedence.
-				if (wantConvertReason && !c.chosen) {
+				if (wantDiag && !c.chosen) {
 					ConvertReason r = ConvertReason::None;
 					if (c.invalidPortal)
 						r = ConvertReason::Portal;
@@ -2956,6 +2998,34 @@ namespace ShadowCasterManager
 			for (int i = 0; i < s_lights.Size; i++)
 				if (s_lights.Lights[i].Light)
 					s_schedDiag.slots_in_use++;
+
+			// Publish the scheduling snapshot for headless inspection (devbench
+			// inspect kind=llfshadows). wantDiag already gated the per-light reason
+			// capture above; copy + swap under the lock so the listener thread reads a
+			// consistent snapshot, then consume one dump-request pass.
+			if (wantDiag) {
+				SchedSnapshot snap;
+				snap.valid = true;
+				snap.frame = globals::state ? globals::state->frameCountAtomic.load(std::memory_order_relaxed) : 0u;
+				snap.total = s_schedDiag.candidates_total;
+				snap.chosen = s_schedDiag.candidates_chosen;
+				snap.excess = s_schedDiag.candidates_excess;
+				snap.invalidCamera = s_schedDiag.candidates_invalid_camera;
+				snap.invalidPortal = s_schedDiag.candidates_invalid_portal;
+				snap.invalidFrustum = s_schedDiag.candidates_invalid_frustum;
+				snap.invalidLod = s_schedDiag.candidates_invalid_lod;
+				snap.invalidOther = s_schedDiag.candidates_invalid_other;
+				snap.slotsInUse = s_schedDiag.slots_in_use;
+				snap.demoted.reserve(s_convertReason.size());
+				for (const auto& [ptr, reason] : s_convertReason)
+					snap.demoted.emplace_back(ptr, static_cast<uint8_t>(reason));
+				{
+					std::scoped_lock lock(s_schedSnapshotMutex);
+					s_schedSnapshot = std::move(snap);
+				}
+				if (s_schedDumpFrames.load(std::memory_order_relaxed) > 0)
+					s_schedDumpFrames.fetch_sub(1, std::memory_order_relaxed);
+			}
 
 			TracyPlot("scm.candidates.total", (int64_t)s_schedDiag.candidates_total);
 			TracyPlot("scm.candidates.chosen", (int64_t)s_schedDiag.candidates_chosen);

--- a/src/Features/LightLimitFix/ShadowCasterManager.h
+++ b/src/Features/LightLimitFix/ShadowCasterManager.h
@@ -515,6 +515,39 @@ namespace ShadowCasterManager
 	bool HasAnyOverrides();
 
 	// -------------------------------------------------------------------------
+	// Scheduling diagnostics snapshot (headless inspection via devbench
+	// `inspect kind=llfshadows`). The scheduler fills it only while the settings
+	// menu is open or a snapshot was recently requested, to keep diagnostics off
+	// the hot path otherwise.
+	// -------------------------------------------------------------------------
+	struct SchedSnapshot
+	{
+		bool valid = false;      ///< false until at least one pass has filled it
+		uint32_t frame = 0;      ///< render frame the snapshot was taken on
+		int total = 0;           ///< candidates examined this pass
+		int chosen = 0;          ///< picked as shadow casters
+		int excess = 0;          ///< over the shadow-caster budget
+		int invalidCamera = 0;   ///< rejected by the engine UpdateCamera test
+		int invalidPortal = 0;   ///< portal-graph unreachable
+		int invalidFrustum = 0;  ///< off-screen / beyond shadow-cull distance
+		int invalidLod = 0;      ///< past the light's LOD fade-out distance
+		int invalidOther = 0;    ///< UpdateCamera failure, neither frustum nor LOD
+		int slotsInUse = 0;      ///< occupied shadow slots at pass end
+		/// Per non-chosen light: (light pointer, demotion-reason byte). Name via SchedReasonName().
+		std::vector<std::pair<uintptr_t, uint8_t>> demoted;
+	};
+
+	/// Requests and returns the latest scheduling-diagnostics snapshot. Thread-safe
+	/// (callable off the render thread). The request primes the scheduler to fill the
+	/// snapshot for a short window, so the first call after an idle period may return a
+	/// stale/empty snapshot (valid == false) -- poll again after a frame for fresh data.
+	SchedSnapshot RequestSchedSnapshot();
+
+	/// Stable lowercase name for a demotion-reason byte (SchedSnapshot::demoted.second):
+	/// "portal" | "frustum" | "lod" | "excess" | "other" | "none".
+	const char* SchedReasonName(uint8_t reason);
+
+	// -------------------------------------------------------------------------
 	// Debugging override API
 	//
 	// Per-light state pins (Shadow / Convert) override the scheduler's automatic

--- a/src/Features/RemoteControl/DevBenchBridge.cpp
+++ b/src/Features/RemoteControl/DevBenchBridge.cpp
@@ -14,6 +14,7 @@
 #ifdef DEVBENCH_BRIDGE_ENABLED
 
 #	include "Feature.h"
+#	include "Features/LightLimitFix/ShadowCasterManager.h"
 #	include "Features/RenderDoc.h"
 #	include "Features/ScreenshotFeature.h"
 #	include "Globals.h"
@@ -27,6 +28,7 @@
 #	include <algorithm>
 #	include <chrono>
 #	include <cstring>
+#	include <format>
 #	include <functional>
 #	include <future>
 #	include <memory>
@@ -313,6 +315,35 @@ namespace
 		};
 	}
 
+	// Light Limit Fix shadow-scheduler diagnostics. RequestSchedSnapshot is thread-safe
+	// (snapshot copied under a mutex by the render thread) and primes the scheduler to
+	// keep filling it for a short window, so a first idle call may return valid=false --
+	// poll again after a frame. Light pointers are hex strings (JSON-number-safe).
+	json BuildInspectShadowsResult(const json&)
+	{
+		const auto snap = ShadowCasterManager::RequestSchedSnapshot();
+		json lights = json::array();
+		for (const auto& [ptr, reason] : snap.demoted)
+			lights.push_back(json{
+				{ "ptr", std::format("{:#018x}", ptr) },
+				{ "reason", ShadowCasterManager::SchedReasonName(reason) },
+			});
+		return json{
+			{ "valid", snap.valid },
+			{ "frame", snap.frame },
+			{ "total", snap.total },
+			{ "chosen", snap.chosen },
+			{ "excess", snap.excess },
+			{ "invalidCamera", snap.invalidCamera },
+			{ "invalidPortal", snap.invalidPortal },
+			{ "invalidFrustum", snap.invalidFrustum },
+			{ "invalidLod", snap.invalidLod },
+			{ "invalidOther", snap.invalidOther },
+			{ "slotsInUse", snap.slotsInUse },
+			{ "lights", lights },
+		};
+	}
+
 	void InspectStateHandler(void*, const char* a_argsJson, void* a_sink, DevBenchAPI::WriteFn a_write)
 	{
 		RunHandler(&BuildInspectStateResult, a_argsJson, a_sink, a_write);
@@ -321,6 +352,11 @@ namespace
 	void InspectShadercacheHandler(void*, const char* a_argsJson, void* a_sink, DevBenchAPI::WriteFn a_write)
 	{
 		RunHandler(&BuildInspectShadercacheResult, a_argsJson, a_sink, a_write);
+	}
+
+	void InspectShadowsHandler(void*, const char* a_argsJson, void* a_sink, DevBenchAPI::WriteFn a_write)
+	{
+		RunHandler(&BuildInspectShadowsResult, a_argsJson, a_sink, a_write);
 	}
 
 	// ---- shadercache: clear / delete the compiled cache -------------------------------
@@ -567,6 +603,10 @@ namespace DevBenchBridge
 			static constexpr const char* inspectCacheDesc =
 				R"({"description":"Open Shaders shader-cache status -> {compiling,completedTasks,totalTasks,failedTasks,currentFailedCount,frame_count}. Poll completedTasks against a pre-deploy snapshot to know a hot-reloaded shader finished; watch failedTasks/currentFailedCount for failed compiles.","readOnly":true,"inputSchema":{"type":"object"}})";
 			dvb->RegisterToolExtension("inspect", "shadercache", inspectCacheDesc, &InspectShadercacheHandler, nullptr);
+
+			static constexpr const char* inspectShadowsDesc =
+				R"({"description":"Open Shaders Light Limit Fix shadow-scheduler diagnostics -> {valid,frame,total,chosen,excess,invalidCamera,invalidPortal,invalidFrustum,invalidLod,invalidOther,slotsInUse,lights:[{ptr,reason}]}. reason: portal|frustum|lod|excess|other -- why a non-chosen light was demoted from a shadow caster. The scheduler fills this only while the settings menu is open or a dump was recently requested; calling this primes it, so if valid==false (idle) poll again after a frame (use inspect kind=openshaders frame_count to know a tick passed).","readOnly":true,"inputSchema":{"type":"object"}})";
+			dvb->RegisterToolExtension("inspect", "llfshadows", inspectShadowsDesc, &InspectShadowsHandler, nullptr);
 		} else {
 			logger::info("DevBenchBridge: devbench build {} < 10500; CS menu + inspect extensions need 1.5.0", dvb->GetBuildNumber());
 		}


### PR DESCRIPTION
## Summary

Adds `inspect kind=llfshadows` to the devbench bridge — headless inspection of the Light Limit Fix shadow scheduler, so shadow QA (incl. the SE/VR runtime tests) can query **why** a light was demoted without opening the in-game menu.

```
inspect kind=llfshadows ->
{ valid, frame, total, chosen, excess,
  invalidCamera, invalidPortal, invalidFrustum, invalidLod, invalidOther,
  slotsInUse, lights:[{ ptr:"0x…", reason:"portal|frustum|lod|excess|other" }] }
```

## Design
- `ShadowCasterManager::RequestSchedSnapshot()` is **thread-safe**: the render-thread scheduler fills a mutex-guarded `SchedSnapshot` at pass end; the devbench listener thread reads a copy under the same lock. No cross-thread map iteration, no live-pointer deref (light keys are integers/hex strings only — coc-safe by construction).
- The per-light reason map gate is **generalized** from menu-open-only (PR #168) to `Menu::IsEnabled || dumpRequested`. A request latches ~120 scheduling passes (~2 s), so polling returns fresh data with the menu closed. First idle call returns `valid:false` and primes — poll again after a frame.
- No new localized strings (reason names are stable API tokens).

## Stacked on #168
Branched off `feat/llf-shadow-distance` (needs its `ConvertReason` machinery). Base will be retargeted to `dev` once #168 lands. Diff here shows only the dump.

## Testing
- Builds clean (ALL).
- SE runtime: querying `inspect kind=llfshadows` + coc-with-table-open guard check — _in progress_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)