### PR TITLE
ci: keep superseded shader caches downloadable (no archive)

### DIFF
--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -529,7 +529,8 @@ jobs:
         # Prebuilt shader caches are OPTIONAL files. The unex path above only sets MAIN files,
         # so the caches use the official-action reusable workflow (file_category + file-group
         # support). aio mode only; each cache is its own manually-minted file group on the Open
-        # Shaders page, and archive_existing_file rolls the prior version into the group. The .7z
+        # Shaders page. archive_existing_file=false keeps superseded caches as
+        # downloadable old versions (archived files are hidden on Nexus). The .7z
         # come from the release assets attached by the "Release: Prebuilt Shader Cache" workflow;
         # a runtime is skipped (warning) if its asset is absent.
         needs: prepare-nexus-matrix
@@ -556,7 +557,11 @@ jobs:
             artifact_pattern: ${{ matrix.pattern }}
             file_category: optional
             display_name: ${{ matrix.display_name }}
-            archive_existing_file: true
+            # Don't archive the superseded cache — archived files are hidden on
+            # Nexus, but users on an older AIO still need the matching old cache.
+            # false keeps the prior version as a downloadable old version of the
+            # group instead of hiding it.
+            archive_existing_file: false
             # Idempotent re-runs: skip a cache already on the page (matches the
             # AIO uploader's check_existing). Requires the mod ID for the query.
             check_existing: true


### PR DESCRIPTION
## What

Flip `archive_existing_file` from `true` → `false` for both shader-cache uploads (SE/AE + VR).

## Why

On Nexus, **archived files are hidden / not downloadable** — only files in the "Old" state are downloadable. With `archive_existing_file: true`, each new cache **hid** the previous one, so a user still on an older AIO couldn't get the matching older cache.

With `false`, the superseded cache stays as a **downloadable old version** of the file group (which is what update groups are for) instead of being archived.

## Notes / limits

- The official uploader only exposes `archive_existing_file` (true/false); it has **no input to explicitly tag the old file as the "Old" category**. So this keeps the old cache *downloadable*; the exact presentation (old-version dropdown vs. a second visible optional file) is Nexus's call. Worth eyeballing the 180419 Files tab after the next release (1.8.1) to confirm it lands cleanly. If not, the follow-up is a Nexus-API recategorize step.
- **Already-archived caches** (e.g. the 1.7.1 set hidden when 1.8.0 uploaded) won't un-hide themselves — they need a manual un-archive on the mod page. This change is go-forward only.
- `check_existing` (added separately) still prevents re-uploads of an already-present version, so this won't churn old versions on a re-run.

`ci:` — no release impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shader cache upload configuration to retain previous versions as downloadable archives instead of superseding them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->