### PR TITLE
fix(sss): clamp Burley diffusion samples to the eye's SBS half in VR

### DIFF
--- a/features/Subsurface Scattering/Shaders/SubsurfaceScattering/Burley.hlsli
+++ b/features/Subsurface Scattering/Shaders/SubsurfaceScattering/Burley.hlsli
@@ -104,7 +104,9 @@ float4 BurleyNormalizedSS(uint2 DTid, float2 texCoord, uint eyeIndex, float sssA
 		uvOffset.y *= sin(theta);
 
 		float2 sampleUV = texCoord + uvOffset;
-		float2 clampedUV = clamp(sampleUV, float2(0.0f, 0.0f), float2(1.0f, 1.0f));
+		// Keep the diffusion sample inside this eye's SBS half (VR); saturate also bounds Y
+		// for the integer texel index. Flat builds clamp X to [0,1] (no seam).
+		float2 clampedUV = saturate(Stereo::ClampToEyeUV(sampleUV, eyeIndex));
 		uint2 samplePixcoord = uint2(clampedUV * SharedData::BufferDim.xy);
 		float maskSample = MaskTexture[samplePixcoord].x;
 		bool mask = maskSample > 1e-5f;

--- a/package/Shaders/Common/VR.hlsli
+++ b/package/Shaders/Common/VR.hlsli
@@ -202,7 +202,8 @@ namespace Stereo
 	*
 	* Prevents cross-neighbor UV samples from crossing the x=0.5 seam into the other eye's
 	* region of the side-by-side stereo texture. Y is not clamped; sampler address modes
-	* handle vertical out-of-bounds.
+	* handle vertical out-of-bounds. In flat (non-VR) builds there is no seam, so X is just
+	* clamped to [0,1] — callers can invoke it unconditionally.
 	*
 	* @param[in] uv        Stereo UV coordinate to clamp.
 	* @param[in] eyeIndex  Eye index (0 = left [0, 0.5], 1 = right [0.5, 1]).
@@ -210,7 +211,12 @@ namespace Stereo
 	*/
 	float2 ClampToEyeUV(float2 uv, uint eyeIndex)
 	{
+#ifdef VR
 		uv.x = clamp(uv.x, eyeIndex == 0 ? 0.0f : 0.5f, eyeIndex == 0 ? 0.5f : 1.0f);
+#else
+		// Flat: the whole screen is one eye spanning [0,1]; clamp X to the full range.
+		uv.x = saturate(uv.x);
+#endif
 		return uv;
 	}
 


### PR DESCRIPTION
## What

The Burley subsurface-scattering diffusion loop clamped each randomized sample UV to the full `[0,1]` range, so in VR a left-eye sample with a large radius offset could land past `x=0.5` and read the **right eye's** color/depth/normal into the left eye's subsurface result — visible as skin-tone shimmer/halo at frame center on faces. The sibling `SeparableSSS` path already clamps per-eye.

The clamp now routes through `Stereo::ClampToEyeUV`, which is made **flat-safe** here (an `#ifdef VR` inside the helper, matching the file's own pattern): VR clamps X to the eye half, flat clamps X to `[0,1]`. The call site is unconditional and the flat path is **behavior-preserving** (`saturate(ClampToEyeUV(uv)) == clamp(uv,0,1)` in flat).

## Validation

- fxc-clean `BURLEY` in both VR and flat.
- Flat byte-identical by construction.

## Next steps for testing

- [ ] In-headset / both-eye capture on a **face** (NPC or 3rd-person) to confirm the center-frame skin-tone shimmer is gone. VR-only; the fix is `#ifdef VR`-guarded so flat is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)