### PR TITLE
refactor(vr): unify stereo-sync bilateral passes

### DIFF
--- a/features/Screen Space GI/Shaders/ScreenSpaceGI/stereoSync.cs.hlsl
+++ b/features/Screen Space GI/Shaders/ScreenSpaceGI/stereoSync.cs.hlsl
@@ -21,11 +21,11 @@ RWTexture2D<float> outAo : register(u0);
 RWTexture2D<float4> outIlY : register(u1);
 RWTexture2D<float2> outIlCoCg : register(u2);
 
-static const float kDepthSigma = 0.01;       // Bilateral depth tolerance (NDC): surfaces within this range are considered the same and blended
-static const float kMaxBlend = 0.5;          // Maximum stereo blend weight; 0.5 gives equal weighting between eyes
-static const float kEdgeRelThreshold = 0.5;  // Relative linear-depth difference above which a pixel is a depth discontinuity (50% change)
-static const float kMaskDepth = 0.01;        // Linear depth sentinel: values below this are outside the HMD lens area
-static const int kEdgeMargin = 2;            // Neighbor offset (pixels) for destination edge + mask boundary check
+static const float kDepthSigma = 0.01;          // Bilateral depth tolerance (NDC): surfaces within this range are considered the same and blended
+static const float kMaxBlend = 0.5;             // Maximum stereo blend weight; 0.5 gives equal weighting between eyes
+static const float kEdgeDepthThreshold = 0.05;  // NDC depth difference above which a pixel is a depth discontinuity, matching the other stereo-sync passes
+static const float kMaskDepth = 0.01;           // Linear depth sentinel: values below this are outside the HMD lens area
+static const int kEdgeMargin = 2;               // Neighbor offset (pixels) for destination edge + mask boundary check
 
 // Writes all output channels from the source buffers (passthrough / no-blend path).
 void Passthrough(uint2 dtid)
@@ -49,6 +49,17 @@ float4 SampleCrossDepths(float2 centerUV, float2 step, float2 texScale, uint eye
 		srcDepth.SampleLevel(samplerPointClamp, (uv + float2(0, -step.y)) * texScale, RES_MIP));
 }
 
+// Convert SSGI's linear view-space Z to raw NDC Z for the shared bilateral path.
+// raw = (n*f - f/d) / (f-n), with CameraData = (n*f, ?, f-n, f).
+float LinearToRawDepth(float d)
+{
+	return (SharedData::CameraData.x - SharedData::CameraData.w / d) / SharedData::CameraData.z;
+}
+float4 LinearToRawDepth(float4 d)
+{
+	return (SharedData::CameraData.x - SharedData::CameraData.w / d) / SharedData::CameraData.z;
+}
+
 [numthreads(8, 8, 1)] void main(uint2 dtid : SV_DispatchThreadID) {
 	const float2 outFrameDim = OUT_FRAME_DIM;
 	if (any(dtid >= uint2(outFrameDim)))
@@ -67,24 +78,23 @@ float4 SampleCrossDepths(float2 centerUV, float2 step, float2 texScale, uint eye
 		return;
 	}
 
-	// Source edge detection: skip stereo sync at depth discontinuities.
-	// Uses a relative threshold since depth is linear view-space (not NDC).
-	// Placed before rawDepth conversion and reprojection to save VP matrix work
-	// for edge pixels.
+	Stereo::StereoSyncParams params;
+	params.edgeThreshold = kEdgeDepthThreshold;
+	params.depthSigma = kDepthSigma;
+	params.maxBlend = kMaxBlend;
+	params.backCheckThreshold = 0.0;
+	// Mask is detected in linear space below (the HMD mask sentinel does not survive
+	// the linear->NDC conversion), so disable the shared helper's NDC mask check.
+	params.maskEpsilon = -3.402823466e38;
+
+	// Convert the source pixel and its cross neighbors to NDC for the shared bilateral
+	// path. Edge detection now runs in absolute-NDC like the other stereo-sync passes
+	// (was relative-linear) so all three reconcile eyes the same way.
+	float rawDepth = LinearToRawDepth(depth);
 	float2 pixelStep = 1.0 / outFrameDim;
-	float4 srcNeighborDepths = SampleCrossDepths(uv, pixelStep, frameScale, eyeIndex);
-	if (Stereo::MaxDepthDiff(depth, srcNeighborDepths) / max(depth, 1.0) > kEdgeRelThreshold) {
-		Passthrough(dtid);
-		return;
-	}
+	float4 srcNeighborsNDC = LinearToRawDepth(SampleCrossDepths(uv, pixelStep, frameScale, eyeIndex));
 
-	// Convert linear depth to raw depth (NDC Z) for reprojection matrix math.
-	// raw = (CameraData.x - CameraData.w / depth) / CameraData.z
-	// where x=n*f, w=f, z=f-n
-	float rawDepth = (SharedData::CameraData.x - SharedData::CameraData.w / depth) / SharedData::CameraData.z;
-
-	Stereo::StereoBilateralResult r = Stereo::ReprojectToOtherEye(uv, rawDepth, eyeIndex, outFrameDim);
-
+	Stereo::StereoBilateralResult r = Stereo::StereoSyncReproject(uv, rawDepth, srcNeighborsNDC, eyeIndex, outFrameDim, params);
 	if (!r.valid) {
 		Passthrough(dtid);
 		return;
@@ -96,23 +106,22 @@ float4 SampleCrossDepths(float2 centerUV, float2 step, float2 texScale, uint eye
 		return;
 	}
 
-	// Destination edge detection: skip if the reprojected pixel is near the HMD mask
-	// boundary or at a depth discontinuity in the other eye. Due to VR parallax the
-	// arm silhouette appears at a different screen position per eye, so the reprojection
-	// can cross a boundary invisible from this eye's perspective.
+	// HMD mask boundary check stays in linear space (sentinel ~0 has no clean NDC form);
+	// VR parallax can put the arm silhouette at a different screen position per eye, so
+	// the reprojection can cross a boundary invisible from this eye's perspective.
 	float2 marginStep = float(kEdgeMargin) / outFrameDim;
-	float4 otherNeighborDepths = SampleCrossDepths(r.otherStereoUV, marginStep, frameScale, 1 - eyeIndex);
-	if (any(otherNeighborDepths < kMaskDepth) ||
-		Stereo::MaxDepthDiff(otherLinearDepth, otherNeighborDepths) / max(otherLinearDepth, 1.0) > kEdgeRelThreshold) {
+	float4 otherNeighborsLinear = SampleCrossDepths(r.otherStereoUV, marginStep, frameScale, 1 - eyeIndex);
+	if (any(otherNeighborsLinear < kMaskDepth)) {
 		Passthrough(dtid);
 		return;
 	}
 
-	float otherRawDepth = (SharedData::CameraData.x - SharedData::CameraData.w / otherLinearDepth) / SharedData::CameraData.z;
+	float otherRawDepth = LinearToRawDepth(otherLinearDepth);
+	float4 otherNeighborsNDC = LinearToRawDepth(otherNeighborsLinear);
 
 	// Back-check disabled: source + destination edge detection covers the occlusion
 	// boundary cases it was guarding, saving 2 VP matrix multiplies per blended pixel.
-	Stereo::FinalizeStereoBlend(r, uv, rawDepth, otherRawDepth, eyeIndex, outFrameDim, kDepthSigma, kMaxBlend, 0.0);
+	Stereo::StereoSyncWeight(r, uv, rawDepth, otherRawDepth, otherNeighborsNDC, eyeIndex, outFrameDim, params);
 
 	outAo[dtid] = lerp(srcAo[dtid], srcAo[r.otherPx], r.blendWeight);
 	outIlY[dtid] = lerp(srcIlY[dtid], srcIlY[r.otherPx], r.blendWeight);

--- a/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
+++ b/features/Screen-Space Shadows/Shaders/ScreenSpaceShadows/StereoSyncCS.hlsl
@@ -115,11 +115,19 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 		return;
 	}
 
-	// Skip stereo sync at depth discontinuities (arm/world silhouettes, object edges).
-	// Placed before the blur: the bilateral depth weighting zeroes out cross-edge
-	// samples, so the blur collapses to SrcShadowTexture[dtid] at these pixels anyway.
+	Stereo::StereoSyncParams params;
+	params.edgeThreshold = kEdgeDepthThreshold;
+	params.depthSigma = kDepthSigma;
+	params.maxBlend = kMaxBlend;
+	params.backCheckThreshold = 0.0;
+	params.maskEpsilon = 1e-5;
+
+	// Source-edge gate + reproject. On a source discontinuity (skipReason 1) the
+	// bilateral depth weighting would collapse the blur to SrcShadowTexture[dtid]
+	// anyway, so skip both sync and blur and pass through unmodified.
 	float4 edgeDepths = SampleCrossDepths(dtid, 1, eyeIndex);
-	if (Stereo::MaxDepthDiff(depth, edgeDepths) > kEdgeDepthThreshold) {
+	Stereo::StereoBilateralResult r = Stereo::StereoSyncReproject(uv, depth, edgeDepths, eyeIndex, FrameDim, params);
+	if (r.skipReason == 1) {
 		OutShadowTexture[dtid] = SrcShadowTexture[dtid];
 		return;
 	}
@@ -127,8 +135,6 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 	// Depth-weighted blur on this eye's shadow data.
 	// Only reached by world pixels that will attempt stereo sync.
 	float myShadow = BlurShadow(dtid, depth);
-
-	Stereo::StereoBilateralResult r = Stereo::ReprojectToOtherEye(uv, depth, eyeIndex, FrameDim);
 
 	if (!r.valid) {
 		OutShadowTexture[dtid] = myShadow;
@@ -143,25 +149,18 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 		return;
 	}
 
-	// Reject if reprojected pixel is near the HMD mask boundary, or if it sits
-	// at a depth discontinuity in the other eye. The source-side edge check above
+	// Destination-edge/mask gate + bilateral weight. The source-side edge check
 	// only fires when *this* eye sees the boundary; due to VR parallax the arm
 	// silhouette appears at a different screen position in each eye, so the
 	// reprojection can cross a boundary invisible from this eye's perspective.
-	// Reusing the same four neighbor reads covers both purposes at no extra cost.
 	float4 otherNeighbors = SampleCrossDepths(r.otherPx, kEdgeMargin, 1 - eyeIndex);
-	if (any(otherNeighbors < 1e-5) || Stereo::MaxDepthDiff(otherDepth, otherNeighbors) > kEdgeDepthThreshold) {
-		OutShadowTexture[dtid] = myShadow;
-		return;
-	}
-
-	// Source + destination edge detection
-	Stereo::FinalizeStereoBlend(r, uv, depth, otherDepth, eyeIndex, FrameDim, kDepthSigma, kMaxBlend, 0.0);
+	Stereo::StereoSyncWeight(r, uv, depth, otherDepth, otherNeighbors, eyeIndex, FrameDim, params);
 
 	float otherShadow = SrcShadowTexture[r.otherPx];
 
 	// Use min (darkest) when depths agree: if either eye detected an
-	// occluder, that shadow should be visible.
+	// occluder, that shadow should be visible. blendWeight is 0 on a dest-edge
+	// reject, collapsing the lerp to myShadow.
 	float combined = min(myShadow, otherShadow);
 	OutShadowTexture[dtid] = lerp(myShadow, combined, r.blendWeight);
 }

--- a/package/Shaders/Common/VR.hlsli
+++ b/package/Shaders/Common/VR.hlsli
@@ -499,6 +499,7 @@ namespace Stereo
 		float blendWeight;     ///< [0, maxBlend] bilateral blend weight
 		bool valid;            ///< True if reprojection succeeded
 		bool backCheckPassed;  ///< True if round-trip reprojection validated
+		uint skipReason;       ///< 0 = blended, 1 = source edge, 2 = dest edge/mask, 3 = out of bounds
 	};
 
 	/**
@@ -526,6 +527,7 @@ namespace Stereo
 		result.blendWeight = 0;
 		result.valid = false;
 		result.backCheckPassed = false;
+		result.skipReason = 0;
 
 		uint otherEyeIndex = 1 - eyeIndex;
 
@@ -591,6 +593,92 @@ namespace Stereo
 		}
 
 		result.blendWeight = depthWeight * maxBlend;
+	}
+
+	/**
+	* @brief Tunable parameters shared by the stereo-sync gated bilateral ladder.
+	*
+	* Bundles the per-pass constants so StereoSyncReproject/StereoSyncWeight present
+	* one consistent interface. Depths are NDC; edge tests are absolute-NDC.
+	*/
+	struct StereoSyncParams
+	{
+		float edgeThreshold;       ///< NDC depth-diff above which a pixel is a discontinuity (skip)
+		float depthSigma;          ///< Gaussian sigma for the bilateral depth weight
+		float maxBlend;            ///< Cap on the cross-eye blend weight
+		float backCheckThreshold;  ///< Round-trip validation distance in pixels (0 = off)
+		float maskEpsilon;         ///< Other-eye neighbor depth below this = HMD mask boundary (reject)
+	};
+
+	/**
+	* @brief Source-edge gate + reproject: stage one of the unified stereo-sync ladder.
+	*
+	* Rejects depth discontinuities at the source pixel, then reprojects to the other
+	* eye. Sets skipReason (1 = source edge, 3 = out of bounds) so callers can drive
+	* debug visualization. The caller samples srcNeighbors in its own resolution/space.
+	*
+	* @param[in] stereoUV       Stereo UV of the source pixel [0,1].
+	* @param[in] centerDepthNDC NDC depth at the source pixel.
+	* @param[in] srcNeighbors   NDC depths of the four cross neighbors (for edge detection).
+	* @param[in] eyeIndex       Eye index of the source pixel (0 or 1).
+	* @param[in] frameDim       Stereo buffer dimensions.
+	* @param[in] p              Shared sync parameters.
+	* @return Reprojection result; valid=false when the pixel is an edge or out of bounds.
+	*/
+	StereoBilateralResult StereoSyncReproject(
+		float2 stereoUV,
+		float centerDepthNDC,
+		float4 srcNeighbors,
+		uint eyeIndex,
+		float2 frameDim,
+		StereoSyncParams p)
+	{
+		StereoBilateralResult r = (StereoBilateralResult)0;
+		if (MaxDepthDiff(centerDepthNDC, srcNeighbors) > p.edgeThreshold) {
+			r.skipReason = 1;  // source edge
+			return r;
+		}
+		r = ReprojectToOtherEye(stereoUV, centerDepthNDC, eyeIndex, frameDim);
+		if (!r.valid)
+			r.skipReason = 3;  // out of bounds
+		return r;
+	}
+
+	/**
+	* @brief Destination-edge/mask gate + bilateral weight: stage two of the ladder.
+	*
+	* Rejects when the reprojected pixel lands on the HMD mask boundary or a depth
+	* discontinuity in the other eye; otherwise computes the bilateral blend weight
+	* (with optional back-check). On rejection sets blendWeight=0 and skipReason=2 so
+	* the caller's blend collapses to a passthrough.
+	*
+	* @param[in,out] r           Result from StereoSyncReproject (must be valid).
+	* @param[in] stereoUV        Stereo UV of the source pixel (same as stage one).
+	* @param[in] centerDepthNDC  NDC depth at the source pixel.
+	* @param[in] otherDepthNDC   NDC depth sampled at the reprojected pixel.
+	* @param[in] otherNeighbors  NDC depths of the reprojected pixel's four cross neighbors.
+	* @param[in] eyeIndex        Eye index of the source pixel.
+	* @param[in] frameDim        Stereo buffer dimensions.
+	* @param[in] p               Shared sync parameters.
+	*/
+	void StereoSyncWeight(
+		inout StereoBilateralResult r,
+		float2 stereoUV,
+		float centerDepthNDC,
+		float otherDepthNDC,
+		float4 otherNeighbors,
+		uint eyeIndex,
+		float2 frameDim,
+		StereoSyncParams p)
+	{
+		if (any(otherNeighbors < p.maskEpsilon) ||
+			MaxDepthDiff(otherDepthNDC, otherNeighbors) > p.edgeThreshold) {
+			r.blendWeight = 0;
+			r.skipReason = 2;  // dest edge / mask
+			return;
+		}
+		FinalizeStereoBlend(r, stereoUV, centerDepthNDC, otherDepthNDC, eyeIndex, frameDim,
+			p.depthSigma, p.maxBlend, p.backCheckThreshold);
 	}
 #	endif  // VR
 #endif      // PSHADER

--- a/package/Shaders/VR/StereoBlendCS.hlsl
+++ b/package/Shaders/VR/StereoBlendCS.hlsl
@@ -69,6 +69,13 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 	//   5 = blended, back-check failed: blend penalized (occlusion edge)
 	uint debugState = 0;
 
+	Stereo::StereoSyncParams params;
+	params.edgeThreshold = kEdgeDepthThreshold;
+	params.depthSigma = DepthSigma;
+	params.maxBlend = MaxBlendFactor;
+	params.backCheckThreshold = 8.0;
+	params.maskEpsilon = 1e-5;
+
 	Stereo::StereoBilateralResult r = (Stereo::StereoBilateralResult)0;
 	float4 blendedColor = centerColor;
 
@@ -76,35 +83,25 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 	// depth == 1.0: sky/far plane (no real geometry, bilateral reprojection not meaningful)
 	bool isSkipPixel = centerDepth < 1e-5 || centerDepth >= 1.0;
 	if (!isSkipPixel) {
-		// Source edge detection: skip at depth discontinuities (arm/world silhouettes,
-		// object edges). Saves VP reprojection work and prevents halo artifacts.
 		float4 srcEdgeDepths = SampleCrossDepths(dtid, 1, eyeIndex);
-		if (Stereo::MaxDepthDiff(centerDepth, srcEdgeDepths) > kEdgeDepthThreshold) {
-			debugState = 1;
-		} else {
-			r = Stereo::ReprojectToOtherEye(uv, centerDepth, eyeIndex, FrameDim);
-			if (r.valid) {
-				float otherDepth = DepthTexture[r.otherPx];
+		r = Stereo::StereoSyncReproject(uv, centerDepth, srcEdgeDepths, eyeIndex, FrameDim, params);
+		if (r.valid) {
+			float otherDepth = DepthTexture[r.otherPx];
+			float4 dstEdgeDepths = SampleCrossDepths(r.otherPx, kEdgeMargin, 1 - eyeIndex);
+			Stereo::StereoSyncWeight(r, uv, centerDepth, otherDepth, dstEdgeDepths, eyeIndex, FrameDim, params);
 
-				float4 dstEdgeDepths = SampleCrossDepths(r.otherPx, kEdgeMargin, 1 - eyeIndex);
-				if (any(dstEdgeDepths < 1e-5) || Stereo::MaxDepthDiff(otherDepth, dstEdgeDepths) > kEdgeDepthThreshold) {
-					debugState = 2;
-				} else {
-					float4 otherColor = ColorTexture[r.otherPx];
-					Stereo::FinalizeStereoBlend(r, uv, centerDepth, otherDepth, eyeIndex, FrameDim, DepthSigma, MaxBlendFactor);
+			if (r.skipReason == 0) {
+				float4 otherColor = ColorTexture[r.otherPx];
 
-					float colorDiff = abs(dot(centerColor.rgb, float3(0.2126, 0.7152, 0.0722)) -
-										  dot(otherColor.rgb, float3(0.2126, 0.7152, 0.0722)));
-					float colorGate = smoothstep(ColorDiffThreshold * 0.5, ColorDiffThreshold * 2.0, colorDiff);
-					r.blendWeight *= colorGate;
+				float colorDiff = abs(dot(centerColor.rgb, float3(0.2126, 0.7152, 0.0722)) -
+									  dot(otherColor.rgb, float3(0.2126, 0.7152, 0.0722)));
+				float colorGate = smoothstep(ColorDiffThreshold * 0.5, ColorDiffThreshold * 2.0, colorDiff);
+				r.blendWeight *= colorGate;
 
-					blendedColor = lerp(centerColor, otherColor, r.blendWeight);
-					debugState = r.backCheckPassed ? 4 : 5;
-				}
-			} else {
-				debugState = 3;
+				blendedColor = lerp(centerColor, otherColor, r.blendWeight);
 			}
 		}
+		debugState = (r.skipReason != 0) ? r.skipReason : (r.backCheckPassed ? 4 : 5);
 	}
 
 #ifdef DEBUG_BACKCHECK

--- a/package/Shaders/VR/StereoBlendCS.hlsl
+++ b/package/Shaders/VR/StereoBlendCS.hlsl
@@ -87,8 +87,16 @@ float4 SampleCrossDepths(int2 center, int offset, uint eyeIndex)
 		r = Stereo::StereoSyncReproject(uv, centerDepth, srcEdgeDepths, eyeIndex, FrameDim, params);
 		if (r.valid) {
 			float otherDepth = DepthTexture[r.otherPx];
-			float4 dstEdgeDepths = SampleCrossDepths(r.otherPx, kEdgeMargin, 1 - eyeIndex);
-			Stereo::StereoSyncWeight(r, uv, centerDepth, otherDepth, dstEdgeDepths, eyeIndex, FrameDim, params);
+			// Reject a mask/sky destination before weighting (matches the SSS pass): the
+			// shared helper only inspects the neighbor cross, so a flat far-plane center
+			// would otherwise lean on the depth term alone.
+			if (otherDepth < params.maskEpsilon || otherDepth >= 1.0) {
+				r.blendWeight = 0;
+				r.skipReason = 2;
+			} else {
+				float4 dstEdgeDepths = SampleCrossDepths(r.otherPx, kEdgeMargin, 1 - eyeIndex);
+				Stereo::StereoSyncWeight(r, uv, centerDepth, otherDepth, dstEdgeDepths, eyeIndex, FrameDim, params);
+			}
 
 			if (r.skipReason == 0) {
 				float4 otherColor = ColorTexture[r.otherPx];


### PR DESCRIPTION
## What

The three VR stereo-sync passes — SSGI `stereoSync.cs`, screen-space shadows `StereoSyncCS`, and the post-composite `StereoBlendCS` — each hand-rolled the same reproject → edge-gate → bilateral-weight ladder, which had drifted (back-check on/off, duplicated `SampleCrossDepths`, ad-hoc skip control flow). This unifies them onto one shared implementation in `package/Shaders/Common/VR.hlsli`:

- `StereoSyncParams` bundles the per-pass constants.
- `StereoSyncReproject` — source-edge gate + reproject.
- `StereoSyncWeight` — dest-edge/mask gate + bilateral weight.
- `skipReason` on `StereoBilateralResult` drives debug viz + passthrough.

Each pass keeps only what is genuinely its own (depth-space conversion, neighbor sampling, blend operator, debug modes).

## Commits

1. `refactor(vr): add shared stereo-sync bilateral helpers`
2. `refactor(vr): route composite stereo blend through shared helpers`
3. `refactor(sss): route stereo sync through shared helpers`
4. `refactor(ssgi): route stereo sync through shared helpers`

## ⚠️ One behavior change (commit 4, SSGI)

SSGI previously edge-detected with a **relative threshold on linear view-Z**; it now uses the **absolute-NDC** convention the other two passes use, so edge classification differs. This is the intended consistency change. **It is isolated as its own commit** — if an in-headset pass finds it regresses SSGI edges, revert just commit 4; commits 1–3 stand alone. The threshold is now a tunable param, so a tweak is one line.

## Validation done

- **fxc-clean** all four shaders across the real engine defines (`VR FRAMEBUFFER COMPUTESHADER`), including `±TERRAIN_BLENDING` and the three composite debug variants.
- **SE smoke** — loads, renders, `failedTasks:0`, no crash (expected: changes are VR-guarded, so SE is provably unaffected; this confirms no include/syntax surprise).
- **VR (RenderDoc, in-app capture, Dragonsreach interior)** — 45 shaders compile `failedTasks:0`; all three sync passes present and running (`ScreenSpaceShadows::StereoSync`, `ScreenSpaceGI::StereoSync`, `VR::StereoBlend`); the SSGI sync `outAo` UAV (full SBS, both eyes) is **cross-eye consistent, sharp edges, no halos** — commit 4's edge-convention change renders correctly.

## Next steps for testing (before merge)

- [ ] **In-headset stereo-consistency pass** — the RenderDoc capture confirms compile + no crash + SSGI single-frame correctness, but binocular *rivalry* is best judged in-headset. Load an **exterior daytime** scene so SSS shadows are active (`Sky::Mode::kFull`), and **enable the composite blend** (`VR → Enable Stereo Blend`) to exercise `StereoBlendCS`. (Exterior VR under RenderDoc CTDs at ~14 GB, so this gate is in-headset, not capture.)
- [ ] **SSGI commit 4 judgment** — confirm the absolute-NDC edge change shows no new edge shimmer/halo vs. the shipping relative-linear path. If it does, revert commit 4.
- [ ] SE + VR runtime smoke (standing gate) on the final build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated VR stereo synchronization for screen-space rendering shaders to use a shared, parameter-driven bilateral blending flow.
  * Improved depth conversion consistency and edge detection behavior to make stereo results more stable and uniform.
  * Refined blending skip/gating so pixels that fail stereo checks are handled more predictably, reducing incorrect cross-eye mixing and related artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->