### PR TITLE
ci: harden feature-audit current-state ref reads

### DIFF
--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -234,22 +234,32 @@ def get_feature_ini_metadata(feature_dir_or_ini_path):
 
     return {k: v for k, v in metadata.items() if v is not None and v != ""}
 
+def read_current_ini_content(ini_path):
+    """Read the current (HEAD) feature .ini text. In ref mode read it from HEAD_REF;
+    if that read fails, fall back to the checked-out workspace file rather than the
+    caller's miss-default. A failed ref read must not be mistaken for "no version /
+    release stage" — that misread proposes a spurious version bump on a pre-release or
+    space-named feature whose ref blob the runner failed to fetch. Returns None only
+    when neither source is readable."""
+    if HEAD_REF != "HEAD":
+        rel_path = os.path.relpath(ini_path, PROJECT_ROOT).replace("\\", "/")
+        try:
+            return subprocess.check_output(
+                ["git", "show", f"{HEAD_REF}:{rel_path}"], stderr=subprocess.DEVNULL
+            ).decode("utf-8")
+        except Exception:
+            pass  # fall back to the checked-out workspace file
+    try:
+        with open(ini_path, "r", encoding="utf-8") as f:
+            return f.read()
+    except Exception:
+        return None
+
 def get_version_from_ini(ini_path, content=None):
     if content is None:
-        if HEAD_REF != "HEAD":
-            rel_path = os.path.relpath(ini_path, PROJECT_ROOT).replace("\\", "/")
-            try:
-                content = subprocess.check_output(
-                    ["git", "show", f"{HEAD_REF}:{rel_path}"], stderr=subprocess.DEVNULL
-                ).decode("utf-8")
-            except Exception:
-                return None
-        else:
-            try:
-                with open(ini_path, "r", encoding="utf-8") as f:
-                    content = f.read()
-            except Exception:
-                return None
+        content = read_current_ini_content(ini_path)
+        if content is None:
+            return None
     m = RE_VERSION.search(content)
     if m:
         return tuple(map(int, m.groups()))
@@ -278,20 +288,9 @@ def stage_from_content(content):
 
 def get_stage_from_ini(ini_path, content=None):
     if content is None:
-        if HEAD_REF != "HEAD":
-            rel_path = os.path.relpath(ini_path, PROJECT_ROOT).replace("\\", "/")
-            try:
-                content = subprocess.check_output(
-                    ["git", "show", f"{HEAD_REF}:{rel_path}"], stderr=subprocess.DEVNULL
-                ).decode("utf-8")
-            except Exception:
-                return STAGE_RELEASE
-        else:
-            try:
-                with open(ini_path, "r", encoding="utf-8") as f:
-                    content = f.read()
-            except Exception:
-                return STAGE_RELEASE
+        content = read_current_ini_content(ini_path)
+        if content is None:
+            return STAGE_RELEASE
     return stage_from_content(content)
 
 def get_prior_stage(ini_path, base_ref):


### PR DESCRIPTION
## Stacked on #181 — must merge AFTER it

This hardens `tools/feature_version_audit.py`, the stage-aware audit that **arrives in `dev` via #181**. The branch is based on #181's head, so until #181 merges this PR's diff shows the sync too; once #181 lands I'll rebase it down to the single audit commit.

## What

`get_version_from_ini` / `get_stage_from_ini` read a feature's current version and release stage from `HEAD_REF` via `git show`. On a failed ref read they silently returned `None` / `STAGE_RELEASE` — indistinguishable from "no version / not pre-release."

When that misfires (the runner fails to read the ref blob), the audit sees a Beta feature as release-stage with an unknown version, falls back to the base-branch version, and demands a spurious bump.

**Observed:** #181's CI flagged `Unified Water` (correctly `0-2-0 Beta`) as needing `1-1-0`. The proposal only appears on the pre-stage path — i.e. the runner read the feature as RELEASE with no version. "Unified Water" is the only feature with a **space in its path**, the likely trip point for the ref read. Locally, the exact merge commit + CI args pass; the failure is environment-specific to the ref read.

## Fix

Extract `read_current_ini_content()`: try `HEAD_REF`, then **fall back to the checked-out workspace `.ini`** (the merge tree CI runs against, which holds the true content) before giving up. Both callers share it, so version and stage can no longer disagree on their source.

## Verification

- Full audit run with #181's exact CI args: exit 0 (no regression).
- Simulated the CI miss (bogus `HEAD_REF` so `git show` fails): fallback recovers `stage=beta`, `version=(0,2,0)` — the old path returned `RELEASE`/`None` → spurious `1-1-0`.

Release impact: none (`ci:` — audit tooling only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature maturity stages (Alpha/Beta) with visual tags in UI
  * SkySync volumetric lighting fade and horizon transition control
  * Automated Discord release notifications

* **Improvements**
  * Enhanced SkySync sunset/sunrise dimming behavior
  * Feature version updates across multiple shaders
  * New translations: German, Spanish, French, Japanese, Dutch, Polish
  * Expanded English and Chinese translation strings
  * Editor UI shows feature stability stages

* **Changes**
  * Screenshot default output format changed to PNG
  * Subsurface Scattering default mode updated
  * UnifiedWater marked as beta-stage feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->