### PR TITLE
build(shaders): single-exit to clear /O3 X4000

### DIFF
--- a/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
+++ b/features/Extended Materials/Shaders/ExtendedMaterials/ExtendedMaterials.hlsli
@@ -358,6 +358,10 @@ namespace ExtendedMaterials
 #endif
 		float minHeight = maxHeight * 0.5;
 
+		// Single exit: the parallax branch's return reads as potentially
+		// uninitialized at /O3 (X4000). Accumulate into result instead.
+		float2 result = coords;
+
 #if defined(LANDSCAPE)
 		if (nearBlendToFar < 1.0) {
 #else
@@ -499,26 +503,29 @@ namespace ExtendedMaterials
 				nearBlendToFar *= nearBlendToFar;
 			float offset = (1.0 - parallaxAmount) * -maxHeight + minHeight;
 			pixelOffset = saturate(lerp(parallaxAmount, 0.5, nearBlendToFar));
-			return lerp(viewDirTS.xy * offset + coords.xy, coords, nearBlendToFar);
-		}
-
+			result = lerp(viewDirTS.xy * offset + coords.xy, coords, nearBlendToFar);
+		} else {
 #if defined(LANDSCAPE)
-		weights[0] = input.LandBlendWeights1.x;
-		weights[1] = input.LandBlendWeights1.y;
-		weights[2] = input.LandBlendWeights1.z;
-		weights[3] = input.LandBlendWeights1.w;
-		weights[4] = input.LandBlendWeights2.x;
-		weights[5] = input.LandBlendWeights2.y;
+			weights[0] = input.LandBlendWeights1.x;
+			weights[1] = input.LandBlendWeights1.y;
+			weights[2] = input.LandBlendWeights1.z;
+			weights[3] = input.LandBlendWeights1.w;
+			weights[4] = input.LandBlendWeights2.x;
+			weights[5] = input.LandBlendWeights2.y;
 #endif
 
-		pixelOffset = 0.0;
-		return coords;
+			pixelOffset = 0.0;
+		}
+		return result;
 	}
 
 	// https://advances.realtimerendering.com/s2006/Tatarchuk-POM.pdf
 	// Cheap method of creating shadows using height for a given light source
 	float GetParallaxSoftShadowMultiplier(float2 coords, float mipLevel, float3 L, float sh0, Texture2D<float4> tex, SamplerState texSampler, uint channel, float quality, float noise, DisplacementParams params)
 	{
+		// Single exit: a conditional return leaves the value potentially uninitialized
+		// to fxc at /O3 (X4000). Accumulate into result instead.
+		float result = 1.0;
 		[branch] if (quality > 0.0)
 		{
 			float2 rayDir = L.xy * 0.1 * params.HeightScale;
@@ -531,9 +538,9 @@ namespace ExtendedMaterials
 				sh.z = AdjustDisplacementNormalized(tex.SampleLevel(texSampler, coords + rayDir * multipliers.z, mipLevel)[channel], params);
 			if (quality > 0.75)
 				sh.w = AdjustDisplacementNormalized(tex.SampleLevel(texSampler, coords + rayDir * multipliers.w, mipLevel)[channel], params);
-			return 1.0 - saturate(dot(max(0, sh - sh0), ShadowIntensity)) * quality;
+			result = 1.0 - saturate(dot(max(0, sh - sh0), ShadowIntensity)) * quality;
 		}
-		return 1.0;
+		return result;
 	}
 
 #if defined(LANDSCAPE)
@@ -543,6 +550,9 @@ namespace ExtendedMaterials
 	float GetParallaxSoftShadowMultiplierTerrain(PS_INPUT input, float2 coords, float mipLevel[6], float3 L, float sh0, float quality, float noise, DisplacementParams params[6])
 #	endif
 	{
+		// Single exit (see GetParallaxSoftShadowMultiplier): conditional/early
+		// returns read as potentially uninitialized at /O3 (X4000).
+		float result = 1.0;
 		if (quality > 0.0) {
 			float4 multipliers = rcp((float4(1, 2, 3, 4) + noise));
 			float4 sh;
@@ -552,28 +562,29 @@ namespace ExtendedMaterials
 #	if defined(TRUE_PBR)
 			float scale = max(params[0].HeightScale * input.LandBlendWeights1.x, max(params[1].HeightScale * input.LandBlendWeights1.y, max(params[2].HeightScale * input.LandBlendWeights1.z,
 																																			max(params[3].HeightScale * input.LandBlendWeights1.w, max(params[4].HeightScale * input.LandBlendWeights2.x, params[5].HeightScale * input.LandBlendWeights2.y)))));
-			if (scale < 0.01)
-				return 1.0;
-			rayDir *= scale;
+			[branch] if (scale >= 0.01)
+			{
+				rayDir *= scale;
 
 #		if defined(TERRAIN_VARIATION)
-			sh = GetTerrainHeight(noise, input, coords + rayDir * multipliers.x, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, sharedOffset, dx, dy, heights);
-			if (quality > 0.25)
-				sh.y = GetTerrainHeight(noise, input, coords + rayDir * multipliers.y, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, sharedOffset, dx, dy, heights);
-			if (quality > 0.5)
-				sh.z = GetTerrainHeight(noise, input, coords + rayDir * multipliers.z, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, sharedOffset, dx, dy, heights);
-			if (quality > 0.75)
-				sh.w = GetTerrainHeight(noise, input, coords + rayDir * multipliers.w, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, sharedOffset, dx, dy, heights);
+				sh = GetTerrainHeight(noise, input, coords + rayDir * multipliers.x, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, sharedOffset, dx, dy, heights);
+				if (quality > 0.25)
+					sh.y = GetTerrainHeight(noise, input, coords + rayDir * multipliers.y, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, sharedOffset, dx, dy, heights);
+				if (quality > 0.5)
+					sh.z = GetTerrainHeight(noise, input, coords + rayDir * multipliers.z, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, sharedOffset, dx, dy, heights);
+				if (quality > 0.75)
+					sh.w = GetTerrainHeight(noise, input, coords + rayDir * multipliers.w, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, sharedOffset, dx, dy, heights);
 #		else
-			sh = GetTerrainHeight(noise, input, coords + rayDir * multipliers.x, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, heights);
-			if (quality > 0.25)
-				sh.y = GetTerrainHeight(noise, input, coords + rayDir * multipliers.y, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, heights);
-			if (quality > 0.5)
-				sh.z = GetTerrainHeight(noise, input, coords + rayDir * multipliers.z, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, heights);
-			if (quality > 0.75)
-				sh.w = GetTerrainHeight(noise, input, coords + rayDir * multipliers.w, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, heights);
+				sh = GetTerrainHeight(noise, input, coords + rayDir * multipliers.x, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, heights);
+				if (quality > 0.25)
+					sh.y = GetTerrainHeight(noise, input, coords + rayDir * multipliers.y, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, heights);
+				if (quality > 0.5)
+					sh.z = GetTerrainHeight(noise, input, coords + rayDir * multipliers.z, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, heights);
+				if (quality > 0.75)
+					sh.w = GetTerrainHeight(noise, input, coords + rayDir * multipliers.w, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, heights);
 #		endif
-			return 1.0 - saturate(dot(max(0, sh - sh0) / scale, ShadowIntensity)) * quality;
+				result = 1.0 - saturate(dot(max(0, sh - sh0) / scale, ShadowIntensity)) * quality;
+			}
 #	else
 #		if defined(TERRAIN_VARIATION)
 			sh = GetTerrainHeight(noise, input, coords + rayDir * multipliers.x, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, sharedOffset, dx, dy, heights);
@@ -592,10 +603,10 @@ namespace ExtendedMaterials
 			if (quality > 0.75)
 				sh.w = GetTerrainHeight(noise, input, coords + rayDir * multipliers.w, mipLevel, params, quality, input.LandBlendWeights1, input.LandBlendWeights2.xy, heights);
 #		endif
-			return 1.0 - saturate(dot(max(0, sh - sh0), ShadowIntensity)) * quality;
+			result = 1.0 - saturate(dot(max(0, sh - sh0), ShadowIntensity)) * quality;
 #	endif
 		}
-		return 1.0;
+		return result;
 	}
 
 #endif  // defined(LANDSCAPE) && defined(TERRAIN_VARIATION)

--- a/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
+++ b/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
@@ -25,6 +25,7 @@ namespace WaterEffects
 
 	float3 ComputeCaustics(float4 waterData, float3 worldPosition, uint eyeIndex)
 	{
+		float3 result = 1.0.xxx;
 		float causticsDistToWater = waterData.w - worldPosition.z;
 		float shoreFactorCaustics = saturate(causticsDistToWater / 64.0);
 
@@ -53,9 +54,9 @@ namespace WaterEffects
 				causticsLow = min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0;
 
 			float3 caustics = lerp(causticsLow, causticsHigh, causticsFade);
-			return lerp(1.0.xxx, caustics, shoreFactorCaustics);
+			result = lerp(1.0.xxx, caustics, shoreFactorCaustics);
 		}
 
-		return 1.0.xxx;
+		return result;
 	}
 }


### PR DESCRIPTION
## Why

The release-parity shader-cache validation (default-install profile config, `/O3`, `--max-warnings 0`) flags 4 `X4000` "use of potentially uninitialized variable" warnings that the default `/O1` validation does **not** surface. These block `release-build`'s in-cycle `ShaderCache-SE/VR` artifact jobs (the validation job double-duties as the cache builder). For v1.9.0 the caches were built and attached out-of-cycle; this change makes future releases build them automatically.

## Root cause

fxc names the **return value** (the function name, not a local) as uninitialized: at `/O3`, a conditional or early `return` can leave the inlined return temp unprovable to fxc's flow analysis. The default `/O1` build doesn't lower it the same way, so the warning is release-parity-only.

## Fix

Convert each affected function to a single `result` accumulator with **one exit**:

- `WaterEffects::ComputeCaustics`
- `ExtendedMaterials::GetParallaxCoords`
- `ExtendedMaterials::GetParallaxSoftShadowMultiplier`
- `ExtendedMaterials::GetParallaxSoftShadowMultiplierTerrain`

Behavior-preserving (the Terrain early-out `scale < 0.01` is inverted into a guarded block; `result` defaults to the prior fall-through value). No `/O1` runtime behavior change.

## Validation

VR profile + `/O3` validation (`--max-warnings 0`): **0 new warnings, 696 suppressed, 0 errors**. clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored parallax displacement mapping and soft-shadow rendering calculations for improved code stability.
  * Enhanced water caustics effect computation to ensure consistent visual quality across rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->