### PR TITLE
ci: SE cache name fix + MSVC retry + idempotent cache uploads

### DIFF
--- a/.github/actions/setup-build-environment/action.yaml
+++ b/.github/actions/setup-build-environment/action.yaml
@@ -74,25 +74,25 @@ runs:
           shell: pwsh
           run: |
               "int main() { return 0; }" | Out-File -FilePath "dummy.cpp" -Encoding ASCII
-              $output = & cl.exe /Bv dummy.cpp 2>&1
+              # After a reboot-pending VS Build Tools install (exit 3010), cl.exe
+              # can be transiently unresolvable / emit no version on the first
+              # probe — the flake that fails the cache-build jobs. Retry the probe.
               $version = $null
-              $lines = $output -split "`n|`r"
-              foreach ($line in $lines) {
-                  if ($line -match 'Version ([0-9]+\.[0-9]+\.[0-9]+)') {
-                      $version = $Matches[1]
-                      break
+              for ($attempt = 1; $attempt -le 5 -and -not $version; $attempt++) {
+                  if ($attempt -gt 1) {
+                      Write-Warning "MSVC probe attempt $attempt: cl.exe not ready yet, retrying..."
+                      Start-Sleep -Seconds 10
                   }
-                  elseif ($line -match '([0-9]+\.[0-9]+\.[0-9]+)') {
-                      $version = $Matches[1]
-                      break
-                  }
-              }
-              if (-not $version) {
-                  if ($output -match 'Version ([0-9]+\.[0-9]+\.[0-9]+)') {
-                      $version = $Matches[1]
-                  }
-                  elseif ($output -match '([0-9]+\.[0-9]+\.[0-9]+)') {
-                      $version = $Matches[1]
+                  try { $output = & cl.exe /Bv dummy.cpp 2>&1 } catch { $output = "$_" }
+                  foreach ($line in ($output -split "`n|`r")) {
+                      if ($line -match 'Version ([0-9]+\.[0-9]+\.[0-9]+)') {
+                          $version = $Matches[1]
+                          break
+                      }
+                      elseif ($line -match '([0-9]+\.[0-9]+\.[0-9]+)') {
+                          $version = $Matches[1]
+                          break
+                      }
                   }
               }
               if ($version) {
@@ -107,7 +107,7 @@ runs:
                       Add-Content -Path $env:GITHUB_OUTPUT -Value "version_mm=$version" -Encoding UTF8
                   }
               } else {
-                  throw "MSVC version not found"
+                  throw "MSVC version not found after 5 cl.exe probe attempts"
               }
               Remove-Item "dummy.cpp" -ErrorAction SilentlyContinue
 

--- a/.github/actions/setup-build-environment/action.yaml
+++ b/.github/actions/setup-build-environment/action.yaml
@@ -80,7 +80,7 @@ runs:
               $version = $null
               for ($attempt = 1; $attempt -le 5 -and -not $version; $attempt++) {
                   if ($attempt -gt 1) {
-                      Write-Warning "MSVC probe attempt $attempt: cl.exe not ready yet, retrying..."
+                      Write-Warning "MSVC probe attempt ${attempt}: cl.exe not ready yet, retrying..."
                       Start-Sleep -Seconds 10
                   }
                   try { $output = & cl.exe /Bv dummy.cpp 2>&1 } catch { $output = "$_" }

--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -540,9 +540,11 @@ jobs:
             fail-fast: false
             matrix:
                 include:
+                    # display_name is the Nexus file/version name; it must match
+                    # ^[a-zA-Z0-9 _'().-]+$ (no '/'), so use "SE-AE" not "SE/AE".
                     - file_group_id: "7535987"
                       pattern: ShaderCache-SE-*.7z
-                      display_name: ShaderCache SE/AE
+                      display_name: ShaderCache SE-AE
                     - file_group_id: "7535993"
                       pattern: ShaderCache-VR-*.7z
                       display_name: ShaderCache VR

--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -557,6 +557,11 @@ jobs:
             file_category: optional
             display_name: ${{ matrix.display_name }}
             archive_existing_file: true
+            # Idempotent re-runs: skip a cache already on the page (matches the
+            # AIO uploader's check_existing). Requires the mod ID for the query.
+            check_existing: true
+            nexus_mod_id: ${{ inputs.nexus_mod_id || '180419' }}
+            nexus_game_id: ${{ inputs.nexus_game_id || 'skyrimspecialedition' }}
             dry_run: ${{ needs.prepare-nexus-matrix.outputs.dry_run == 'true' }}
             description: >-
                 Prebuilt shader cache for default AIO settings. If you install any other


### PR DESCRIPTION
Two CI fixes uncovered while shipping `v1.8.0`.

## 1. SE shader-cache upload was failing (Nexus 422)
`upload-shader-caches` for SE/AE failed every run with:
```
422 Unprocessable Content: name pattern ^[a-zA-Z0-9 _'().-]+$ does not match value: "ShaderCache SE/AE"
```
The `display_name` `ShaderCache SE/AE` contains a `/`, which the Nexus file-update-group API rejects. Renamed to **`ShaderCache SE-AE`**. (VR was unaffected — `ShaderCache VR` has no slash and uploaded fine.)

## 2. Cache-build jobs flake on VS toolchain setup
The release shader-validation (cache-build) jobs intermittently fail at toolchain setup: the VS Build Tools installer returns reboot-pending (exit `3010`), then the immediate `cl.exe /Bv` probe finds no version → **`MSVC version not found`** and the job dies (so no cache `.7z` is produced). The plugin build job, with the same setup, gets a clean install — so it's a transient post-install settle race.

Wrap the `cl.exe` MSVC-version probe in a **retry loop (5 attempts, 10s apart)** so it survives the race instead of failing the job.

> Scoped mitigation for the observed transient. If the install genuinely fails to register (not just settle-lag), a deeper fix (retry the install / self-hosted runner with VS 2026 pre-baked) would be the follow-up.

`ci:` — no release impact. Companion to a `nexus-workflows` PR adding `check_existing` to the official cache uploader (so cache re-uploads are idempotent like the AIO already is).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced reliability of build environment setup with improved error handling and retry logic
  * Corrected deployment artifact naming to meet platform requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->