### PR TITLE
ci: validate shaders at release parity on PRs and at the release cut

### DIFF
--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -27,6 +27,10 @@ on:
                 description: "Compile shader validation at release parity and upload distributable ShaderCache artifacts"
                 type: boolean
                 default: false
+            release-parity-validation:
+                description: "Validate shaders at release parity (/O3 + default-install profile config) WITHOUT producing cache artifacts. Implied by cache-artifacts; use to gate a release on the same checks the cache build enforces."
+                type: boolean
+                default: false
             run-cpp-tests:
                 description: "Run C++ unit tests (tests/cpp)"
                 type: boolean
@@ -229,14 +233,16 @@ jobs:
                   fi
                   echo "Changed files for incremental validation:"
                   cat changed_files.txt || true
-                  # When the run doubles as the cache builder: release parity (/O3, debug
-                  # defines stripped) AND the default-install profile config (non-AIO and
+                  # Release parity (cache build OR a release gate): /O3 with debug
+                  # defines stripped AND the default-install profile config (non-AIO and
                   # default-disabled feature defines stripped -- the shipped cache targets a
-                  # default install and is invalid once any extra feature is added). PR
+                  # default install and is invalid once any extra feature is added). This is
+                  # the set the release ships; the gate catches /O3-only warnings (e.g. X4000
+                  # uninitialized return) that the default /O1 PR validation does not. PR
                   # validation keeps the full configs, so all feature paths stay covered.
                   CONFIG="${{ matrix.config.file }}"
                   EXTRA=""
-                  if [ "${{ inputs.cache-artifacts }}" = "true" ]; then
+                  if [ "${{ inputs.cache-artifacts }}" = "true" ] || [ "${{ inputs.release-parity-validation }}" = "true" ]; then
                     EXTRA="--strip-debug-defines --optimization-level 3"
                     python tools/build-shader-cache.py --emit-profile-config "$CONFIG" "profile-config-${{ matrix.config.runtime }}.yaml"
                     CONFIG="profile-config-${{ matrix.config.runtime }}.yaml"

--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -28,9 +28,13 @@ on:
                 type: boolean
                 default: false
             release-parity-validation:
-                description: "Validate shaders at release parity (/O3 + default-install profile config) WITHOUT producing cache artifacts. Implied by cache-artifacts; use to gate a release on the same checks the cache build enforces."
+                description: "Run the release-parity pass (/O3 + default-install profile config) WITHOUT producing cache artifacts. Implied by cache-artifacts; use to gate a release, or alongside run-full-config-validation on PRs to cover both sets."
                 type: boolean
                 default: false
+            run-full-config-validation:
+                description: "Run the full-config pass (every feature, default opt). On by default for broad PR coverage; release/cache/gate runs set this false since they only need the release-parity (profile) set."
+                type: boolean
+                default: true
             run-cpp-tests:
                 description: "Run C++ unit tests (tests/cpp)"
                 type: boolean
@@ -233,22 +237,35 @@ jobs:
                   fi
                   echo "Changed files for incremental validation:"
                   cat changed_files.txt || true
-                  # Release parity (cache build OR a release gate): /O3 with debug
-                  # defines stripped AND the default-install profile config (non-AIO and
-                  # default-disabled feature defines stripped -- the shipped cache targets a
-                  # default install and is invalid once any extra feature is added). This is
-                  # the set the release ships; the gate catches /O3-only warnings (e.g. X4000
-                  # uninitialized return) that the default /O1 PR validation does not. PR
-                  # validation keeps the full configs, so all feature paths stay covered.
-                  CONFIG="${{ matrix.config.file }}"
-                  EXTRA=""
-                  if [ "${{ inputs.cache-artifacts }}" = "true" ] || [ "${{ inputs.release-parity-validation }}" = "true" ]; then
-                    EXTRA="--strip-debug-defines --optimization-level 3"
-                    python tools/build-shader-cache.py --emit-profile-config "$CONFIG" "profile-config-${{ matrix.config.runtime }}.yaml"
-                    CONFIG="profile-config-${{ matrix.config.runtime }}.yaml"
+                  # Two independent incremental passes. validate_changed_shaders builds the
+                  # #include graph and compiles only the entry points that transitively
+                  # include a changed file, so both stay bounded by the change set:
+                  #   1. Full config, default opt -- every feature path stays covered.
+                  #   2. Release parity: /O3 (debug defines stripped) on the default-install
+                  #      profile config (non-AIO and default-disabled defines stripped -- the
+                  #      shipped cache targets a default install). This is the set the release
+                  #      ships and the only one that surfaces /O3-only warnings (e.g. X4000
+                  #      uninitialized return). PRs run both; the cache build and release gate
+                  #      run only #2.
+                  FXC="${{ steps.find_fxc.outputs.fxc_path }}"
+                  PLAIN_CONFIG="${{ matrix.config.file }}"
+                  mkdir -p build/ShaderCache build/ShaderCacheFull
+
+                  if [ "${{ inputs.run-full-config-validation }}" = "true" ]; then
+                    echo "::group::Full-config validation (default opt)"
+                    python tools/validate_changed_shaders.py --changed-list-file changed_files.txt -- \
+                      hlslkit-compile --fxc "$FXC" --shader-dir build/ALL/aio/Shaders --output-dir build/ShaderCacheFull --config "$PLAIN_CONFIG" --max-warnings 0 --suppress-warnings X1519
+                    echo "::endgroup::"
                   fi
-                  python tools/validate_changed_shaders.py --changed-list-file changed_files.txt -- \
-                    hlslkit-compile --fxc "${{ steps.find_fxc.outputs.fxc_path }}" --shader-dir build/ALL/aio/Shaders --output-dir build/ShaderCache --config "$CONFIG" --max-warnings 0 --suppress-warnings X1519 $EXTRA
+
+                  if [ "${{ inputs.cache-artifacts }}" = "true" ] || [ "${{ inputs.release-parity-validation }}" = "true" ]; then
+                    echo "::group::Release-parity validation (/O3, default-install profile)"
+                    PROFILE_CONFIG="profile-config-${{ matrix.config.runtime }}.yaml"
+                    python tools/build-shader-cache.py --emit-profile-config "$PLAIN_CONFIG" "$PROFILE_CONFIG"
+                    python tools/validate_changed_shaders.py --changed-list-file changed_files.txt -- \
+                      hlslkit-compile --fxc "$FXC" --shader-dir build/ALL/aio/Shaders --output-dir build/ShaderCache --config "$PROFILE_CONFIG" --max-warnings 0 --suppress-warnings X1519 --strip-debug-defines --optimization-level 3
+                    echo "::endgroup::"
+                  fi
 
             # Never runs in pull_request_target contexts or on fork checkouts
             # (cache-artifacts is only set by release-build); the guards make

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -154,6 +154,10 @@ jobs:
             shader-tests-should-build: ${{ needs.check-changes.outputs.shader-tests-should-build || 'true' }}
             cpp-tests-should-build: ${{ needs.check-changes.outputs.cpp-tests-should-build || 'true' }}
             changed-files-json: ${{ needs.check-changes.outputs.changed-files-json }}
+            # Also run the release-parity pass (/O3 + profile) incrementally, so /O3-only
+            # warnings (e.g. X4000) that would break the release cache are caught pre-merge.
+            # run-full-config-validation stays on, so PRs cover both sets.
+            release-parity-validation: true
 
     # Security: this job has GITHUB_TOKEN write permissions but executes no fork
     # code. It sparse-checks-out the BASE branch (trusted) for the

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -44,6 +44,8 @@ jobs:
             run-shader-tests: ${{ github.event_name != 'workflow_dispatch' || inputs.validate-shaders == true }}
             cache-key-suffix: ${{ inputs.cache-key-suffix || '' }}
             cache-artifacts: true
+            # Cache build only needs the release-parity (profile) pass.
+            run-full-config-validation: false
 
     feature-audit:
         name: Feature Version Audit (Release)

--- a/.github/workflows/release-semantic.yaml
+++ b/.github/workflows/release-semantic.yaml
@@ -48,6 +48,8 @@ jobs:
             run-shader-tests: false
             run-cpp-tests: false
             release-parity-validation: true
+            # Gate matches the shipped set only; the full-config pass is a PR concern.
+            run-full-config-validation: false
 
     release:
         needs: validate-shaders

--- a/.github/workflows/release-semantic.yaml
+++ b/.github/workflows/release-semantic.yaml
@@ -32,7 +32,25 @@ concurrency:
     cancel-in-progress: false
 
 jobs:
+    # Gate the version cut on the release-parity shader validation the cache build
+    # enforces (/O3 + default-install profile). Shader-only (no C++ build), so it adds
+    # zero PR-phase cost and runs once per release cut. Catches /O3-only warnings (e.g.
+    # X4000 uninitialized return) before semantic-release tags a version whose caches
+    # would then fail to build. Validates the about-to-be-released ref: ff_target in
+    # promotion mode, else the dispatched SHA.
+    validate-shaders:
+        uses: ./.github/workflows/_shared-build.yaml
+        with:
+            ref: ${{ inputs.ff_target || github.sha }}
+            repository: ${{ github.repository }}
+            run-cpp: false
+            run-shader-validation: true
+            run-shader-tests: false
+            run-cpp-tests: false
+            release-parity-validation: true
+
     release:
+        needs: validate-shaders
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository


### PR DESCRIPTION
## Problem

Release-parity shader validation (`/O3` + default-install profile config) only ran inside `release-build`, *after* semantic-release cut the tag. So an `/O3`-only warning (e.g. the 4 `X4000` "uninitialized return" warnings fixed in #188) wasn't seen until the version was already tagged with caches that then fail to build — the v1.9.0 case. The default `/O1` PR validation never surfaces these.

## Fix — catch on PRs, with a release-cut backstop

Two layers, both reusing one mechanism in `_shared-build`:

1. **PRs (primary).** `pr-checks` now runs the release-parity pass **incrementally** alongside the existing full-config pass. `validate_changed_shaders.py` builds the `#include` graph and compiles only the entry points that transitively include a changed file, so a changed `.hlsli` (e.g. `WaterCaustics.hlsli`) pulls in `Lighting.hlsl`/`Water.hlsl` and the `/O3` warning is caught **pre-merge** — it never reaches `dev`. Bounded cost; only shader PRs pay.

2. **Release-cut gate (backstop).** `release-semantic` gains a shader-only `validate-shaders` job (`run-cpp: false`, no ~18-min MSVC build) that the `release` job `needs:`. Catches anything that bypassed PR checks before a tag is cut.

### `_shared-build` now runs two independent incremental passes
- **Full config, default opt** — every feature path stays covered (`run-full-config-validation`, default on).
- **Release parity** — `/O3` + default-install profile config (the shipped set).

PRs run **both**. The cache build (`release-build`) and the release-cut gate set `run-full-config-validation: false` and run only the release-parity pass — preserving current behavior. The full-config pass writes `build/ShaderCacheFull` so it never clobbers the `build/ShaderCache` dir the cache finalize/upload steps consume.

## Why this shape
- **Pre-merge detection** so a bad shader can't break `dev` (not just blocked at release).
- **No real duplication:** PRs do a cheap *incremental* pass; `release-build` does the one *full* compile that must happen to ship the cache. Different scopes.
- **DRY:** one validation path in `_shared-build`, parameterized by two booleans.

Companion to #188 (fixes the four shaders that triggered this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)