### PR TITLE
ci: add feature-audit escape hatches

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -47,3 +47,26 @@ jobs:
             # Isolate this harness's build caches from production keys so a
             # ci_test branch cannot poison dev / main / PR build caches.
             cache-key-suffix: "-ci-test"
+
+    # Run the feature version audit from THIS branch's ref. pr-checks runs it
+    # under pull_request_target from the BASE branch, so a change to the audit
+    # algorithm itself (e.g. release-stage 0.x logic) can never be exercised by
+    # its own PR. Push the change to ci_test/** to verify the verdict here first.
+    feature-audit:
+        if: github.repository == 'alandtse/open-shaders'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.11"
+            - name: Run feature version audit (this branch vs dev)
+              run: |
+                  set -euo pipefail
+                  git fetch origin dev
+                  python tools/feature_version_audit.py --pr-check --ci \
+                    --base "$(git rev-parse origin/dev)" --head "${{ github.sha }}"

--- a/.github/workflows/release-semantic.yaml
+++ b/.github/workflows/release-semantic.yaml
@@ -16,6 +16,11 @@ on:
                 description: "Promotion mode: dev SHA to fast-forward main to before releasing. Leave empty for a normal release on the dispatched branch."
                 required: false
                 default: ""
+            skip_feature_bumps:
+                description: "Skip the automatic feature .ini version bumps (feature_version_audit.py --apply-bumps). Tick to bypass the bump algorithm and hand-manage feature versions for this release."
+                type: boolean
+                required: false
+                default: false
 
 permissions:
     contents: write
@@ -120,7 +125,11 @@ jobs:
                   # semantic-release runs against the promoted history.
                   git checkout -B main "${FF_TARGET}"
 
+            # Escape hatch: the audit runs from the dispatched branch here (not
+            # under pull_request_target), but a misfiring bump algorithm can still
+            # apply a wrong version. Tick skip_feature_bumps to hand-manage instead.
             - name: Apply feature version bumps
+              if: ${{ !inputs.skip_feature_bumps }}
               run: |
                   python tools/feature_version_audit.py \
                     --apply-bumps \


### PR DESCRIPTION
## Why

The `feature-audit-pr` job runs under **`pull_request_target`**, so it executes the **base branch's** `tools/feature_version_audit.py` against the PR's content (read via `refs/pr_head`). Two gaps fall out of that trusted-base design:

1. A PR that changes the **audit algorithm itself** (e.g. #181's release-stage 0.x logic) is judged by the *old* base script and can self-block — it can never exercise its own change. The existing `ci_test/**` self-test covers build/shader/cpp but **not** the audit, so it couldn't catch this.
2. The release-time `--apply-bumps` has **no manual override** if the bump algorithm ever proposes a wrong version.

This is exactly what stranded #181 (Unified Water `0-2-0 Beta` flagged for `1-1-0` by dev's stage-unaware script).

## Changes

- **`ci-test.yaml`** — adds a `feature-audit` job that runs the audit from **this branch's** ref (`--base origin/dev --head <branch sha>`). Push an audit-algorithm change to `ci_test/<name>` and the verdict is computed by the branch's own script, before merge.
- **`release-semantic.yaml`** — adds a `skip_feature_bumps` `workflow_dispatch` boolean that gates the `Apply feature version bumps` step, so a release can bypass the algorithm and hand-manage feature versions.

## Notes

- Pure CI infra (`ci:` — no release impact). Independent of #181/#184.
- Does not change the `pull_request_target` audit (intentional security boundary); it adds a **branch-test path** + a **release valve** around it.