### PR TITLE
fix(vr): eye-stable noise seeds

### DIFF
--- a/features/Exponential Height Fog/Shaders/ExponentialHeightFog/ExponentialHeightFog.hlsli
+++ b/features/Exponential Height Fog/Shaders/ExponentialHeightFog/ExponentialHeightFog.hlsli
@@ -129,8 +129,8 @@ namespace ExponentialHeightFog
 		[branch] if (SharedData::exponentialHeightFogSettings.volumetricUpsampleJitterMultiplier > 0.0f)
 		{
 			float2 noise = float2(
-				Random::InterleavedGradientNoise(screenPosition.xy, SharedData::FrameCount),
-				Random::InterleavedGradientNoise(screenPosition.yx + 19.19f, SharedData::FrameCount));
+				Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(screenPosition.xy, SharedData::BufferDim.xy), SharedData::FrameCount),
+				Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(screenPosition.yx, SharedData::BufferDim.xy) + 19.19f, SharedData::FrameCount));
 			jitter = (noise * 2.0f - 1.0f) * SharedData::exponentialHeightFogSettings.volumetricUpsampleJitterMultiplier * gridPixelSize;
 		}
 

--- a/features/Exponential Height Fog/Shaders/ExponentialHeightFog/ExponentialHeightFog.hlsli
+++ b/features/Exponential Height Fog/Shaders/ExponentialHeightFog/ExponentialHeightFog.hlsli
@@ -128,9 +128,10 @@ namespace ExponentialHeightFog
 		float2 jitter = 0.0f.xx;
 		[branch] if (SharedData::exponentialHeightFogSettings.volumetricUpsampleJitterMultiplier > 0.0f)
 		{
+			float2 stableNoiseCoord = Stereo::EyeStableNoiseCoord(screenPosition.xy, SharedData::BufferDim.xy);
 			float2 noise = float2(
-				Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(screenPosition.xy, SharedData::BufferDim.xy), SharedData::FrameCount),
-				Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(screenPosition.yx, SharedData::BufferDim.xy) + 19.19f, SharedData::FrameCount));
+				Random::InterleavedGradientNoise(stableNoiseCoord, SharedData::FrameCount),
+				Random::InterleavedGradientNoise(stableNoiseCoord.yx + 19.19f, SharedData::FrameCount));
 			jitter = (noise * 2.0f - 1.0f) * SharedData::exponentialHeightFogSettings.volumetricUpsampleJitterMultiplier * gridPixelSize;
 		}
 

--- a/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSS.hlsli
+++ b/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSS.hlsli
@@ -132,7 +132,7 @@ float4 SSSSBlurCS(
 	finalStep *= FrameBuffer::DynamicResolutionParams1.xy;
 
 	// Per-pixel rotation to break separable axis-aligned banding
-	float jitter = Random::InterleavedGradientNoise(texcoord * SharedData::BufferDim.xy, SharedData::FrameCount) * Math::TAU;
+	float jitter = Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(texcoord * SharedData::BufferDim.xy, SharedData::BufferDim.xy), SharedData::FrameCount) * Math::TAU;
 	float2x2 rotationMatrix = float2x2(cos(jitter), sin(jitter), -sin(jitter), cos(jitter));
 
 	// Accumulate the other samples:

--- a/features/Water Effects/Shaders/WaterEffects/WaterParallax.hlsli
+++ b/features/Water Effects/Shaders/WaterEffects/WaterParallax.hlsli
@@ -60,7 +60,7 @@ namespace WaterEffects
 		// Parallax scale is also multiplied by normalScalesRcp
 		parallaxOffsetTS *= 20.0;
 
-		float screenNoise = Random::InterleavedGradientNoise(input.HPosition.xy, SharedData::FrameCount);
+		float screenNoise = Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(input.HPosition.xy, SharedData::BufferDim.xy), SharedData::FrameCount);
 
 		float3 mipLevels;
 		mipLevels.x = GetMipLevel(input.TexCoord1.xy, Normals01Tex, screenNoise);
@@ -166,7 +166,7 @@ namespace WaterEffects
 		float2 parallaxOffsetTS = viewDirection.xy / -viewDirection.z;
 		parallaxOffsetTS *= 80.0;
 
-		float screenNoise = Random::InterleavedGradientNoise(input.HPosition.xy, SharedData::FrameCount);
+		float screenNoise = Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(input.HPosition.xy, SharedData::BufferDim.xy), SharedData::FrameCount);
 		float mipLevel = GetMipLevel(input.TexCoord1.xy, Normals01Tex, screenNoise);
 
 		float stepSize = rcp(16.0);

--- a/package/Shaders/Common/ShadowSampling.hlsli
+++ b/package/Shaders/Common/ShadowSampling.hlsli
@@ -95,7 +95,7 @@ namespace ShadowSampling
 		uint sampleCount = clamp(uint(totalRayLength / stepSize + 0.5), 1, 4);
 		float rcpSampleCount = rcp(sampleCount);
 
-		float noise = Random::InterleavedGradientNoise(screenPosition, SharedData::FrameCount);
+		float noise = Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(screenPosition, SharedData::BufferDim.xy), SharedData::FrameCount);
 
 		float worldShadow = 0.0;
 		for (uint i = 0; i < sampleCount; i++) {

--- a/package/Shaders/Common/VR.hlsli
+++ b/package/Shaders/Common/VR.hlsli
@@ -107,6 +107,33 @@ namespace Stereo
 	}
 
 	/**
+	* @brief Returns an eye-stable pixel coordinate for seeding screen-space noise (IGN).
+	*
+	* Seeding interleaved-gradient noise from the raw side-by-side pixel coordinate makes
+	* the two eyes hash decorrelated values for the same world point — the half-buffer
+	* x-offset dominates — which reads as per-eye rivalry on whatever the noise drives
+	* (shadow/dither/LOD shimmer). This maps the coordinate to the eye-local mono pixel
+	* grid so both eyes hash the same value for the same screen-relative position, at the
+	* same noise frequency (the 0.5 width factor preserves the per-eye pixel pitch).
+	* Flat builds have no seam and return the coordinate unchanged (byte-identical).
+	*
+	* @param[in] sbsPixel  Raw SV_Position-style pixel coordinate in the packed buffer.
+	* @param[in] bufferDim Full packed buffer dimensions (both eyes wide in VR).
+	* @return Pixel coordinate to pass to Random::InterleavedGradientNoise.
+	*/
+	float2 EyeStableNoiseCoord(float2 sbsPixel, float2 bufferDim)
+	{
+#ifdef VR
+		float2 stereoUV = sbsPixel / bufferDim;
+		uint eyeIndex = GetEyeIndexFromTexCoord(stereoUV);
+		float2 monoUV = ConvertFromStereoUV(stereoUV, eyeIndex);
+		return monoUV * float2(bufferDim.x * 0.5, bufferDim.y);
+#else
+		return sbsPixel;
+#endif
+	}
+
+	/**
 	* @brief Applies motion velocity to UV coordinates and determines if the resulting mono UV is out of screen bounds.
 	* @param uv Screen UV coordinates (stereo in VR, mono in SE)
 	* @param velocity Delta motion mapping

--- a/package/Shaders/DistantTree.hlsl
+++ b/package/Shaders/DistantTree.hlsl
@@ -233,7 +233,7 @@ PS_OUTPUT main(PS_INPUT input)
 #		if defined(DEFERRED)
 	float3 viewPosition = mul(FrameBuffer::CameraView[eyeIndex], float4(input.WorldPosition.xyz, 1)).xyz;
 	float2 screenUV = FrameBuffer::ViewToUV(viewPosition, true, eyeIndex);
-	float screenNoise = Random::InterleavedGradientNoise(input.Position.xy, SharedData::FrameCount);
+	float screenNoise = Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(input.Position.xy, SharedData::BufferDim.xy), SharedData::FrameCount);
 
 	float dirShadow = 1;
 

--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -750,7 +750,7 @@ PS_OUTPUT main(PS_INPUT input)
 	float3 propertyColor = Color::Effect(PropertyColor.xyz);
 	float shadowVariance = 1.0;
 
-	float screenNoise = Random::InterleavedGradientNoise(input.Position.xy, SharedData::FrameCount);
+	float screenNoise = Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(input.Position.xy, SharedData::BufferDim.xy), SharedData::FrameCount);
 
 	float2 rotation;
 	sincos(Math::TAU * screenNoise, rotation.y, rotation.x);

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -960,7 +960,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float3 viewDirection = -normalize(input.WorldPosition.xyz);
 
 	float2 screenUV = FrameBuffer::ViewToUV(viewPosition, true, eyeIndex);
-	float screenNoise = Random::InterleavedGradientNoise(input.Position.xy, SharedData::FrameCount);
+	float screenNoise = Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(input.Position.xy, SharedData::BufferDim.xy), SharedData::FrameCount);
 
 #	if defined(DEFERRED)
 	const bool inWorld = true;

--- a/package/Shaders/Particle.hlsl
+++ b/package/Shaders/Particle.hlsl
@@ -298,7 +298,7 @@ PS_OUTPUT main(PS_INPUT input)
 	positionWS = mul(FrameBuffer::CameraViewProjInverse[eyeIndex], positionWS);
 	positionWS.xyz = positionWS.xyz / positionWS.w;
 
-	float screenNoise = Random::InterleavedGradientNoise(input.Position.xy, SharedData::FrameCount);
+	float screenNoise = Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(input.Position.xy, SharedData::BufferDim.xy), SharedData::FrameCount);
 
 	float3 worldPositionWS = positionWS.xyz + FrameBuffer::CameraPosAdjust[eyeIndex].xyz;
 

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -533,7 +533,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	float3 viewPosition = mul(FrameBuffer::CameraView[eyeIndex], float4(input.WorldPosition.xyz, 1)).xyz;
 	float2 screenUV = FrameBuffer::ViewToUV(viewPosition, true, eyeIndex);
-	float screenNoise = Random::InterleavedGradientNoise(input.HPosition.xy, SharedData::FrameCount);
+	float screenNoise = Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(input.HPosition.xy, SharedData::BufferDim.xy), SharedData::FrameCount);
 
 	// Swaps direction of the backfaces otherwise they seem to get lit from the wrong direction.
 	if (!(Permutation::ExtraShaderDescriptor & Permutation::ExtraFlags::GrassSphereNormal))
@@ -840,7 +840,7 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float3 viewPosition = mul(FrameBuffer::CameraView[eyeIndex], float4(input.WorldPosition.xyz, 1)).xyz;
 	float2 screenUV = FrameBuffer::ViewToUV(viewPosition, true, eyeIndex);
-	float screenNoise = Random::InterleavedGradientNoise(input.HPosition.xy, SharedData::FrameCount);
+	float screenNoise = Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(input.HPosition.xy, SharedData::BufferDim.xy), SharedData::FrameCount);
 
 	float4 shadowColor = TexShadowMaskSampler.Load(int3(input.HPosition.xy, 0));
 

--- a/package/Shaders/Sky.hlsl
+++ b/package/Shaders/Sky.hlsl
@@ -240,7 +240,7 @@ PS_OUTPUT main(PS_INPUT input)
 	if (HDRSun::IsHdrSunActive()) {
 		// Dither bright output to reduce banding in high-boost sun path.
 		// Same baseColor/skyScale treatment for DITHER and non-DITHER; DITHER adds noiseGrad later.
-		baseColor.xyz += (Random::InterleavedGradientNoise(input.Position.xy) - 0.5f) *
+		baseColor.xyz += (Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(input.Position.xy, SharedData::BufferDim.xy)) - 0.5f) *
 		                 (saturate(hdrSunGain - 1.0f) / 255.0f);
 		skyScale = 0.0f;
 	}

--- a/package/Shaders/Utility.hlsl
+++ b/package/Shaders/Utility.hlsl
@@ -502,7 +502,7 @@ PS_OUTPUT main(PS_INPUT input)
 	float fadeFactor = input.Alpha.x;
 #		endif
 
-	float noise = Random::InterleavedGradientNoise(input.PositionCS.xy, SharedData::FrameCount);
+	float noise = Random::InterleavedGradientNoise(Stereo::EyeStableNoiseCoord(input.PositionCS.xy, SharedData::BufferDim.xy), SharedData::FrameCount);
 
 	float2 rotation;
 	sincos(Math::TAU * noise, rotation.y, rotation.x);


### PR DESCRIPTION
## What

Screen-space interleaved-gradient noise (IGN) was seeded from the raw **side-by-side pixel coordinate** across the base pipeline. For the same world point the two eyes land in different halves of the packed buffer — the half-width x-offset dominates — so they hash **decorrelated** noise. That reads as per-eye **binocular rivalry** (shimmer/flicker) on everything the noise drives: shadow penumbrae, contact-shadow band edges, hair outlines, stochastic LOD/mip, parallax and banding dither. This is the codebase-wide root cause surfaced by the VR-seam audit.

`Stereo::EyeStableNoiseCoord(sbsPixel, bufferDim)` (new, in `VR.hlsli`) maps the coordinate to the **eye-local mono pixel grid** so both eyes hash the same value for the same screen-relative position, at the same noise frequency. Every base seed site routes through it:

`Lighting`, `Sky`, `Effect`, `DistantTree`, `Particle`, `RunGrass`, `Utility`, `ShadowSampling`, `WaterParallax`, `ExponentialHeightFog`, `SeparableSSS`.

`Lighting.hlsl`'s contact-shadow seed already uses the eye-stable `GetContactShadowNoiseCoord`, so it's left as-is (unifying that helper onto `EyeStableNoiseCoord` is a tidy follow-up).

## Flat is byte-identical

The helper returns the coordinate unchanged in non-VR builds (`#else return sbsPixel`), so the flat permutation is provably unchanged — this is a VR-only fix.

## Validation done

- **hlslkit full suite, 0 errors**: VR config 3617 shaders, flat config 3324 shaders.
- Flat byte-identity by construction (above).

## Next steps for testing (before merge)

- [ ] **In-headset / null-driver A/B** — the perceptual gate. Capture an **exterior daytime** scene both eyes (shadows are where this shimmer is most visible) and confirm the per-eye shadow/dither shimmer is reduced vs. the shipping seed, with no new artifact. This touches the **lighting hot path**, so also confirm no perf regression (Tracy per-pass, % of the 90 fps budget).
- [ ] SE + VR runtime smoke (standing gate) on the final build.

Note: this removes the dominant (half-buffer) divergence; a small parallax residual remains (Tier 2 / parallax-correct seed) and is only worth pursuing per-effect if an A/B shows it still shimmers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stereo and VR rendering stability by enhancing per-eye noise generation consistency across volumetric fog, shadows, water parallax, sky HDR dithering, particle effects, and grass rendering.
  * Reduced stereo-related jitter and visual artifacts by updating stochastic sampling inputs to use eye-stable coordinates instead of raw screen position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->