### PR TITLE
fix(llf): shadow-promotion cell-transition crashes

### DIFF
--- a/include/PCH.h
+++ b/include/PCH.h
@@ -77,13 +77,13 @@ namespace stl
 	}
 
 	template <class T>
-	void detour_thunk(REL::RelocationID a_relId)
+	long detour_thunk(REL::RelocationID a_relId)
 	{
 		T::func = a_relId.address();
 		DetourTransactionBegin();
 		DetourUpdateThread(GetCurrentThread());
 		DetourAttach(reinterpret_cast<PVOID*>(&T::func), reinterpret_cast<PVOID>(T::thunk));
-		DetourTransactionCommit();
+		return DetourTransactionCommit();  // NO_ERROR (0) on success; callers may ignore
 	}
 
 	template <class T>

--- a/include/PCH.h
+++ b/include/PCH.h
@@ -80,9 +80,16 @@ namespace stl
 	long detour_thunk(REL::RelocationID a_relId)
 	{
 		T::func = a_relId.address();
-		DetourTransactionBegin();
-		DetourUpdateThread(GetCurrentThread());
-		DetourAttach(reinterpret_cast<PVOID*>(&T::func), reinterpret_cast<PVOID>(T::thunk));
+		if (const long rc = DetourTransactionBegin(); rc != NO_ERROR)
+			return rc;
+		if (const long rc = DetourUpdateThread(GetCurrentThread()); rc != NO_ERROR) {
+			DetourTransactionAbort();
+			return rc;
+		}
+		if (const long rc = DetourAttach(reinterpret_cast<PVOID*>(&T::func), reinterpret_cast<PVOID>(T::thunk)); rc != NO_ERROR) {
+			DetourTransactionAbort();
+			return rc;
+		}
 		return DetourTransactionCommit();  // NO_ERROR (0) on success; callers may ignore
 	}
 

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -1288,6 +1288,37 @@ void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* T
 	singleton.BSLightingShader_SetupGeometry_After(Pass);
 }
 
+namespace
+{
+	// VirtualQuery readability probe: the environment-independent check the
+	// address-floor heuristic can't be -- it asks the OS whether [ptr, ptr+size)
+	// is committed + readable, so a freed light at ANY address (the 16 MB garbage
+	// in the VR effect-shader crash, or a high unmapped one) is rejected without
+	// guessing the heap base. Wrapped in a Tracy zone (LLF::EffectLightProbe) so
+	// its per-frame cost is measurable in a TRACY_SUPPORT build.
+	bool IsReadableRange(const void* a_ptr, std::size_t a_size) noexcept
+	{
+		MEMORY_BASIC_INFORMATION mbi{};
+		if (::VirtualQuery(a_ptr, &mbi, sizeof(mbi)) == 0)
+			return false;
+		if (mbi.State != MEM_COMMIT)
+			return false;
+		constexpr DWORD kReadable = PAGE_READONLY | PAGE_READWRITE | PAGE_WRITECOPY |
+		                            PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
+		if ((mbi.Protect & kReadable) == 0 || (mbi.Protect & (PAGE_GUARD | PAGE_NOACCESS)) != 0)
+			return false;
+		const auto base = reinterpret_cast<std::uintptr_t>(mbi.BaseAddress);
+		const auto p = reinterpret_cast<std::uintptr_t>(a_ptr);
+		return (p + a_size) <= (base + mbi.RegionSize);  // whole range in this committed region
+	}
+
+	bool ProbeReadable(const void* a_ptr, std::size_t a_size)
+	{
+		ZoneScopedN("LLF::EffectLightProbe");
+		return IsReadableRange(a_ptr, a_size);
+	}
+}
+
 void LightLimitFix::Hooks::BSEffectShader_SetupGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
 {
 	// Defensive pre-call guard: BSEffectShader::SetupGeometry iterates
@@ -1301,17 +1332,20 @@ void LightLimitFix::Hooks::BSEffectShader_SetupGeometry::thunk(RE::BSShader* Thi
 	// but it's still ref-counted alive in some list).
 	//
 	// Walk the array and clamp numLights to the count of entries that the
-	// engine can safely dereference. Validation:
-	//   - BSLight* is canonical, 8-byte aligned, non-null
-	//   - bsLight->light pointer is canonical, 8-byte aligned, non-null
-	// Entries failing either check stop the loop; the engine's own loop
-	// bails on the first bad entry too, so clamping matches its contract.
+	// engine can safely dereference. Validation does the cheap range/alignment
+	// check first, then a VirtualQuery readability probe -- the probe is the real
+	// boundary, since a freed light can pass the cheap checks yet point to
+	// unmapped memory (the 16 MB garbage pointer that AV'd reading NiLight->fade):
+	//   - BSLight* canonical/aligned/non-null + [.., +0x50) readable (->light @ +0x48)
+	//   - bsLight->light (NiLight) canonical/aligned/non-null + [.., +0x168) readable (->fade @ VR +0x15C)
+	// Entries failing any check stop the loop; the engine's own loop bails on the
+	// first bad entry too, so clamping matches its contract.
 	if (Pass && Pass->sceneLights && Pass->numLights > 0) {
 		using ShadowCasterManager::IsPlausibleShadowLightPtr;
 		std::uint8_t validCount = 0;
 		for (std::uint8_t i = 0; i < Pass->numLights; ++i) {
 			RE::BSLight* bsLight = Pass->sceneLights[i];
-			if (!IsPlausibleShadowLightPtr(reinterpret_cast<std::uintptr_t>(bsLight))) {
+			if (!IsPlausibleShadowLightPtr(reinterpret_cast<std::uintptr_t>(bsLight)) || !ProbeReadable(bsLight, 0x50)) {
 				static int loggedBsLight = 0;
 				if (loggedBsLight++ < 10) {
 					logger::warn(
@@ -1322,7 +1356,7 @@ void LightLimitFix::Hooks::BSEffectShader_SetupGeometry::thunk(RE::BSShader* Thi
 				break;
 			}
 			RE::NiLight* niLight = bsLight->light.get();
-			if (!IsPlausibleShadowLightPtr(reinterpret_cast<std::uintptr_t>(niLight))) {
+			if (!IsPlausibleShadowLightPtr(reinterpret_cast<std::uintptr_t>(niLight)) || !ProbeReadable(niLight, 0x168)) {
 				// Catches both NULL (engine cleared the NiPointer) and
 				// garbage (BSLight memory recycled). NULL is the more common
 				// observed failure -- the engine's loop has no null check

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -1290,12 +1290,9 @@ void LightLimitFix::Hooks::BSLightingShader_SetupGeometry::thunk(RE::BSShader* T
 
 namespace
 {
-	// VirtualQuery readability probe: the environment-independent check the
-	// address-floor heuristic can't be -- it asks the OS whether [ptr, ptr+size)
-	// is committed + readable, so a freed light at ANY address (the 16 MB garbage
-	// in the VR effect-shader crash, or a high unmapped one) is rejected without
-	// guessing the heap base. Wrapped in a Tracy zone (LLF::EffectLightProbe) so
-	// its per-frame cost is measurable in a TRACY_SUPPORT build.
+	// VirtualQuery readability probe -- the environment-independent check the address-floor
+	// heuristic can't be: asks the OS whether [ptr, ptr+size) is committed + readable, rejecting
+	// a freed light at ANY address without guessing the heap base. Tracy zone LLF::EffectLightProbe.
 	bool IsReadableRange(const void* a_ptr, std::size_t a_size) noexcept
 	{
 		MEMORY_BASIC_INFORMATION mbi{};
@@ -1321,25 +1318,12 @@ namespace
 
 void LightLimitFix::Hooks::BSEffectShader_SetupGeometry::thunk(RE::BSShader* This, RE::BSRenderPass* Pass, uint32_t RenderFlags)
 {
-	// Defensive pre-call guard: BSEffectShader::SetupGeometry iterates
-	// Pass->sceneLights[i] and dereferences bsLight->light->fade
-	// (BSLight+0x48 -> NiLight+0x134) with NO null check. Stale entries are
-	// possible because Pass->sceneLights[] is a raw BSLight** (not
-	// NiPointer<>): the engine's pass cache can outlive individual lights
-	// or capture them after their NiLight has been cleared. Crashes seen in
-	// the wild include garbage data (BSLight memory recycled as a string
-	// buffer) and outright NULL NiLight (engine half-destroyed the BSLight
-	// but it's still ref-counted alive in some list).
-	//
-	// Walk the array and clamp numLights to the count of entries that the
-	// engine can safely dereference. Validation does the cheap range/alignment
-	// check first, then a VirtualQuery readability probe -- the probe is the real
-	// boundary, since a freed light can pass the cheap checks yet point to
-	// unmapped memory (the 16 MB garbage pointer that AV'd reading NiLight->fade):
-	//   - BSLight* canonical/aligned/non-null + [.., +0x50) readable (->light @ +0x48)
-	//   - bsLight->light (NiLight) canonical/aligned/non-null + [.., +0x168) readable (->fade @ VR +0x15C)
-	// Entries failing any check stop the loop; the engine's own loop bails on the
-	// first bad entry too, so clamping matches its contract.
+	// Defensive guard: BSEffectShader::SetupGeometry derefs Pass->sceneLights[i]->light->fade with
+	// no null check, and sceneLights[] is a raw BSLight** that can outlive its lights (recycled
+	// garbage, or a half-destroyed BSLight with NULL NiLight -> AV). Clamp numLights to the entries
+	// the engine can safely deref: cheap range/alignment check, then a VirtualQuery readability
+	// probe (the real boundary -- a freed light passes the cheap checks but points to unmapped
+	// memory). Entries failing any check stop the loop, matching the engine's bail-on-first-bad.
 	if (Pass && Pass->sceneLights && Pass->numLights > 0) {
 		using ShadowCasterManager::IsPlausibleShadowLightPtr;
 		std::uint8_t validCount = 0;

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -3608,6 +3608,15 @@ namespace ShadowCasterManager
 				s_shadowConvert.insert(light);
 			}
 			justPromoted = true;
+		} else {
+			// This NiLight is not one we promoted (native shadow caster, or promotion off).
+			// If the allocator reused its address from a freed promoted light, drop the stale
+			// entry now -- synchronously, before the scheduler can misread it as promoted.
+			// A re-added promoted light always arrives with shadowLight=false and takes the
+			// branch above, so this never un-tracks one of ours.
+			std::scoped_lock lk(s_shadowConvertMutex);
+			s_shadowConvert.erase(light);
+			s_shadowConvertDescriptorInited.erase(light);
 		}
 		// Portal-strict policy by shadow type (engine picks the shadow class by FOV: >=2pi omni,
 		// >=pi hemi, <pi spot). Tighten on omnis/hemis; on spots it drops culled-but-visible spots.

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -293,6 +293,10 @@ namespace ShadowCasterManager
 	// Promoted lights whose descriptor pool-slots were initialized once (scheduler-time),
 	// covering lights never enabled -- EnableLight only inits slot winners.
 	static std::set<RE::NiLight*> s_shadowConvertDescriptorInited;
+	// Guards both sets above. Game-thread hooks (Add/SetLight/Remove) mutate them while the
+	// render-thread scheduler reads and reconciles; concurrent std::set mutation corrupts the
+	// tree and hangs a later traversal. Lock every access; never re-entered while held.
+	static std::mutex s_shadowConvertMutex;
 
 	// Set by Hook_ClearLightArrays on engine bulk teardown, drained atop ScheduleShadowCasters
 	// so stale s_lights/convert pointers clear before the next pass dereferences a slot.
@@ -1371,6 +1375,16 @@ namespace ShadowCasterManager
 		return globals::game::isVR ? light->GetVRRuntimeData().shadowmapDescriptors.front().cullingProcess : light->GetRuntimeData().shadowmapDescriptors.front().cullingProcess;
 	}
 
+	// True if this NiLight was promoted normal->shadow (PromoteNormalToShadow). Takes the
+	// tracking lock; safe to call from the render thread while hooks mutate the set.
+	static bool IsPromotedLight(RE::NiLight* ni)
+	{
+		if (!ni)
+			return false;
+		std::scoped_lock lk(s_shadowConvertMutex);
+		return s_shadowConvert.contains(ni);
+	}
+
 	// =========================================================================
 	// Formula helpers
 	//
@@ -1483,7 +1497,7 @@ namespace ShadowCasterManager
 			z = nilight->world.translate.z;
 
 			if (s_settings.PromoteNormalToShadow)
-				FormulaHelper::SetParam(kFormulaParam_LightNS, s_shadowConvert.find(nilight) != s_shadowConvert.end() ? 1.0 : 0.0);
+				FormulaHelper::SetParam(kFormulaParam_LightNS, IsPromotedLight(nilight) ? 1.0 : 0.0);
 		} else {
 			FormulaHelper::SetParam(kFormulaParam_LightIntensity, 0.0);
 			FormulaHelper::SetParam(kFormulaParam_LightRadius, 0.0);
@@ -2136,10 +2150,12 @@ namespace ShadowCasterManager
 				// init here (once) -- this is the type-safe BSShadowLight source -- to cover a
 				// promoted light added but never enabled before teardown reads it.
 				if (s_settings.ShadowLightCount > 4) {
-					if (auto* ni = l->light.get(); ni && s_shadowConvert.contains(ni) &&
-												   !s_shadowConvertDescriptorInited.contains(ni)) {
-						InitPromotedDescriptorSlots(l);
-						s_shadowConvertDescriptorInited.insert(ni);
+					if (auto* ni = l->light.get(); ni) {
+						std::scoped_lock lk(s_shadowConvertMutex);
+						if (s_shadowConvert.contains(ni) && !s_shadowConvertDescriptorInited.contains(ni)) {
+							InitPromotedDescriptorSlots(l);
+							s_shadowConvertDescriptorInited.insert(ni);
+						}
 					}
 				}
 				auto& c = candidates.emplace_back();
@@ -2153,6 +2169,22 @@ namespace ShadowCasterManager
 			if (n > 0)
 				ZoneText(buf, static_cast<size_t>(n));
 #endif
+		}
+
+		// Drop tracking entries whose NiLight left activeShadowLights -- pointer membership
+		// only, never deref a freed light. This is the only safe cleanup: ResetSession can't
+		// wipe (deferred, races the new cell's promotions) and bulk ClearLightArrays bypasses
+		// the per-light erase, so without it promoted lights leak in and read as native.
+		{
+			std::scoped_lock lk(s_shadowConvertMutex);
+			if (!s_shadowConvert.empty() || !s_shadowConvertDescriptorInited.empty()) {
+				std::set<RE::NiLight*> liveNi;
+				for (auto& c : candidates)
+					if (auto* ni = c.light->light.get())
+						liveNi.insert(ni);
+				std::erase_if(s_shadowConvert, [&](RE::NiLight* ni) { return !liveNi.contains(ni); });
+				std::erase_if(s_shadowConvertDescriptorInited, [&](RE::NiLight* ni) { return !liveNi.contains(ni); });
+			}
 		}
 
 		// Validation, redraw-interval scoring, and RedrawFrame marking all
@@ -2261,7 +2293,11 @@ namespace ShadowCasterManager
 				// Portal culling only applies in interior cells where a portal graph exists.
 				// Lights with no culling process (e.g. WSU spotlights outside cell bounds)
 				// or no portal are unconditionally visible; skip the check for them.
-				auto* cull = GetLightCullingProcess(l);
+				// Promoted lights carry a rebuilt culling process whose portal-graph entry the
+				// engine never room-associates (always visibleUnboundSpace), so the test
+				// false-culls an in-view light. The verdict is unreliable for them by
+				// construction -- always skip the demotion; native lights still get it.
+				auto* cull = IsPromotedLight(l->light.get()) ? nullptr : GetLightCullingProcess(l);
 				if (cull) {
 					auto* portal = reinterpret_cast<RE::BSPortalGraphEntry*>(cull->portalGraphEntry);
 					if (portal) {
@@ -3503,6 +3539,7 @@ namespace ShadowCasterManager
 			}
 		}
 		if (light) {
+			std::scoped_lock lk(s_shadowConvertMutex);
 			s_shadowConvert.erase(light);
 			s_shadowConvertDescriptorInited.erase(light);
 		}
@@ -3566,7 +3603,10 @@ namespace ShadowCasterManager
 			p->falloff = 1.0f;
 			p->depthBias = 1.0f;
 			p->nearDistance = (light->GetLightRuntimeData().radius.x / 512.0f) * 219.6356f;
-			s_shadowConvert.insert(light);
+			{
+				std::scoped_lock lk(s_shadowConvertMutex);
+				s_shadowConvert.insert(light);
+			}
 			justPromoted = true;
 		}
 		// Portal-strict policy by shadow type (engine picks the shadow class by FOV: >=2pi omni,
@@ -3605,14 +3645,17 @@ namespace ShadowCasterManager
 		// room-light culling calls a vfunc on -> garbage-vtable CTD. Null it at creation
 		// (SetLight runs during AddLight, before any accumulate) so the engine builds a real
 		// one, exactly as a fresh zeroed page would.
-		if (nilight && s_shadowConvert.count(nilight))
-			bslight->cullingProcess = nullptr;
-		auto* oldlight = bslight->light.get();
-		if (oldlight && oldlight != nilight) {
-			bool did = s_shadowConvert.erase(oldlight) != 0;
-			s_shadowConvertDescriptorInited.erase(oldlight);  // reassigned nilight re-inits via scheduler
-			if (nilight && did)
-				s_shadowConvert.insert(nilight);
+		{
+			std::scoped_lock lk(s_shadowConvertMutex);
+			if (nilight && s_shadowConvert.count(nilight))
+				bslight->cullingProcess = nullptr;
+			auto* oldlight = bslight->light.get();
+			if (oldlight && oldlight != nilight) {
+				bool did = s_shadowConvert.erase(oldlight) != 0;
+				s_shadowConvertDescriptorInited.erase(oldlight);  // reassigned nilight re-inits via scheduler
+				if (nilight && did)
+					s_shadowConvert.insert(nilight);
+			}
 		}
 	}
 
@@ -4271,8 +4314,9 @@ namespace ShadowCasterManager
 		// takes NiLight* (not BSLight* as the wrapper assumed); the call
 		// was a silent no-op on every runtime and accomplished nothing.
 		s_normalConvert.clear();
-		s_shadowConvert.clear();
-		s_shadowConvertDescriptorInited.clear();
+		// Promotion tracking is NOT wiped here: this reset is deferred to the render thread
+		// and can drain after the game thread promotes the new cell's lights, wiping live
+		// entries. ScheduleShadowCasters reconciles stale entries per-frame instead.
 		s_pinShadow.clear();
 		s_pinConvert.clear();
 		s_soloLight = 0;

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -290,23 +290,16 @@ namespace ShadowCasterManager
 	};
 	static std::vector<ConvertedLight> s_normalConvert;
 	static std::set<RE::NiLight*> s_shadowConvert;
-	// Promoted lights whose descriptor pool-slots have been initialized once. EnableLight
-	// only inits lights that win a render slot; this tracks the scheduler-time init that
-	// covers promoted lights added but never enabled, so teardown can't read garbage.
+	// Promoted lights whose descriptor pool-slots were initialized once (scheduler-time),
+	// covering lights never enabled -- EnableLight only inits slot winners.
 	static std::set<RE::NiLight*> s_shadowConvertDescriptorInited;
 
-	// Set by Hook_ClearLightArrays (the engine's bulk shadow-light teardown) and
-	// drained at the top of ScheduleShadowCasters on the render thread, so a
-	// scene tear-down drops every stale s_lights/convert pointer before the next
-	// pass dereferences a slot -- the natural-engine-cycle clear that the
-	// LoadingMenu-driven ResetSession is too coarse to time precisely.
+	// Set by Hook_ClearLightArrays on engine bulk teardown, drained atop ScheduleShadowCasters
+	// so stale s_lights/convert pointers clear before the next pass dereferences a slot.
 	static std::atomic<bool> s_pendingSessionReset{ false };
 
-	// Serializes the scheduler's portalGraph-dependent engine mutations (render
-	// thread) against the cell teardown that nulls/swaps ssn->portalGraph (main
-	// thread, ResetScene). The scheduler/AccumulateLight take it shared; ResetScene
-	// takes it exclusive, so the graph can't change while a reader holds it -- closes
-	// the cross-thread null-deref the pass-start gate can't catch.
+	// Serializes render-thread portalGraph readers (scheduler/AccumulateLight, shared) against
+	// ResetScene nulling/swapping ssn->portalGraph (exclusive) -- the cross-thread null deref.
 	static std::shared_mutex s_portalGraphMutex;
 
 	// User suppression set (lightKey = BSShadowLight pointer cast to uintptr_t).
@@ -1119,15 +1112,9 @@ namespace ShadowCasterManager
 		return sg ? sg->GetRuntimeData().camera.get() : nullptr;
 	}
 
-	// True while an interior cell's BSPortalGraph is mid-rebuild (transiently null
-	// during a cell transition). Engine portal accumulation
-	// (ShadowSceneNode::AccumulateLight, RE 106401) and BSShadowLight::Render deref
-	// ssn->portalGraph (+0x228) with no null guard in either the strict or loose
-	// branch, so driving our schedule/render while it is null faults in portal
-	// culling. SCM is the sole shadow-caster scheduler (we replace
-	// CalculateActiveShadowCasterLights), so pausing for the 1-2 frames the graph is
-	// null closes the window without disturbing the light set. Exteriors legitimately
-	// have no portal graph -- only gate in interiors so outdoor scheduling is unaffected.
+	// True while an interior cell's BSPortalGraph is transiently null mid-transition. Engine
+	// portal accumulation derefs ssn->portalGraph (+0x228) unguarded, so we pause scheduling
+	// for the 1-2 null frames. Interior-only: exteriors legitimately have no portal graph.
 	static bool IsPortalGraphTransitioning()
 	{
 		if (!Util::IsInterior())
@@ -1689,15 +1676,10 @@ namespace ShadowCasterManager
 		GameEnableLight(ssn, light);
 	}
 
-	// Reset a promoted (parabolic) light's descriptor pool-slot indices to the
-	// "no slot" sentinel. BSShadowParabolicLight is allocated NON-zeroed and its
-	// ctor never writes the descriptor renderTarget / vrRenderTarget / shadowmapIndex
-	// (RENDER_TARGET_DEPTHSTENCIL slot *indices* into the shared depth-stencil pool,
-	// not pointers). In VR the engine indexes the pool by vrRenderTarget, so the
-	// uninitialized heap garbage becomes an OOB pool walk -> nvwgf2umx AV on the next
-	// cell teardown. kNONE forces the engine's RenderCascade/Accumulate to re-allocate
-	// a valid slot. Must run for EVERY promoted light (incl. ones never EnableLight'd),
-	// or teardown reads the garbage of an added-but-unscheduled promoted light.
+	// Reset a promoted light's descriptor pool-slot indices to kNONE. BSShadowParabolicLight is
+	// allocated non-zeroed and no ctor writes them; the VR engine indexes the depth-stencil pool
+	// by the garbage -> nvwgf2umx OOB walk on teardown. kNONE forces re-allocation. Must run for
+	// EVERY promoted light, incl. ones never EnableLight'd (else teardown reads the garbage).
 	static void InitPromotedDescriptorSlots(RE::BSShadowLight* light)
 	{
 		if (!light)
@@ -1725,16 +1707,10 @@ namespace ShadowCasterManager
 		}
 	}
 
-	// Vtable hook (slot 0x0A Render) on BSShadowParabolicLight. The engine's Render
-	// renders cascade 0 (RenderCascade assigns it a real depth-stencil slot in
-	// renderTarget+shadowmapIndex), then for cascade 1 copies cascade 0's renderTarget
-	// but NOT its shadowmapIndex -- so descriptor[1] keeps a stale/wrong shadowmapIndex
-	// (the SCM pool idx left there is out of the depth-stencil pool range).
-	// At cell teardown Reset reads descriptor[1].shadowmapIndex (renderTarget is valid,
-	// so it isn't skipped) and frees the WRONG global pool slot -> mask corruption ->
-	// nvwgf2umx OOB pool walk. Mirror what the engine already does for renderTarget:
-	// copy descriptor[0].shadowmapIndex into descriptor[1] after Render. Runs on the
-	// render thread per-light (same safety as EnableLight); no cross-thread race.
+	// Vtable Render hook on BSShadowParabolicLight. The engine copies cascade 0's renderTarget
+	// to descriptor[1] but NOT its shadowmapIndex, so descriptor[1] keeps a stale out-of-range
+	// idx that teardown frees as the wrong pool slot -> nvwgf2umx OOB walk. Mirror renderTarget:
+	// copy descriptor[0].shadowmapIndex into [1]. Render-thread per-light, no cross-thread race.
 	struct Hook_ParabolicRender
 	{
 		static void thunk(RE::BSShadowParabolicLight* light, std::uint32_t& a_index)
@@ -1993,13 +1969,10 @@ namespace ShadowCasterManager
 		}
 	}
 
-	// Run UpdateCamera + EnableLight + the validity scan in one non-inlined SEH
-	// region: EnableLight can read shadowMapCount from a freed light and corrupt
-	// accumLightSlot / array bounds, AV'ing here or in the membership scan that
-	// follows; catching it skips the light instead of a CTD (the per-frame
-	// accumLightSlot reset recovers next frame). __declspec(noinline) is
-	// load-bearing -- without the boundary the optimizer inlines this and dissolves
-	// the __except region. No C++ unwinding objects in this frame (MSVC __try).
+	// Run UpdateCamera + EnableLight + the validity scan in one SEH region: EnableLight can read a
+	// freed light and corrupt accumLightSlot/bounds, AV'ing here; catching it skips the light (the
+	// per-frame accumLightSlot reset recovers). __declspec(noinline) is load-bearing -- inlining
+	// dissolves the __except. No C++ unwinding objects in this frame (MSVC __try).
 	template <class UsableFn>
 	__declspec(noinline) static bool SafeEnableAndValidate(LightEntry& e, RE::NiCamera* a_camera,
 		RE::ShadowSceneNode* a_ssn, std::uint32_t a_slot, UsableFn&& a_isUsable)
@@ -2042,36 +2015,21 @@ namespace ShadowCasterManager
 		if (IsPortalGraphTransitioning())
 			return;
 
-		// Drain a pending teardown reset BEFORE touching any slot, then SKIP this
-		// pass. The engine's bulk shadow-light teardown (ClearLightArrays) freed
-		// the previous scene's lights since our last pass but does NOT shrink
-		// activeShadowLights -- it leaves dangling entries until it later drains
-		// lightQueueRemove and rebuilds the array. So this frame we must neither
-		// snapshot activeShadowLights (heldRefs would IncRef freed memory) nor
-		// score candidates from it. Clear our pool on the render thread and bail;
-		// the engine's ResetCalculatedShadowCasterLights already left the array
-		// vanilla-valid for this frame, and the next pass runs once the array is
-		// rebuilt. (Load-bearing: removing this return reintroduces the 20 SEH
-		// catches. It does NOT cause the separate d3d11 shadow-render crash, which
-		// reproduces with or without the skip.)
+		// Drain a pending teardown reset before touching any slot, then SKIP this pass.
+		// ClearLightArrays freed the previous scene's lights but doesn't shrink
+		// activeShadowLights, so snapshotting or scoring it now would touch freed memory.
+		// The engine left the array vanilla-valid this frame; the next pass runs once it is
+		// rebuilt. (Load-bearing: removing this return reintroduces the 20 SEH catches.)
 		if (s_pendingSessionReset.exchange(false, std::memory_order_acquire)) {
 			ResetSession();
 			return;
 		}
 
-		// Hold a strong ref to every active shadow light for the whole pass.
-		// activeShadowLights is BSTArray<NiPointer<BSShadowLight>>, but the
-		// scheduler walks raw BSShadowLight* (candidates, s_lights.Lights[]).
-		// EnableLight/ConvertLight trigger engine scene mutations -- and a
-		// concurrent bulk cell-teardown (NiNode::ReleaseChildren, which bypasses
-		// our per-light RemoveLight hook) can free a light mid-pass while our raw
-		// pointer still references it. The freed memory is then recycled and our
-		// write through it (e.g. lodDimmer = 1.0f below) corrupts the new
-		// occupant's vtable -> CTD.
-		// Snapshotting NiPointers here keeps every light alive until heldRefs
-		// destructs at pass end -- the refs are taken now, while activeShadowLights
-		// is valid, so the engine's frees only take effect once we have stopped
-		// touching the pointers. Local (not static): releases at every return path.
+		// Hold a strong ref to every active shadow light for the whole pass. The scheduler
+		// walks raw BSShadowLight*, but a concurrent bulk cell-teardown (ReleaseChildren,
+		// which bypasses our RemoveLight hook) can free one mid-pass; a later write through
+		// the stale pointer corrupts the recycled occupant's vtable -> CTD. Snapshot now
+		// while activeShadowLights is valid; local so it releases at every return path.
 		std::vector<RE::NiPointer<RE::BSShadowLight>> heldRefs;
 		{
 			auto& alive = ssn->GetRuntimeData().activeShadowLights;
@@ -2899,11 +2857,10 @@ namespace ShadowCasterManager
 		// zone captures both our scheduler work and any engine-side rendering
 		// it pulls in for chosen lights.
 		{
-			// Hold the graph lock shared for the whole mutation loop: ClearSceneAndFog
-			// (main thread) takes it exclusive to null ssn->portalGraph, so while we hold
-			// it the graph stays valid and the engine mutations below (ConvertLight /
-			// DisableLight / EnableLight -> AccumulateLight) can't deref a null graph.
-			// try_to_lock: if a teardown holds it, skip this pass instead of blocking.
+			// Hold the graph lock shared for the whole mutation loop so ResetScene (main thread)
+			// can't null ssn->portalGraph while the engine mutations below (ConvertLight /
+			// DisableLight / EnableLight -> AccumulateLight) deref it. try_to_lock: skip the
+			// pass if a teardown holds it exclusive, rather than block.
 			std::shared_lock<std::shared_mutex> graphLock(s_portalGraphMutex, std::try_to_lock);
 			if (!graphLock.owns_lock())
 				return;
@@ -2931,24 +2888,11 @@ namespace ShadowCasterManager
 					ZoneNamedN(zCvt, "SCM::Engine::convertOrDisable(invalid)", true);
 					if (convertOrDisable(c.light, /*allowConvert=*/c.invalidCamera)) {
 						s_schedDiag.converted_invalid++;
-						// UpdateCamera zeros lodDimmer alongside frustrumCull
-						// when its shadow-distance LOD cull fires. The
-						// cluster lighting builder multiplies light.fade by
-						// lodDimmer and drops the light if the product falls
-						// below 1e-4. Restore only when fully zeroed -- any
-						// smooth fade value the engine set is preserved so
-						// the cluster contribution fades gradually rather
-						// than snapping to full intensity. Matches the
-						// per-frame restore in LightLimitFix::UpdateLights
-						// for already-converted lights.
-						//
-						// Re-validate before writing: ConvertLight's scene
-						// mutation (or a concurrent bulk cell-teardown) can free
-						// c.light here, and a 1.0f store into the recycled memory
-						// corrupts the new occupant's vtable -> CTD. heldRefs
-						// should keep it alive; this guards any candidate it
-						// doesn't cover. A demoted-but-removed light skips the
-						// restore -- UpdateLights re-applies it next frame.
+						// UpdateCamera zeros lodDimmer on its shadow-distance LOD cull; the cluster
+						// builder multiplies fade*lodDimmer and drops the light below 1e-4. Restore
+						// only when fully zeroed (preserves any smooth fade), matching UpdateLights.
+						// Re-validate first: a concurrent free could recycle c.light, and a 1.0f store
+						// would corrupt the new occupant's vtable -> CTD (heldRefs should cover it).
 						if (SafeUsable(isUsableLight, c.light) && c.light->lodDimmer == 0.0f)
 							c.light->lodDimmer = 1.0f;
 					} else {
@@ -2982,13 +2926,8 @@ namespace ShadowCasterManager
 
 						auto* lightSnapshot = e.Light;  // value snapshot for budget pairing
 						s_budget.BeginLight(lightSnapshot, 0);
-						// EnableLight callbacks can null e.Light (re-entrant scheduling /
-						// scene mutation), AND the engine can free the BSShadowLight during
-						// the call without nulling our pointer, then read shadowMapCount from
-						// it -- corrupting accumLightSlot / the array bounds and AV'ing here
-						// or in the membership scan. Run UpdateCamera + EnableLight + the
-						// validity scan in one noinline SEH region so the AV is caught and the
-						// light skipped, not a CTD (per-frame accumLightSlot reset recovers).
+						// EnableLight can null e.Light or free the BSShadowLight mid-call (then read
+						// shadowMapCount from it) -> AV. SafeEnableAndValidate catches it (noinline SEH).
 						bool stillUsable;
 						{
 							ZoneNamedN(zEnable, "SCM::Engine::EnableLight", true);
@@ -3269,15 +3208,10 @@ namespace ShadowCasterManager
 
 	static void RenderScheduledShadowLights()
 	{
-		// A cell-transition teardown (ShadowSceneNode::ClearLightArrays, hooked to set
-		// s_pendingSessionReset at its entry before it frees) deallocates the engine
-		// shadow accumulator's renderPass storage. The schedule pass drains the flag,
-		// but a teardown landing after schedule and before this render pass leaves us
-		// flushing a freed accumulator -> AV in BSBatchRenderer::RenderBatches
-		// (renderPass._data == NULL). Skip the whole pass while a reset is pending;
-		// ScheduleShadowCasters owns the drain (+ ResetSession) next frame -- only load
-		// here, never exchange, or s_lights would never get reset. Do this before the
-		// drawStereo save so a skip leaves engine state untouched.
+		// A cell-transition teardown (ClearLightArrays) frees the engine accumulator's renderPass
+		// storage. A teardown landing between schedule and this pass would flush a freed accumulator
+		// -> AV in BSBatchRenderer. Skip while a reset is pending; ScheduleShadowCasters owns the
+		// drain next frame -- only LOAD here, never exchange, or s_lights would never reset.
 		if (s_pendingSessionReset.load(std::memory_order_acquire))
 			return;
 
@@ -3574,12 +3508,9 @@ namespace ShadowCasterManager
 		}
 	}
 
-	// Fires at start of ShadowSceneNode::ClearLightArrays (RelocationID 99704/106338),
-	// the engine's bulk shadow-light teardown on cell unload / scene reset. It frees
-	// activeShadowLights via the inner queued removal -- bypassing the per-light
-	// RemoveLight hook above -- so this is the only signal for a wholesale free.
-	// Flag a session reset; the scheduler drains it on the render thread next pass
-	// so our stale pointers never outlive the lights the engine just freed.
+	// Fires at start of ShadowSceneNode::ClearLightArrays (99704/106338), the engine's bulk
+	// shadow-light teardown -- the only signal for a wholesale free (it bypasses RemoveLight).
+	// Flag a session reset; the scheduler drains it next pass before our pointers go stale.
 	static void Hook_ClearLightArrays(CONTEXT& ctx)
 	{
 		auto* ssn = reinterpret_cast<RE::ShadowSceneNode*>(ctx.Rcx);
@@ -3587,12 +3518,9 @@ namespace ShadowCasterManager
 			s_pendingSessionReset.store(true, std::memory_order_release);
 	}
 
-	// Detours ShadowSceneNode::ResetScene (RelocationID 99741/106385) -- the SSN portalGraph
-	// setter (this->portalGraph = a_graph), called from ResetCellGrid on interior cell
-	// transitions to detach the old cell's graph (a_graph null). This is the coc-time nuller
-	// behind the crash (ClearSceneAndFog only fires on SSN teardown, never on a transition).
-	// Hold the graph lock exclusive across it so it cannot null/swap portalGraph while
-	// AccumulateLight reads it.
+	// Detours ShadowSceneNode::ResetScene (99741/106385) -- the portalGraph setter, called from
+	// ResetCellGrid on cell transitions. This is the coc-time nuller (not ClearSceneAndFog, which
+	// only fires on SSN teardown). Hold the graph lock exclusive so it can't swap mid-read.
 	struct Hook_ResetScene
 	{
 		static void thunk(RE::ShadowSceneNode* a_ssn, RE::BSPortalGraph* a_graph)
@@ -3603,15 +3531,10 @@ namespace ShadowCasterManager
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
-	// Detours ShadowSceneNode::AccumulateLight (RelocationID 99753/106401), the engine's
-	// per-light portal/room shadow accumulation. It derefs ssn->portalGraph at several
-	// sites AFTER an entry null guard already passed, so the teardown nulling portalGraph
-	// on another thread mid-call is a TOCTOU. Take the graph lock SHARED but with
-	// try_to_lock: while ResetScene holds it exclusive (actively swapping portalGraph),
-	// skip this light's accumulation for the frame -- safe, and crucially non-blocking, so
-	// the render thread never parks on the lock (a blocking acquire deadlocks against
-	// ResetScene's own wait for render-thread progress). When acquired, holding it shared
-	// keeps ResetScene from nulling portalGraph mid-call.
+	// Detours ShadowSceneNode::AccumulateLight (99753/106401). It derefs ssn->portalGraph after
+	// an entry guard passed, so the teardown nulling it mid-call is a TOCTOU. Take the graph lock
+	// SHARED with try_to_lock: skip the light if ResetScene holds it exclusive. try_to_lock is
+	// load-bearing -- a blocking acquire deadlocks against ResetScene's wait for render progress.
 	struct Hook_AccumulateLight
 	{
 		static void thunk(RE::ShadowSceneNode* a_ssn, RE::BSLight* a_light, void* a3, std::uint8_t a4)
@@ -3646,26 +3569,11 @@ namespace ShadowCasterManager
 			s_shadowConvert.insert(light);
 			justPromoted = true;
 		}
-		// Portal-strict policy by shadow type. The engine picks the concrete
-		// shadow class (BSShadowParabolicLight / BSShadowHemisphereLight /
-		// BSShadowFrustumLight) based on the FOV in LIGHT_CREATE_PARAMS:
-		//   fov >= ~2pi  -> dual-paraboloid omni
-		//   fov >= ~pi   -> hemisphere
-		//   fov <  ~pi   -> perspective spot/frustum
-		// Tightening portal-strict on omnis/hemis usefully exercises the
-		// portal-graph visibility test; doing it on spots drops culled-but-
-		// visible spots entirely.
-		//
-		// NEVER force portal-strict on a light WE just promoted. A promoted
-		// (originally-normal) light has no stable portal-graph entry; portalStrict
-		// sends it down the engine's STRICT portal-accumulation branch, which derefs
-		// ShadowSceneNode::portalGraph (+0x228) and cull->portalGraphEntry WITHOUT the
-		// NULL guards the non-strict branch has. During a cell transition the graph is
-		// transiently NULL -> flat: null deref in BSParabolicCullingProcess (RE 76136
-		// <- 106401, SkyrimSE+0xE15240); VR: the light is mis-culled, never enters
-		// shadowLightsAccum, so RenderCascade never assigns it a depth-stencil slot and
-		// its vrRenderTarget stays uninitialized garbage -> nvwgf2umx OOB pool walk.
-		// Non-strict survives cleanly.
+		// Portal-strict policy by shadow type (engine picks the shadow class by FOV: >=2pi omni,
+		// >=pi hemi, <pi spot). Tighten on omnis/hemis; on spots it drops culled-but-visible spots.
+		// NEVER force it on a light WE just promoted: a promoted light has no stable portal-graph
+		// entry, so portalStrict takes the engine's unguarded strict branch and faults on the
+		// transiently-null graph during a cell transition (flat: null deref; VR: nvwgf2umx).
 		if (!justPromoted) {
 			constexpr float kFovHemiThreshold = 3.0f;  // ~pi
 			constexpr float kFovOmniThreshold = 6.0f;  // ~2pi
@@ -4126,25 +4034,11 @@ namespace ShadowCasterManager
 			REL::safe_write(uid3.address(), &zero, 1);
 		}
 
-		// ---- Screen-space shadow-mask pass: skip vanilla on all runtimes -----
-		// Detour the standalone RenderShadowLightsWithUtilityShader
-		// (100423/107141) to a no-op. Its inner loop indexes a 4-entry
-		// per-slot blend-mode table by BSShadowLight::maskIndex; SLF's extended
-		// slots -- and teardown's 0xFF "removed" sentinel -- push maskIndex >= 4
-		// -> OOB read -> corrupt shadow-render state (a VR driver CTD on cell
-		// transitions; tolerated as a garbage blend value on flat). LIGHT_LIMIT_
-		// FIX consumes only the mask's R channel and serves extended casters
-		// from its own cluster pipeline reading kSHADOWMAPS directly, so
-		// dropping the pass loses nothing. See
-		// Hook_RenderShadowLightsWithUtilityShader above for the full rationale.
-		//
-		// RenderShadowmasks calls this standalone function on every runtime
-		// including VR (verified via Ghidra: VR @ 0x141323740, called from
-		// RenderShadowmasks+0x9E -- the loop is NOT inlined). This used to be a
-		// VR-specific call-site NOP only because the VR address library mismapped
-		// id 100423 to an unrelated helper (0x1409c0c80), so the detour resolved
-		// to the wrong function. With the addrlib entry corrected to 0x141323740
-		// the one detour works on all three -- do not reintroduce the VR split.
+		// Screen-space shadow-mask pass: no-op RenderShadowLightsWithUtilityShader (100423/107141)
+		// on all runtimes. Its loop indexes a 4-entry blend-mode table by BSShadowLight::maskIndex;
+		// SLF's extended slots (and teardown's 0xFF sentinel) push it >=4 -> OOB -> corrupt shadow
+		// state (VR CTD on transitions). LLF serves casters from its own pipeline, so this loses
+		// nothing. One detour for all runtimes -- don't re-split for VR (a since-corrected mismap).
 		stl::detour_thunk<Hook_RenderShadowLightsWithUtilityShader>(
 			REL::RelocationID(100423, 107141));
 
@@ -4241,12 +4135,9 @@ namespace ShadowCasterManager
 		}
 
 		{
-			// ShadowSceneNode::ClearLightArrays -- the bulk shadow-light teardown
-			// on cell unload, which frees activeShadowLights via the inner queued
-			// removal (bypassing the per-light RemoveLight hook). Hook the function
-			// start to flag a session reset. Prologue is version-specific: SE/VR
-			// steal 4 PUSHes (5 bytes); AE's 5th byte splits a SUB RSP, so steal
-			// through it (8 bytes).
+			// ShadowSceneNode::ClearLightArrays -- bulk shadow-light teardown; hook the start to
+			// flag a session reset. Version-specific prologue: SE/VR steal 4 PUSHes (5 bytes); AE's
+			// 5th byte splits a SUB RSP, so steal through it (8 bytes).
 			static REL::RelocationID uid(99704, 106338);
 			int sz = REL::Relocate(5, 8, 5);
 			if (!SKSE::stl::install_context_hook(uid.address(), sz, Hook_ClearLightArrays, sz))

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -19,6 +19,7 @@
 
 #include <exprtk.hpp>
 
+#include <Windows.h>  // SEH (__try) for the shadow-light usability backstop
 #include <mutex>
 
 #define I18N_KEY_PREFIX "feature.light_limit_fix."
@@ -288,6 +289,13 @@ namespace ShadowCasterManager
 	};
 	static std::vector<ConvertedLight> s_normalConvert;
 	static std::set<RE::NiLight*> s_shadowConvert;
+
+	// Set by Hook_ClearLightArrays (the engine's bulk shadow-light teardown) and
+	// drained at the top of ScheduleShadowCasters on the render thread, so a
+	// scene tear-down drops every stale s_lights/convert pointer before the next
+	// pass dereferences a slot -- the natural-engine-cycle clear that the
+	// LoadingMenu-driven ResetSession is too coarse to time precisely.
+	static std::atomic<bool> s_pendingSessionReset{ false };
 
 	// User suppression set (lightKey = BSShadowLight pointer cast to uintptr_t).
 	// Persisted across light lifetimes so suppressing a torch survives the player
@@ -806,6 +814,11 @@ namespace ShadowCasterManager
 		return s_installedSlotCount > 0 ? s_installedSlotCount : s_requestedSlotCount;
 	}
 
+	bool IsSessionResetPending()
+	{
+		return s_pendingSessionReset.load(std::memory_order_acquire);
+	}
+
 	// Resolution actually used to allocate kSHADOWMAPS this session. Captured
 	// lazily from the real D3D11 texture geometry the first time it becomes
 	// readable -- NOT from the RE::Setting at Install() time. The engine's
@@ -1092,6 +1105,23 @@ namespace ShadowCasterManager
 		static REL::RelocationID uid(528087, 415032);
 		auto* sg = *reinterpret_cast<RE::BSSceneGraph**>(uid.address());
 		return sg ? sg->GetRuntimeData().camera.get() : nullptr;
+	}
+
+	// True while an interior cell's BSPortalGraph is mid-rebuild (transiently null
+	// during a cell transition). Engine portal accumulation
+	// (ShadowSceneNode::AccumulateLight, RE 106401) and BSShadowLight::Render deref
+	// ssn->portalGraph (+0x228) with no null guard in either the strict or loose
+	// branch, so driving our schedule/render while it is null faults in portal
+	// culling. SCM is the sole shadow-caster scheduler (we replace
+	// CalculateActiveShadowCasterLights), so pausing for the 1-2 frames the graph is
+	// null closes the window without disturbing the light set. Exteriors legitimately
+	// have no portal graph -- only gate in interiors so outdoor scheduling is unaffected.
+	static bool IsPortalGraphTransitioning()
+	{
+		if (!Util::IsInterior())
+			return false;
+		auto* ssn = GetShadowSceneNode();
+		return !ssn || ssn->GetRuntimeData().portalGraph == nullptr;
 	}
 
 	static bool GetSunBool1()
@@ -1647,6 +1677,72 @@ namespace ShadowCasterManager
 		GameEnableLight(ssn, light);
 	}
 
+	// Reset a promoted (parabolic) light's descriptor pool-slot indices to the
+	// "no slot" sentinel. BSShadowParabolicLight is allocated NON-zeroed and its
+	// ctor never writes the descriptor renderTarget / vrRenderTarget / shadowmapIndex
+	// (RENDER_TARGET_DEPTHSTENCIL slot *indices* into the shared depth-stencil pool,
+	// not pointers). In VR the engine indexes the pool by vrRenderTarget, so the
+	// uninitialized heap garbage becomes an OOB pool walk -> nvwgf2umx AV on the next
+	// cell teardown. kNONE forces the engine's RenderCascade/Accumulate to re-allocate
+	// a valid slot. Must run for EVERY promoted light (incl. ones never EnableLight'd),
+	// or teardown reads the garbage of an added-but-unscheduled promoted light.
+	static void InitPromotedDescriptorSlots(RE::BSShadowLight* light)
+	{
+		if (!light)
+			return;
+		int32_t idx = s_lights.FindLight(light, s_settings.ShadowLightCount);
+		if (idx < 0)
+			idx = 0;
+		if (globals::game::isVR) {
+			auto& vrData = light->GetVRRuntimeData();
+			for (auto& desc : vrData.shadowmapDescriptors) {
+				desc.renderTarget = RE::RENDER_TARGET_DEPTHSTENCIL::kNONE;
+				desc.vrRenderTarget[0] = RE::RENDER_TARGET_DEPTHSTENCIL::kNONE;
+				desc.vrRenderTarget[1] = RE::RENDER_TARGET_DEPTHSTENCIL::kNONE;
+				desc.shadowmapIndex = static_cast<uint32_t>(idx);
+			}
+			for (auto& desc : vrData.focusShadowmapDescriptors) {
+				desc.vrRenderTarget[0] = RE::RENDER_TARGET_DEPTHSTENCIL::kNONE;
+				desc.vrRenderTarget[1] = RE::RENDER_TARGET_DEPTHSTENCIL::kNONE;
+			}
+		} else {
+			for (auto& desc : light->GetRuntimeData().shadowmapDescriptors) {
+				desc.renderTarget = RE::RENDER_TARGET_DEPTHSTENCIL::kNONE;
+				desc.shadowmapIndex = static_cast<uint32_t>(idx);
+			}
+		}
+	}
+
+	// Vtable hook (slot 0x0A Render) on BSShadowParabolicLight. The engine's Render
+	// renders cascade 0 (RenderCascade assigns it a real depth-stencil slot in
+	// renderTarget+shadowmapIndex), then for cascade 1 copies cascade 0's renderTarget
+	// but NOT its shadowmapIndex -- so descriptor[1] keeps a stale/wrong shadowmapIndex
+	// (the SCM pool idx left there is out of the depth-stencil pool range).
+	// At cell teardown Reset reads descriptor[1].shadowmapIndex (renderTarget is valid,
+	// so it isn't skipped) and frees the WRONG global pool slot -> mask corruption ->
+	// nvwgf2umx OOB pool walk. Mirror what the engine already does for renderTarget:
+	// copy descriptor[0].shadowmapIndex into descriptor[1] after Render. Runs on the
+	// render thread per-light (same safety as EnableLight); no cross-thread race.
+	struct Hook_ParabolicRender
+	{
+		static void thunk(RE::BSShadowParabolicLight* light, std::uint32_t& a_index)
+		{
+			func(light, a_index);
+			if (!light)
+				return;
+			if (globals::game::isVR) {
+				auto& descs = light->GetVRRuntimeData().shadowmapDescriptors;
+				if (descs.size() >= 2)
+					descs[1].shadowmapIndex = descs[0].shadowmapIndex;
+			} else {
+				auto& descs = light->GetRuntimeData().shadowmapDescriptors;
+				if (descs.size() >= 2)
+					descs[1].shadowmapIndex = descs[0].shadowmapIndex;
+			}
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
 	// Activates a non-sun shadow light into slot `slotIndex`.
 	static void EnableLight(RE::BSShadowLight* light, RE::NiCamera* camera,
 		RE::ShadowSceneNode* ssn, int slotIndex)
@@ -1744,22 +1840,8 @@ namespace ShadowCasterManager
 		// RenderCascade keeps the slot from a prior frame and lights not
 		// redrawn this frame would corrupt another light's shadow map.
 		// Pool index maps 1:1 to texture slot; slice 0 stays unused.
-		if (s_settings.ShadowLightCount > 4) {
-			int32_t idx = s_lights.FindLight(light, s_settings.ShadowLightCount);
-			if (idx < 0)
-				idx = 0;
-			if (globals::game::isVR) {
-				for (auto& desc : light->GetVRRuntimeData().shadowmapDescriptors) {
-					desc.renderTarget = RE::RENDER_TARGET_DEPTHSTENCIL::kNONE;
-					desc.shadowmapIndex = static_cast<uint32_t>(idx);
-				}
-			} else {
-				for (auto& desc : light->GetRuntimeData().shadowmapDescriptors) {
-					desc.renderTarget = RE::RENDER_TARGET_DEPTHSTENCIL::kNONE;
-					desc.shadowmapIndex = static_cast<uint32_t>(idx);
-				}
-			}
-		}
+		if (s_settings.ShadowLightCount > 4)
+			InitPromotedDescriptorSlots(light);
 
 		// Only apply lens flare when lensFlareData is non-null; calling it on parabolic lights
 		// (null lensFlareData) registers them into the lens flare system, causing a crash
@@ -1875,6 +1957,51 @@ namespace ShadowCasterManager
 		}
 	}
 
+	// Shadow-light usability SEH backstop. The ClearLightArrays teardown hook is
+	// the primary defense (clears our pool when the engine bulk-frees lights); this
+	// SEH catches any residual AV in the membership/usability scan so a missed edge
+	// is a skipped light, not a CTD. Kept until broad validation lets it go.
+	static void LogShadowSehCatch()
+	{
+		static std::atomic<int> n{ 0 };
+		if (n.fetch_add(1, std::memory_order_relaxed) < 20)
+			logger::warn("[SCM] SEH caught AV in shadow-light usability scan (probe missed); skipping light");
+	}
+
+	// SEH backstop in its own function (no C++ unwinding objects) so MSVC accepts
+	// __try. Returns false (unusable) on any access violation.
+	template <class Fn>
+	static bool SafeUsable(Fn&& a_fn, RE::BSShadowLight* a_light)
+	{
+		__try {
+			return a_fn(a_light);
+		} __except (GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH) {
+			LogShadowSehCatch();
+			return false;
+		}
+	}
+
+	// Run UpdateCamera + EnableLight + the validity scan in one non-inlined SEH
+	// region: EnableLight can read shadowMapCount from a freed light and corrupt
+	// accumLightSlot / array bounds, AV'ing here or in the membership scan that
+	// follows; catching it skips the light instead of a CTD (the per-frame
+	// accumLightSlot reset recovers next frame). __declspec(noinline) is
+	// load-bearing -- without the boundary the optimizer inlines this and dissolves
+	// the __except region. No C++ unwinding objects in this frame (MSVC __try).
+	template <class UsableFn>
+	__declspec(noinline) static bool SafeEnableAndValidate(LightEntry& e, RE::NiCamera* a_camera,
+		RE::ShadowSceneNode* a_ssn, std::uint32_t a_slot, UsableFn&& a_isUsable)
+	{
+		__try {
+			e.Light->UpdateCamera(a_camera);
+			EnableLight(e.Light, a_camera, a_ssn, a_slot);
+			return e.Light && a_isUsable(e.Light);
+		} __except (GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH) {
+			LogShadowSehCatch();
+			return false;
+		}
+	}
+
 	static void ScheduleShadowCasters()
 	{
 		ZoneScopedN("SCM::ScheduleShadowCasters");
@@ -1898,6 +2025,49 @@ namespace ShadowCasterManager
 		auto* camera = GetWorldCamera();
 		if (!ssn || !camera)
 			return;
+
+		// Pause while the interior portal graph is mid-rebuild (cell transition).
+		if (IsPortalGraphTransitioning())
+			return;
+
+		// Drain a pending teardown reset BEFORE touching any slot, then SKIP this
+		// pass. The engine's bulk shadow-light teardown (ClearLightArrays) freed
+		// the previous scene's lights since our last pass but does NOT shrink
+		// activeShadowLights -- it leaves dangling entries until it later drains
+		// lightQueueRemove and rebuilds the array. So this frame we must neither
+		// snapshot activeShadowLights (heldRefs would IncRef freed memory) nor
+		// score candidates from it. Clear our pool on the render thread and bail;
+		// the engine's ResetCalculatedShadowCasterLights already left the array
+		// vanilla-valid for this frame, and the next pass runs once the array is
+		// rebuilt. (Load-bearing: removing this return reintroduces the 20 SEH
+		// catches. It does NOT cause the separate d3d11 shadow-render crash, which
+		// reproduces with or without the skip.)
+		if (s_pendingSessionReset.exchange(false, std::memory_order_acquire)) {
+			ResetSession();
+			return;
+		}
+
+		// Hold a strong ref to every active shadow light for the whole pass.
+		// activeShadowLights is BSTArray<NiPointer<BSShadowLight>>, but the
+		// scheduler walks raw BSShadowLight* (candidates, s_lights.Lights[]).
+		// EnableLight/ConvertLight trigger engine scene mutations -- and a
+		// concurrent bulk cell-teardown (NiNode::ReleaseChildren, which bypasses
+		// our per-light RemoveLight hook) can free a light mid-pass while our raw
+		// pointer still references it. The freed memory is then recycled and our
+		// write through it (e.g. lodDimmer = 1.0f below) corrupts the new
+		// occupant's vtable -> CTD.
+		// Snapshotting NiPointers here keeps every light alive until heldRefs
+		// destructs at pass end -- the refs are taken now, while activeShadowLights
+		// is valid, so the engine's frees only take effect once we have stopped
+		// touching the pointers. Local (not static): releases at every return path.
+		std::vector<RE::NiPointer<RE::BSShadowLight>> heldRefs;
+		{
+			auto& alive = ssn->GetRuntimeData().activeShadowLights;
+			heldRefs.reserve(alive.size() + 1);
+			for (auto& sp : alive)
+				if (sp)
+					heldRefs.push_back(sp);
+		}
 
 		// Couple the shadow-cull distance to the light fade before the validation
 		// pass runs UpdateCamera (which reads the cached square). No-op unless
@@ -2642,6 +2812,9 @@ namespace ShadowCasterManager
 				return false;
 			if (l == sunLight)
 				return true;
+			// Membership scan over activeShadowLights. The ClearLightArrays
+			// teardown hook (+ ResetSession/skip) keeps us from scanning a
+			// torn-down array; SafeUsable (SEH) is the remaining backstop.
 			for (auto& sp : shadowSceneNodeRT->activeShadowLights)
 				if (sp.get() == l)
 					return true;
@@ -2735,7 +2908,15 @@ namespace ShadowCasterManager
 						// than snapping to full intensity. Matches the
 						// per-frame restore in LightLimitFix::UpdateLights
 						// for already-converted lights.
-						if (c.light->lodDimmer == 0.0f)
+						//
+						// Re-validate before writing: ConvertLight's scene
+						// mutation (or a concurrent bulk cell-teardown) can free
+						// c.light here, and a 1.0f store into the recycled memory
+						// corrupts the new occupant's vtable -> CTD. heldRefs
+						// should keep it alive; this guards any candidate it
+						// doesn't cover. A demoted-but-removed light skips the
+						// restore -- UpdateLights re-applies it next frame.
+						if (SafeUsable(isUsableLight, c.light) && c.light->lodDimmer == 0.0f)
 							c.light->lodDimmer = 1.0f;
 					} else {
 						s_schedDiag.disabled_invalid++;
@@ -2761,32 +2942,26 @@ namespace ShadowCasterManager
 						// may have transitively freed this light via game-side scene
 						// mutations (membership change OR tbbmalloc-zeroed memory),
 						// so re-validate before any virtual dispatch.
-						if (!isUsableLight(e.Light)) {
+						if (!SafeUsable(isUsableLight, e.Light)) {
 							e.Light = nullptr;
 							continue;
 						}
 
 						auto* lightSnapshot = e.Light;  // value snapshot for budget pairing
-
-						e.Light->UpdateCamera(camera);
 						s_budget.BeginLight(lightSnapshot, 0);
+						// EnableLight callbacks can null e.Light (re-entrant scheduling /
+						// scene mutation), AND the engine can free the BSShadowLight during
+						// the call without nulling our pointer, then read shadowMapCount from
+						// it -- corrupting accumLightSlot / the array bounds and AV'ing here
+						// or in the membership scan. Run UpdateCamera + EnableLight + the
+						// validity scan in one noinline SEH region so the AV is caught and the
+						// light skipped, not a CTD (per-frame accumLightSlot reset recovers).
+						bool stillUsable;
 						{
 							ZoneNamedN(zEnable, "SCM::Engine::EnableLight", true);
-							EnableLight(e.Light, camera, ssn, slot);
+							stillUsable = SafeEnableAndValidate(e, camera, ssn, slot, isUsableLight);
 						}
-
-						// EnableLight callbacks can null e.Light (re-entrant scheduling
-						// / scene mutation), AND the engine can free the BSShadowLight
-						// during the call without nulling our pointer -- a third-party
-						// VR crash report (CommunityShaders.dll v1.5.1, file path
-						// D:\a\skyrim-community-shaders\... at EnableLight's
-						// `*GetAccumLightSlot() += light->shadowMapCount`) showed the
-						// engine reading shadowMapCount from a freed BSShadowLight,
-						// corrupting the global accumLightSlot counter, then a
-						// downstream `[base + corrupted*8]` AV. Bare null check passes
-						// for the freed-but-non-null case; isUsableLight rejects it
-						// via the activeShadowLights-membership and vtable checks.
-						if (!e.Light || !isUsableLight(e.Light))
+						if (!stillUsable)
 							continue;
 						s_budget.EndLight(lightSnapshot, 0);
 
@@ -2924,7 +3099,7 @@ namespace ShadowCasterManager
 					// Same hazard as the post-EnableLight site: the engine can
 					// free the light during this call. Use isUsableLight, not
 					// just null check.
-					if (!e.Light || !isUsableLight(e.Light))
+					if (!e.Light || !SafeUsable(isUsableLight, e.Light))
 						continue;
 					endIdx += e.Light->shadowMapCount;
 					ShadowField(e.Light, maskIndex) = static_cast<uint32_t>(i);
@@ -3061,6 +3236,23 @@ namespace ShadowCasterManager
 
 	static void RenderScheduledShadowLights()
 	{
+		// A cell-transition teardown (ShadowSceneNode::ClearLightArrays, hooked to set
+		// s_pendingSessionReset at its entry before it frees) deallocates the engine
+		// shadow accumulator's renderPass storage. The schedule pass drains the flag,
+		// but a teardown landing after schedule and before this render pass leaves us
+		// flushing a freed accumulator -> AV in BSBatchRenderer::RenderBatches
+		// (renderPass._data == NULL). Skip the whole pass while a reset is pending;
+		// ScheduleShadowCasters owns the drain (+ ResetSession) next frame -- only load
+		// here, never exchange, or s_lights would never get reset. Do this before the
+		// drawStereo save so a skip leaves engine state untouched.
+		if (s_pendingSessionReset.load(std::memory_order_acquire))
+			return;
+
+		// Pause while the interior portal graph is mid-rebuild (cell transition);
+		// BSShadowLight::Render walks portal culling that derefs ssn->portalGraph.
+		if (IsPortalGraphTransitioning())
+			return;
+
 		// VR: RenderActiveShadowCasterLights normally saves+clears g_drawStereo before
 		// iterating shadow casters, then restores it. Without this, each hemisphere
 		// render is doubled for both eyes -> 4-quadrant shadow map texture.
@@ -3083,7 +3275,8 @@ namespace ShadowCasterManager
 		// we replaced that walk with this loop, so we need to call sun.Render
 		// explicitly. Without this, the directional cascade pass is skipped
 		// and exterior scenes render with no sun shadow.
-		if (s_lights.Sun && s_lights.Lights[0].Light) {
+		if (s_lights.Sun && s_lights.Lights[0].Light &&
+			!s_pendingSessionReset.load(std::memory_order_acquire)) {
 			ZoneNamedN(zSun, "SCM::Render::Sun", true);
 			CS_GPU_PASS("SCM::Render::Sun");
 			s_budget.BeginLight(s_lights.Lights[0].Light, 1);
@@ -3098,6 +3291,11 @@ namespace ShadowCasterManager
 			ZoneNamedN(zPoint, "SCM::Render::PointLights", true);
 			CS_GPU_PASS("SCM::Render::PointLights");
 			for (int i = s_lights.PointLightFirst(); i < s_lights.PointLightEnd(s_settings.ShadowLightCount); i++) {
+				// A teardown can begin mid-pass; ClearLightArrays sets the flag at its
+				// entry before freeing, so bailing here stops flushing into an accumulator
+				// being torn down (narrows the window to a single in-flight Render call).
+				if (s_pendingSessionReset.load(std::memory_order_acquire))
+					break;
 				auto& e = s_lights.Lights[i];
 				if (!e.Light || !e.RedrawFrame)
 					continue;
@@ -3341,6 +3539,19 @@ namespace ShadowCasterManager
 			s_shadowConvert.erase(light);
 	}
 
+	// Fires at start of ShadowSceneNode::ClearLightArrays (RelocationID 99704/106338),
+	// the engine's bulk shadow-light teardown on cell unload / scene reset. It frees
+	// activeShadowLights via the inner queued removal -- bypassing the per-light
+	// RemoveLight hook above -- so this is the only signal for a wholesale free.
+	// Flag a session reset; the scheduler drains it on the render thread next pass
+	// so our stale pointers never outlive the lights the engine just freed.
+	static void Hook_ClearLightArrays(CONTEXT& ctx)
+	{
+		auto* ssn = reinterpret_cast<RE::ShadowSceneNode*>(ctx.Rcx);
+		if (ssn == GetShadowSceneNode())
+			s_pendingSessionReset.store(true, std::memory_order_release);
+	}
+
 	// Fires at start of ShadowSceneNode::AddLight (ID 99692/106326).
 	// Optionally promotes normal light to shadow light; always forces portal-strict.
 	static void Hook_ConvertLights_Add(CONTEXT& ctx)
@@ -3351,6 +3562,7 @@ namespace ShadowCasterManager
 		if (ssn != GetShadowSceneNode() || !light || !p)
 			return;
 
+		bool justPromoted = false;
 		if (s_settings.PromoteNormalToShadow && !p->shadowLight) {
 			p->shadowLight = true;
 			p->fov = 6.2831855f;
@@ -3360,6 +3572,7 @@ namespace ShadowCasterManager
 			p->depthBias = 1.0f;
 			p->nearDistance = (light->GetLightRuntimeData().radius.x / 512.0f) * 219.6356f;
 			s_shadowConvert.insert(light);
+			justPromoted = true;
 		}
 		// Portal-strict policy by shadow type. The engine picks the concrete
 		// shadow class (BSShadowParabolicLight / BSShadowHemisphereLight /
@@ -3369,20 +3582,33 @@ namespace ShadowCasterManager
 		//   fov <  ~pi   -> perspective spot/frustum
 		// Tightening portal-strict on omnis/hemis usefully exercises the
 		// portal-graph visibility test; doing it on spots drops culled-but-
-		// visible spots entirely (the cone test rejects spots whose origin
-		// sits behind a portal even when the cone sweeps into a visible
-		// room). Honour the per-type toggle so users can A/B easily.
-		constexpr float kFovHemiThreshold = 3.0f;  // ~pi
-		constexpr float kFovOmniThreshold = 6.0f;  // ~2pi
-		bool enforce = false;
-		if (p->fov >= kFovOmniThreshold)
-			enforce = s_settings.ForceEnablePortalStrictOmni;
-		else if (p->fov >= kFovHemiThreshold)
-			enforce = s_settings.ForceEnablePortalStrictHemi;
-		else
-			enforce = s_settings.ForceEnablePortalStrictSpot;
-		if (enforce)
-			p->portalStrict = true;
+		// visible spots entirely.
+		//
+		// NEVER force portal-strict on a light WE just promoted. A promoted
+		// (originally-normal) light has no stable portal-graph entry; portalStrict
+		// sends it down the engine's STRICT portal-accumulation branch, which derefs
+		// ShadowSceneNode::portalGraph (+0x228) and cull->portalGraphEntry WITHOUT the
+		// NULL guards the non-strict branch has. During a cell transition the graph is
+		// transiently NULL -> flat: null deref in BSParabolicCullingProcess (RE 76136
+		// <- 106401, SkyrimSE+0xE15240); VR: the light is mis-culled, never enters
+		// shadowLightsAccum, so RenderCascade never assigns it a depth-stencil slot and
+		// its vrRenderTarget stays uninitialized garbage -> nvwgf2umx OOB pool walk.
+		// Non-strict survives cleanly.
+		if (!justPromoted) {
+			constexpr float kFovHemiThreshold = 3.0f;  // ~pi
+			constexpr float kFovOmniThreshold = 6.0f;  // ~2pi
+			bool enforce = false;
+			if (p->fov >= kFovOmniThreshold)
+				enforce = s_settings.ForceEnablePortalStrictOmni;
+			else if (p->fov >= kFovHemiThreshold)
+				enforce = s_settings.ForceEnablePortalStrictHemi;
+			else
+				enforce = s_settings.ForceEnablePortalStrictSpot;
+			// Portals only exist in interiors; portalStrict outdoors has no graph to
+			// test against -- a no-op at best, a mis-cull of visible casters at worst.
+			if (enforce && Util::IsInterior())
+				p->portalStrict = true;
+		}
 	}
 
 	// Fires at start of BSLight::SetLight (ID 101302/108289).
@@ -3819,55 +4045,27 @@ namespace ShadowCasterManager
 			REL::safe_write(uid3.address(), &zero, 1);
 		}
 
-		// ---- Screen-space shadow-mask pass: clamp to vanilla 4 slices ---------
-		// Suppress the engine's screen-space shadow-mask inner loop. With
-		// extended slot counts SLF can produce maskIndex >= 4, which makes
-		// the loop OOB-read the 4-entry per-slot blend-mode table
-		// (DAT_141861380); the mask's R channel (sun cascades) is the only
-		// channel LIGHT_LIMIT_FIX consumes anyway -- extended shadow casters
-		// are served by LLF's cluster pipeline reading kSHADOWMAPS directly.
-		// See Hook_RenderShadowLightsWithUtilityShader above for the full
-		// rationale, including the previous Hook_DisableColorMask's misread
-		// (it patched out the inner call, not a color-mask call -- verified
-		// via Ghidra).
-		if (globals::game::isVR) {
-			// VR's Main::RenderShadowmasks (100422) inlines the inner loop
-			// instead of calling the standalone 100423, so the detour below
-			// would never fire. NOP the near-CALL at +0x9E directly. Only
-			// needed when extended slot counts can produce maskIndex >= 4;
-			// vanilla 4-slice VR doesn't trip the OOB.
-			if (settings.ShadowLightCount > 4) {
-				// Site verification: the call at +0x9E must be `E8 rel32`
-				// targeting the inlined helper at +0xC0 (rel32 = 0xC0 -
-				// next-instruction-addr = 0xC0 - 0xA3 = 0x1D). If either the
-				// opcode or the target drifts, fail closed -- clamp the
-				// scheduler back to vanilla 4 slots so a drifted binary
-				// degrades to "no extended shadows" rather than the original
-				// CTD path this patch protects.
-				static REL::RelocationID renderShadowmasks(100422, 107140);
-				constexpr std::uint8_t kCallOffset = 0x9E;
-				constexpr std::uint8_t kCallOpcode = 0xE8;  // near CALL rel32
-				constexpr std::int32_t kExpectedRel32 = 0x1D;
-				const auto site = renderShadowmasks.address() + kCallOffset;
-				const auto opcode = *reinterpret_cast<const std::uint8_t*>(site);
-				const auto rel32 = *reinterpret_cast<const std::int32_t*>(site + 1);
-				if (opcode != kCallOpcode || rel32 != kExpectedRel32) {
-					logger::warn(
-						"[SCM] VR shadow-mask site drift: expected E8 rel32=0x{:X} at RenderShadowmasks+0x{:X}, "
-						"found 0x{:02X} rel32=0x{:X}. Clamping ShadowLightCount to 4 (vanilla) to avoid OOB CTD.",
-						kExpectedRel32, kCallOffset, opcode, rel32);
-					s_installedShadowLightCount = 4;
-				} else {
-					REL::safe_fill(site, REL::NOP, 5);
-					logger::info("[SCM] VR: NOPed inner shadow-mask call at RenderShadowmasks+0x{:X}", kCallOffset);
-				}
-			}
-		} else {
-			// Flat (SE/AE): RenderShadowmasks calls the standalone 100423,
-			// so detour that function to a no-op.
-			stl::detour_thunk<Hook_RenderShadowLightsWithUtilityShader>(
-				REL::RelocationID(100423, 107141));
-		}
+		// ---- Screen-space shadow-mask pass: skip vanilla on all runtimes -----
+		// Detour the standalone RenderShadowLightsWithUtilityShader
+		// (100423/107141) to a no-op. Its inner loop indexes a 4-entry
+		// per-slot blend-mode table by BSShadowLight::maskIndex; SLF's extended
+		// slots -- and teardown's 0xFF "removed" sentinel -- push maskIndex >= 4
+		// -> OOB read -> corrupt shadow-render state (a VR driver CTD on cell
+		// transitions; tolerated as a garbage blend value on flat). LIGHT_LIMIT_
+		// FIX consumes only the mask's R channel and serves extended casters
+		// from its own cluster pipeline reading kSHADOWMAPS directly, so
+		// dropping the pass loses nothing. See
+		// Hook_RenderShadowLightsWithUtilityShader above for the full rationale.
+		//
+		// RenderShadowmasks calls this standalone function on every runtime
+		// including VR (verified via Ghidra: VR @ 0x141323740, called from
+		// RenderShadowmasks+0x9E -- the loop is NOT inlined). This used to be a
+		// VR-specific call-site NOP only because the VR address library mismapped
+		// id 100423 to an unrelated helper (0x1409c0c80), so the detour resolved
+		// to the wrong function. With the addrlib entry corrected to 0x141323740
+		// the one detour works on all three -- do not reintroduce the VR split.
+		stl::detour_thunk<Hook_RenderShadowLightsWithUtilityShader>(
+			REL::RelocationID(100423, 107141));
 
 		// ---- Shadow caster selection -----------------------------------------
 
@@ -3947,6 +4145,10 @@ namespace ShadowCasterManager
 			vtbl4.write_vfunc(3, Hook_IsShadowLight);
 		}
 
+		// Parabolic Render (vtable 0x0A): repair the engine's omission of copying
+		// cascade 0's shadowmapIndex to cascade 1, so teardown frees the right slot.
+		stl::write_vfunc<0x0A, Hook_ParabolicRender>(RE::VTABLE_BSShadowParabolicLight[0]);
+
 		{
 			// ShadowSceneNode::RemoveLight -- fires at +0x9 (SE: 6 bytes, AE: 5 bytes).
 			// Drains s_normalConvert / s_shadowConvert entries for the removed light.
@@ -3955,6 +4157,19 @@ namespace ShadowCasterManager
 			int sz = REL::Relocate(6, 5, 6);
 			if (!SKSE::stl::install_context_hook(uid.address() + REL::Relocate(0x9, 0x9, 0x9), sz, Hook_ConvertLights_Remove, sz))
 				logger::error("[SCM] Failed to install Hook_ConvertLights_Remove");
+		}
+
+		{
+			// ShadowSceneNode::ClearLightArrays -- the bulk shadow-light teardown
+			// on cell unload, which frees activeShadowLights via the inner queued
+			// removal (bypassing the per-light RemoveLight hook). Hook the function
+			// start to flag a session reset. Prologue is version-specific: SE/VR
+			// steal 4 PUSHes (5 bytes); AE's 5th byte splits a SUB RSP, so steal
+			// through it (8 bytes).
+			static REL::RelocationID uid(99704, 106338);
+			int sz = REL::Relocate(5, 8, 5);
+			if (!SKSE::stl::install_context_hook(uid.address(), sz, Hook_ClearLightArrays, sz))
+				logger::error("[SCM] Failed to install Hook_ClearLightArrays");
 		}
 
 		{

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -21,6 +21,7 @@
 
 #include <Windows.h>  // SEH (__try) for the shadow-light usability backstop
 #include <mutex>
+#include <shared_mutex>
 
 #define I18N_KEY_PREFIX "feature.light_limit_fix."
 
@@ -296,6 +297,13 @@ namespace ShadowCasterManager
 	// pass dereferences a slot -- the natural-engine-cycle clear that the
 	// LoadingMenu-driven ResetSession is too coarse to time precisely.
 	static std::atomic<bool> s_pendingSessionReset{ false };
+
+	// Serializes the scheduler's portalGraph-dependent engine mutations (render
+	// thread) against the cell teardown that nulls ssn->portalGraph (main thread,
+	// ClearSceneAndFog). The scheduler takes it shared; ClearSceneAndFog takes it
+	// exclusive, so the graph can't be nulled while the scheduler holds it -- closes
+	// the cross-thread null-deref the pass-start gate can't catch.
+	static std::shared_mutex s_portalGraphMutex;
 
 	// User suppression set (lightKey = BSShadowLight pointer cast to uintptr_t).
 	// Persisted across light lifetimes so suppressing a torch survives the player
@@ -2876,17 +2884,18 @@ namespace ShadowCasterManager
 		// zone captures both our scheduler work and any engine-side rendering
 		// it pulls in for chosen lights.
 		{
+			// Hold the graph lock shared for the whole mutation loop: ClearSceneAndFog
+			// (main thread) takes it exclusive to null ssn->portalGraph, so while we hold
+			// it the graph stays valid and the engine mutations below (ConvertLight /
+			// DisableLight / EnableLight -> AccumulateLight) can't deref a null graph.
+			// try_to_lock: if a teardown holds it, skip this pass instead of blocking.
+			std::shared_lock<std::shared_mutex> graphLock(s_portalGraphMutex, std::try_to_lock);
+			if (!graphLock.owns_lock())
+				return;
+			if (IsPortalGraphTransitioning())  // re-check once; stable now under the lock
+				return;
 			ZoneNamedN(zoneAtomic, "SCM::AtomicMutationLoop", true);
 			for (auto& c : candidates) {
-				// The main thread nulls ssn->portalGraph mid-pass during a cell
-				// transition; every engine mutation below (ConvertLight / DisableLight /
-				// EnableLight) fans into AccumulateLight, which derefs portalGraph
-				// unguarded. The pass-start gate can't catch a cross-thread null that
-				// lands mid-pass, so re-check here and stop touching the engine for the
-				// rest of the pass -- candidates keep their state and are reconsidered
-				// next pass.
-				if (IsPortalGraphTransitioning())
-					break;
 				if (c.invalid) {
 					// isUsableLight (membership + vtable) is the same gate the
 					// excess branch uses. Both ConvertLight and DisableLight
@@ -3561,6 +3570,56 @@ namespace ShadowCasterManager
 			s_pendingSessionReset.store(true, std::memory_order_release);
 	}
 
+	// Detours ShadowSceneNode::ClearSceneAndFog (RelocationID 99687/106321), the
+	// teardown that sets ssn->portalGraph = nullptr on cell unload. Hold the graph
+	// lock exclusive across the original so the render-thread scheduler (which holds
+	// it shared) cannot read portalGraph while it is being nulled.
+	struct Hook_ClearSceneAndFog
+	{
+		static void thunk(RE::ShadowSceneNode* a_ssn)
+		{
+			std::unique_lock lock(s_portalGraphMutex);
+			func(a_ssn);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	// Detours ShadowSceneNode::ResetScene (RelocationID 99741/106385) -- the SSN portalGraph
+	// setter (this->portalGraph = a_graph), called from ResetCellGrid on interior cell
+	// transitions to detach the old cell's graph (a_graph null). This is the actual coc-time
+	// nuller (ClearSceneAndFog only fires on SSN teardown). Hold the graph lock exclusive
+	// across it so it cannot null/swap portalGraph while AccumulateLight reads it.
+	struct Hook_ResetScene
+	{
+		static void thunk(RE::ShadowSceneNode* a_ssn, RE::BSPortalGraph* a_graph)
+		{
+			std::unique_lock lock(s_portalGraphMutex);
+			func(a_ssn, a_graph);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	// Detours ShadowSceneNode::AccumulateLight (RelocationID 99753/106401), the engine's
+	// per-light portal/room shadow accumulation. It derefs ssn->portalGraph at several
+	// sites AFTER an entry null guard already passed, so the teardown nulling portalGraph
+	// on another thread mid-call is a TOCTOU. Take the graph lock SHARED but with
+	// try_to_lock: while ResetScene holds it exclusive (actively swapping portalGraph),
+	// skip this light's accumulation for the frame -- safe, and crucially non-blocking, so
+	// the render thread never parks on the lock (a blocking acquire deadlocks against
+	// ResetScene's own wait for render-thread progress). When acquired, holding it shared
+	// keeps ResetScene from nulling portalGraph mid-call.
+	struct Hook_AccumulateLight
+	{
+		static void thunk(RE::ShadowSceneNode* a_ssn, RE::BSLight* a_light, void* a3, std::uint8_t a4)
+		{
+			std::shared_lock lock(s_portalGraphMutex, std::try_to_lock);
+			if (!lock.owns_lock())
+				return;  // ResetScene is swapping portalGraph; skip rather than read a null graph
+			func(a_ssn, a_light, a3, a4);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
 	// Fires at start of ShadowSceneNode::AddLight (ID 99692/106326).
 	// Optionally promotes normal light to shadow light; always forces portal-strict.
 	static void Hook_ConvertLights_Add(CONTEXT& ctx)
@@ -3628,6 +3687,14 @@ namespace ShadowCasterManager
 		auto* nilight = reinterpret_cast<RE::NiLight*>(ctx.Rdx);
 		if (!bslight)
 			return;
+		// A promoted shadow light is allocated non-zeroed and no ctor in the chain inits
+		// BSLight::cullingProcess (+0x128). AccumulateLight reuses a non-null cullingProcess
+		// as-is, so stale heap garbage there becomes a fake BSParabolicCullingProcess that
+		// room-light culling calls a vfunc on -> garbage-vtable CTD. Null it at creation
+		// (SetLight runs during AddLight, before any accumulate) so the engine builds a real
+		// one, exactly as a fresh zeroed page would.
+		if (nilight && s_shadowConvert.count(nilight))
+			bslight->cullingProcess = nullptr;
 		auto* oldlight = bslight->light.get();
 		if (oldlight && oldlight != nilight) {
 			bool did = s_shadowConvert.erase(oldlight) != 0;
@@ -4179,6 +4246,30 @@ namespace ShadowCasterManager
 			int sz = REL::Relocate(5, 8, 5);
 			if (!SKSE::stl::install_context_hook(uid.address(), sz, Hook_ClearLightArrays, sz))
 				logger::error("[SCM] Failed to install Hook_ClearLightArrays");
+		}
+
+		{
+			// ShadowSceneNode::ClearSceneAndFog -- nulls ssn->portalGraph on cell
+			// teardown. Detour to hold s_portalGraphMutex exclusive across it so the
+			// render-thread scheduler can't read a null graph mid-pass (crash#1 race).
+			if (long rc = stl::detour_thunk<Hook_ClearSceneAndFog>(REL::RelocationID(99687, 106321)))
+				logger::error("[SCM] Hook_ClearSceneAndFog detour FAILED (DetourTransactionCommit={})", rc);
+		}
+
+		{
+			// ShadowSceneNode::ResetScene -- the portalGraph setter; the coc-time nuller
+			// (via ResetCellGrid). Exclusive lock so it can't swap portalGraph while the
+			// render-thread AccumulateLight holds it shared (crash#1 TOCTOU).
+			if (long rc = stl::detour_thunk<Hook_ResetScene>(REL::RelocationID(99741, 106385)))
+				logger::error("[SCM] Hook_ResetScene detour FAILED (DetourTransactionCommit={})", rc);
+		}
+
+		{
+			// ShadowSceneNode::AccumulateLight -- hold s_portalGraphMutex shared across
+			// the engine's per-light accumulate so ClearSceneAndFog can't null portalGraph
+			// mid-call (crash#1 mid-function TOCTOU). Read side of the ClearSceneAndFog lock.
+			if (long rc = stl::detour_thunk<Hook_AccumulateLight>(REL::RelocationID(99753, 106401)))
+				logger::error("[SCM] Hook_AccumulateLight detour FAILED (DetourTransactionCommit={})", rc);
 		}
 
 		{

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -290,6 +290,10 @@ namespace ShadowCasterManager
 	};
 	static std::vector<ConvertedLight> s_normalConvert;
 	static std::set<RE::NiLight*> s_shadowConvert;
+	// Promoted lights whose descriptor pool-slots have been initialized once. EnableLight
+	// only inits lights that win a render slot; this tracks the scheduler-time init that
+	// covers promoted lights added but never enabled, so teardown can't read garbage.
+	static std::set<RE::NiLight*> s_shadowConvertDescriptorInited;
 
 	// Set by Hook_ClearLightArrays (the engine's bulk shadow-light teardown) and
 	// drained at the top of ScheduleShadowCasters on the render thread, so a
@@ -2169,6 +2173,17 @@ namespace ShadowCasterManager
 				auto* l = sp.get();
 				if (!l || l == sunLight)
 					continue;
+				// Promoted lights are allocated non-zeroed; their descriptor pool-slots stay
+				// garbage until init. EnableLight only inits lights that win a render slot, so
+				// init here (once) -- this is the type-safe BSShadowLight source -- to cover a
+				// promoted light added but never enabled before teardown reads it.
+				if (s_settings.ShadowLightCount > 4) {
+					if (auto* ni = l->light.get(); ni && s_shadowConvert.contains(ni) &&
+												   !s_shadowConvertDescriptorInited.contains(ni)) {
+						InitPromotedDescriptorSlots(l);
+						s_shadowConvertDescriptorInited.insert(ni);
+					}
+				}
 				auto& c = candidates.emplace_back();
 				c.light = l;
 				c.sun = false;
@@ -3553,8 +3568,10 @@ namespace ShadowCasterManager
 				break;
 			}
 		}
-		if (light)
+		if (light) {
 			s_shadowConvert.erase(light);
+			s_shadowConvertDescriptorInited.erase(light);
+		}
 	}
 
 	// Fires at start of ShadowSceneNode::ClearLightArrays (RelocationID 99704/106338),
@@ -3685,6 +3702,7 @@ namespace ShadowCasterManager
 		auto* oldlight = bslight->light.get();
 		if (oldlight && oldlight != nilight) {
 			bool did = s_shadowConvert.erase(oldlight) != 0;
+			s_shadowConvertDescriptorInited.erase(oldlight);  // reassigned nilight re-inits via scheduler
 			if (nilight && did)
 				s_shadowConvert.insert(nilight);
 		}
@@ -4363,6 +4381,7 @@ namespace ShadowCasterManager
 		// was a silent no-op on every runtime and accomplished nothing.
 		s_normalConvert.clear();
 		s_shadowConvert.clear();
+		s_shadowConvertDescriptorInited.clear();
 		s_pinShadow.clear();
 		s_pinConvert.clear();
 		s_soloLight = 0;

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -299,9 +299,9 @@ namespace ShadowCasterManager
 	static std::atomic<bool> s_pendingSessionReset{ false };
 
 	// Serializes the scheduler's portalGraph-dependent engine mutations (render
-	// thread) against the cell teardown that nulls ssn->portalGraph (main thread,
-	// ClearSceneAndFog). The scheduler takes it shared; ClearSceneAndFog takes it
-	// exclusive, so the graph can't be nulled while the scheduler holds it -- closes
+	// thread) against the cell teardown that nulls/swaps ssn->portalGraph (main
+	// thread, ResetScene). The scheduler/AccumulateLight take it shared; ResetScene
+	// takes it exclusive, so the graph can't change while a reader holds it -- closes
 	// the cross-thread null-deref the pass-start gate can't catch.
 	static std::shared_mutex s_portalGraphMutex;
 
@@ -3570,25 +3570,12 @@ namespace ShadowCasterManager
 			s_pendingSessionReset.store(true, std::memory_order_release);
 	}
 
-	// Detours ShadowSceneNode::ClearSceneAndFog (RelocationID 99687/106321), the
-	// teardown that sets ssn->portalGraph = nullptr on cell unload. Hold the graph
-	// lock exclusive across the original so the render-thread scheduler (which holds
-	// it shared) cannot read portalGraph while it is being nulled.
-	struct Hook_ClearSceneAndFog
-	{
-		static void thunk(RE::ShadowSceneNode* a_ssn)
-		{
-			std::unique_lock lock(s_portalGraphMutex);
-			func(a_ssn);
-		}
-		static inline REL::Relocation<decltype(thunk)> func;
-	};
-
 	// Detours ShadowSceneNode::ResetScene (RelocationID 99741/106385) -- the SSN portalGraph
 	// setter (this->portalGraph = a_graph), called from ResetCellGrid on interior cell
-	// transitions to detach the old cell's graph (a_graph null). This is the actual coc-time
-	// nuller (ClearSceneAndFog only fires on SSN teardown). Hold the graph lock exclusive
-	// across it so it cannot null/swap portalGraph while AccumulateLight reads it.
+	// transitions to detach the old cell's graph (a_graph null). This is the coc-time nuller
+	// behind the crash (ClearSceneAndFog only fires on SSN teardown, never on a transition).
+	// Hold the graph lock exclusive across it so it cannot null/swap portalGraph while
+	// AccumulateLight reads it.
 	struct Hook_ResetScene
 	{
 		static void thunk(RE::ShadowSceneNode* a_ssn, RE::BSPortalGraph* a_graph)
@@ -4249,14 +4236,6 @@ namespace ShadowCasterManager
 		}
 
 		{
-			// ShadowSceneNode::ClearSceneAndFog -- nulls ssn->portalGraph on cell
-			// teardown. Detour to hold s_portalGraphMutex exclusive across it so the
-			// render-thread scheduler can't read a null graph mid-pass (crash#1 race).
-			if (long rc = stl::detour_thunk<Hook_ClearSceneAndFog>(REL::RelocationID(99687, 106321)))
-				logger::error("[SCM] Hook_ClearSceneAndFog detour FAILED (DetourTransactionCommit={})", rc);
-		}
-
-		{
 			// ShadowSceneNode::ResetScene -- the portalGraph setter; the coc-time nuller
 			// (via ResetCellGrid). Exclusive lock so it can't swap portalGraph while the
 			// render-thread AccumulateLight holds it shared (crash#1 TOCTOU).
@@ -4266,8 +4245,8 @@ namespace ShadowCasterManager
 
 		{
 			// ShadowSceneNode::AccumulateLight -- hold s_portalGraphMutex shared across
-			// the engine's per-light accumulate so ClearSceneAndFog can't null portalGraph
-			// mid-call (crash#1 mid-function TOCTOU). Read side of the ClearSceneAndFog lock.
+			// the engine's per-light accumulate so ResetScene can't swap portalGraph
+			// mid-call (crash#1 mid-function TOCTOU). Read side of the ResetScene lock.
 			if (long rc = stl::detour_thunk<Hook_AccumulateLight>(REL::RelocationID(99753, 106401)))
 				logger::error("[SCM] Hook_AccumulateLight detour FAILED (DetourTransactionCommit={})", rc);
 		}

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -2878,6 +2878,15 @@ namespace ShadowCasterManager
 		{
 			ZoneNamedN(zoneAtomic, "SCM::AtomicMutationLoop", true);
 			for (auto& c : candidates) {
+				// The main thread nulls ssn->portalGraph mid-pass during a cell
+				// transition; every engine mutation below (ConvertLight / DisableLight /
+				// EnableLight) fans into AccumulateLight, which derefs portalGraph
+				// unguarded. The pass-start gate can't catch a cross-thread null that
+				// lands mid-pass, so re-check here and stop touching the engine for the
+				// rest of the pass -- candidates keep their state and are reconsidered
+				// next pass.
+				if (IsPortalGraphTransitioning())
+					break;
 				if (c.invalid) {
 					// isUsableLight (membership + vtable) is the same gate the
 					// excess branch uses. Both ConvertLight and DisableLight

--- a/src/Features/LightLimitFix/ShadowCasterManager.h
+++ b/src/Features/LightLimitFix/ShadowCasterManager.h
@@ -59,6 +59,13 @@ namespace ShadowCasterManager
 	/// this rather than reaching into Deferred / the renderer directly.
 	std::uint32_t GetInstalledSlotCount();
 
+	/// True while an engine shadow-scene teardown (ClearLightArrays) is pending
+	/// and not yet drained by ScheduleShadowCasters. During this window the
+	/// engine frees shadow lights and their GPU resources, so per-frame consumers
+	/// must skip iterating the accumulator and binding shadow resources to avoid
+	/// referencing freed objects. Non-draining load; the scheduler owns the drain.
+	bool IsSessionResetPending();
+
 	/// Live VRAM telemetry used for shadow-array sizing decisions and stats.
 	/// All values in bytes; populated from IDXGIAdapter3::QueryVideoMemoryInfo
 	/// + the kSHADOWMAPS texture's actual geometry. valid=false when the

--- a/src/Features/LightLimitFix/ShadowRenderer.cpp
+++ b/src/Features/LightLimitFix/ShadowRenderer.cpp
@@ -48,6 +48,22 @@ void LightLimitFix::CopyShadowLightData()
 	ZoneScoped;
 	CS_GPU_PASS("LightLimitFix::CopyShadowLightData");
 
+	// While an engine shadow teardown is pending (ClearLightArrays), the engine
+	// frees shadow lights and their GPU resources. Iterating shadowLightsAccum or
+	// binding shadow SRVs in this window can reference a freed object -- the async
+	// driver deref of a freed shadow resource is the cell-transition CTD. Degrade
+	// to the same unbound/cleared state the slots==0 path uses until the scheduler
+	// drains the reset next frame. (The render gate in RenderScheduledShadowLights
+	// covers the shadow *render*; this covers the per-frame upload/bind.)
+	if (ShadowCasterManager::IsSessionResetPending()) {
+		ShadowCasterManager::BeginSlotFrame(0);
+		shadowLightCount = 0;
+		shadowUnshadowedLightCount = 0;
+		ID3D11ShaderResourceView* nullSRVs[2]{ nullptr, nullptr };
+		globals::d3d::context->PSSetShaderResources(102, ARRAYSIZE(nullSRVs), nullSRVs);
+		return;
+	}
+
 	uint32_t slots = ShadowCasterManager::GetInstalledSlotCount();
 	if (slots == 0) {
 		// Clean degradation when SCM hasn't published a usable slot count yet

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -147,7 +147,7 @@ bool Load()
 	}
 
 	if (REL::Module::IsVR()) {  // Pre-ReInit check; globals::game::isVR not populated yet
-		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.225.0", true);
+		REL::IDDatabase::get().IsVRAddressLibraryAtLeastVersion("0.227.0", true);
 	}
 
 	auto privateProfileRedirectorVersion = Util::GetDllVersion(L"Data/SKSE/Plugins/PrivateProfileRedirector.dll");


### PR DESCRIPTION
Fixes two interior cell-transition CTDs in ShadowCasterManager with `PromoteNormalToShadow` + large `ShadowLightCount`.

**crash#1 (null `portalGraph` TOCTOU):** `ResetScene` swaps `ssn->portalGraph` (main thread) while `AccumulateLight` reads it (render thread), after the engine's own entry null-guard passed. A `shared_mutex` serializes them — `ResetScene` exclusive, `AccumulateLight` try-shared (skips a light if contended, never blocks → no deadlock).

**crash#2 (uninit `cullingProcess`):** a promoted `BSShadowParabolicLight` is allocated non-zeroed; `+0x128` holds heap garbage the engine reuses as a culling process and calls a vfunc on. Nulled at creation in the `SetLight` hook.

Validated SE 1.6.1170 (24 transitions) and VR 1.4.15 (20), promote on, `ShadowLightCount=127`. RE named in the SE/AE/VR Ghidra DBs.

> [!NOTE]
> VR resolves ids `99741`/`99753` via the VR address library (PR alandtse/skyrim_vr_address_library#124) — needs publishing, or the code switched to 3-arg `RelocationID(se, ae, REL::Offset(vr))`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added stricter validation of light data by checking readable, committed memory ranges before using lights during shader setup.
  * Fixed extended-mode shadow descriptor handling by correcting promoted shadow slot behavior across cascades.
  * Hardened shadow scheduling and rendering during portal/scene transitions, including skipping passes when teardown is pending and clamping on validation failures.
  * Prevented per-frame shadow SRV binding while shadow resources may be freed to avoid crashes.
* **Chores**
  * Improved detour transaction error handling to fail more safely during patching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->