### PR TITLE
fix(upscaling): hook PerfMode Fade tonemap variant

### DIFF
--- a/src/Features/Upscaling/PerfMode.h
+++ b/src/Features/Upscaling/PerfMode.h
@@ -171,10 +171,24 @@ private:
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
-	// IS shader hook: ISHDRTonemapBlendCinematic (Render vfunc 0x1 on vtable[3])
-	// Chains after FrameAnnotations (if active). Swaps kMAIN SRV + kMAIN DS before
-	// tonemap, restores after.
+	// Shared swap+render impl for the cinematic tonemap hooks (Render vfunc 0x1 on
+	// vtable[3]). Templated so each variant calls its own `func` (the two vtables
+	// hold different originals). Chains after FrameAnnotations: swaps kMAIN SRV +
+	// kMAIN DS before tonemap, restores after.
+	template <class Hook>
+	static void RenderTonemapWithSwap(void* imageSpaceShader, RE::BSTriShape* shape, RE::ImageSpaceEffectParam* param);
+
 	struct TonemapRender_Hook
+	{
+		static void thunk(void* imageSpaceShader, RE::BSTriShape* shape, RE::ImageSpaceEffectParam* param);
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+	// Fade variant (BSImagespaceShaderHDRTonemapBlendCinematicFade). The engine swaps
+	// to this tonemap whenever a fullscreen imagespace fade is active — e.g. a nearby
+	// fireball/Unrelenting Force impact. It needs the identical RT/DS fixup; without it
+	// the 3k tonemap RT binds against the 1k kMAIN depth-stencil, D3D11 drops the
+	// size-mismatched draw, and the world freezes behind a still-updating menu.
+	struct TonemapFadeRender_Hook
 	{
 		static void thunk(void* imageSpaceShader, RE::BSTriShape* shape, RE::ImageSpaceEffectParam* param);
 		static inline REL::Relocation<decltype(thunk)> func;

--- a/src/Features/Upscaling/PerfMode/Core.cpp
+++ b/src/Features/Upscaling/PerfMode/Core.cpp
@@ -175,6 +175,8 @@ void PerfMode::SetupResources()
 	// IS shader hooks (must be installed AFTER FrameAnnotations)
 	if (hookActive && !tonemapHookInstalled) {
 		stl::write_vfunc<0x1, TonemapRender_Hook>(RE::VTABLE_BSImagespaceShaderHDRTonemapBlendCinematic[3]);
+		// Also hook the Fade variant (active during fullscreen imagespace fades).
+		stl::write_vfunc<0x1, TonemapFadeRender_Hook>(RE::VTABLE_BSImagespaceShaderHDRTonemapBlendCinematicFade[3]);
 		tonemapHookInstalled = true;
 	}
 

--- a/src/Features/Upscaling/PerfMode/PostIntercept.cpp
+++ b/src/Features/Upscaling/PerfMode/PostIntercept.cpp
@@ -12,18 +12,20 @@
 #include <FidelityFX/host/ffx_fsr3.h>
 
 // ============================================================================
-// TonemapRender_Hook: IS shader hook for ISHDRTonemapBlendCinematic
+// Tonemap hooks: ISHDRTonemapBlendCinematic + ...CinematicFade (Render vfunc
+// 0x1 on vtable[3]) — both share RenderTonemapWithSwap.
 // ============================================================================
 // Installed via stl::write_vfunc<0x1> on vtable[3], chains after FrameAnnotations.
 // Inner layer of two-layer swap: swaps kMAIN SRV → testTextureSRV and
 // kMAIN DS → fakeDS before tonemap Render(), restores after.
 
-void PerfMode::TonemapRender_Hook::thunk(void* imageSpaceShader, RE::BSTriShape* shape, RE::ImageSpaceEffectParam* param)
+template <class Hook>
+void PerfMode::RenderTonemapWithSwap(void* imageSpaceShader, RE::BSTriShape* shape, RE::ImageSpaceEffectParam* param)
 {
 	auto& perfMode = globals::features::upscaling.perfMode;
 
 	if (!perfMode.hookActive || !perfMode.testTextureSRV || !perfMode.fakeDSV) {
-		func(imageSpaceShader, shape, param);
+		Hook::func(imageSpaceShader, shape, param);
 		return;
 	}
 
@@ -36,7 +38,7 @@ void PerfMode::TonemapRender_Hook::thunk(void* imageSpaceShader, RE::BSTriShape*
 	// DLSS-reconstructed testTexture into kTOTAL. Per-frame guarded so it
 	// runs at most once per frame regardless of how many menu redraws fire.
 	if (globals::state && globals::state->IsMainOrLoadingMenuOpen()) {
-		func(imageSpaceShader, shape, param);
+		Hook::func(imageSpaceShader, shape, param);
 		perfMode.MaybeBlitMenuBG(RE::RENDER_TARGETS::kTOTAL);
 		return;
 	}
@@ -71,7 +73,7 @@ void PerfMode::TonemapRender_Hook::thunk(void* imageSpaceShader, RE::BSTriShape*
 	}
 
 	// --- Call original (or FrameAnnotations chain) ---
-	func(imageSpaceShader, shape, param);
+	Hook::func(imageSpaceShader, shape, param);
 
 	// --- Restore kMAIN SRV ---
 	kmainRT.SRV = perfMode.savedKMainSRV;
@@ -86,6 +88,16 @@ void PerfMode::TonemapRender_Hook::thunk(void* imageSpaceShader, RE::BSTriShape*
 		kmainDS.views[i] = perfMode.savedKMainViews[i];
 	for (int i = 0; i < 8; i++)
 		kmainDS.readOnlyViews[i] = perfMode.savedKMainReadOnlyViews[i];
+}
+
+void PerfMode::TonemapRender_Hook::thunk(void* imageSpaceShader, RE::BSTriShape* shape, RE::ImageSpaceEffectParam* param)
+{
+	PerfMode::RenderTonemapWithSwap<TonemapRender_Hook>(imageSpaceShader, shape, param);
+}
+
+void PerfMode::TonemapFadeRender_Hook::thunk(void* imageSpaceShader, RE::BSTriShape* shape, RE::ImageSpaceEffectParam* param)
+{
+	PerfMode::RenderTonemapWithSwap<TonemapFadeRender_Hook>(imageSpaceShader, shape, param);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Problem

With DLSS/FSR upscaling + **Render engine at upscaled resolution** (PerfMode, VR), casting **Fireball** (or Unrelenting Force) so it impacts **near the player** freezes the rendered world — the menu still draws and game logic continues, but the world is stuck. Distant explosions don't trigger it. Workaround was disabling the setting. Fixes #190.

## Root cause

PerfMode only hooked `BSImagespaceShaderHDRTonemapBlendCinematic`. A nearby explosion activates a **fullscreen imagespace fade**, so the engine swaps to the separate `…CinematicFade` tonemap shader — a different class with its **own vtable**, whose `Render` vfunc was **unhooked**.

PerfMode's tonemap hook does the load-bearing resolution fixup: swap `kMAIN`/`kMAIN_COPY` SRV → the 3k `testTexture` and swap the kMAIN depth-stencil → `fakeDS` so the displayRes (3k) tonemap RT doesn't mismatch the renderRes (1k) kMAIN DS. Unhooked, the 3k RT binds against the 1k DS → **D3D11 silently drops the size-mismatched draw** → the composited world never updates → frozen world behind a still-working menu.

## Evidence (RenderDoc A/B)

Two captures, same scene, near vs distant fireball:

| | no-stall (distant) | stall (near) |
|---|---|---|
| `PerfMode::TonemapRender` wrapper | present | **absent** |
| tonemap shader | `ISHDRTonemapBlendCinematic` | `ISHDRTonemapBlendCinematic`**`Fade`** |

Everything before the tonemap (upscale, downscale, HDR pyramid, light-adapt) is byte-for-byte identical; the GPU frame is a normal ~25 ms (not a hang). Only the tonemap variant — and whether it's wrapped — differs.

## Fix

Factor the swap/restore into a templated `RenderTonemapWithSwap<Hook>` and add a sibling `TonemapFadeRender_Hook` (its own `func` trampoline, since the two vtables hold different originals), installed on `VTABLE_BSImagespaceShaderHDRTonemapBlendCinematicFade[3]`.

## Testing

- Builds clean (`ALL`).
- **VR: confirmed fixed** — Fireball-at-self with PerfMode on no longer freezes; the impact fade/tonemap renders correctly.
- SE: unaffected by inspection — PerfMode (and therefore this hook) only installs when `hookActive`, which is VR-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability for HDR tonemap rendering by fixing render target and depth-stencil consistency.

* **New Features**
  * Added support for HDR fade tonemap variant, ensuring proper visual processing for fade effects during HDR rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->