### PR TITLE
build: bump Tracy to v81 (1706ac57)

### DIFF
--- a/cmake/ports/tracy/portfile.cmake
+++ b/cmake/ports/tracy/portfile.cmake
@@ -1,11 +1,9 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO wolfpld/tracy
-    REF 14a1a3227e046e7bee3abed406c7faab61de3620
-    SHA512 113b2dd35d75edeb1358514bf857bc694c048fb7b2604a22e8fcc7efa63d342a6c7cbf02162073d2ee8690821e0f80f95be6270416777645d9092d5508e76372
+    REF 1706ac57acc8d067134e2f59aa67421d48bfb31a
+    SHA512 f08f94eb5452f33aca36ce87515628b7292f3f670be5ade0739978db8ae3975b7718f4c153e79e5d049fe27d45b71b2f9dc89485be42672e8379f0e9b346b5c6
     HEAD_REF master
-    PATCHES
-        build-tools.patch
 )
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
@@ -42,6 +40,15 @@ vcpkg_cmake_configure(
         LEGACY
 )
 vcpkg_cmake_install()
+
+# Tracy's install() FILES list omits these common headers at this ref even
+# though the client headers (e.g. TracyProfiler.hpp) include them; copy them
+# so downstream code compiles.
+file(INSTALL
+    "${SOURCE_PATH}/public/common/TracyFormat.hpp"
+    "${SOURCE_PATH}/public/common/TracyVersion.hpp"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include/tracy/common")
+
 vcpkg_copy_pdbs()
 vcpkg_cmake_config_fixup(PACKAGE_NAME Tracy CONFIG_PATH lib/cmake/Tracy)
 

--- a/cmake/ports/tracy/vcpkg.json
+++ b/cmake/ports/tracy/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "tracy",
-    "version-string": "0.13.3-14a1a322",
+    "version-string": "0.13.3-1706ac57",
     "description": "A real time, nanosecond resolution, remote telemetry, hybrid frame and sampling profiler for games and other applications.",
     "homepage": "https://github.com/wolfpld/tracy",
     "license": "BSD-3-Clause",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -63,7 +63,7 @@
         },
         {
             "name": "tracy",
-            "version-string": "0.13.3-14a1a322"
+            "version-string": "0.13.3-1706ac57"
         },
         {
             "name": "directx-headers",


### PR DESCRIPTION
Bumps the vendored Tracy overlay port from `0.13.3-14a1a322` (wire protocol **v78**) to wolfpld/tracy master `1706ac57` (**v81**) so `TRACY_SUPPORT` builds can be captured by current Tracy profiler/MCP builds again — v78 fails live capture with "incompatible protocol version."

- **REF + SHA512 + version-string** → `1706ac57` (portfile + both vcpkg.json files).
- **Header-install fix:** this ref ships `public/common/TracyFormat.hpp` + `TracyVersion.hpp` and includes them from the client headers, but omits them from its own `install()` list — so the port now copies them explicitly. Without this the game fails to compile (`Cannot open include file '../common/TracyFormat.hpp'`).
- **Dropped `build-tools.patch` from PATCHES:** it no longer applies to the new CMakeLists.txt and only enabled the standalone cli/gui tools, which the fork doesn't build (capture is via the Tracy MCP). The patch file is retained for future regeneration; the `cli-tools`/`gui-tools` features are dormant (not requested by the project).

**Verified:** `ALL` preset + `-DTRACY_SUPPORT=ON` builds clean; the game announces protocol v81 and live MCP capture succeeded on **SE + VR** (Guardian Stones → Whiterun).

No release impact (`build:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Tracy profiling library dependency to a newer version with improved header packaging and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->