### PR TITLE
ci: bump Node-20 actions to Node-24 majors

### DIFF
--- a/.github/actions/prepare-shaders/action.yml
+++ b/.github/actions/prepare-shaders/action.yml
@@ -19,7 +19,7 @@ runs:
               buildPresetAdditionalArgs: "['--target prepare_shaders']"
 
         - name: Setup Python
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@v6
           with:
               python-version: "3.11"
 

--- a/.github/workflows/pr-i18n.yaml
+++ b/.github/workflows/pr-i18n.yaml
@@ -20,11 +20,11 @@ jobs:
         if: ${{ !github.event.pull_request.draft }}
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
 
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@v6
               with:
                   python-version: "3.11"
 


### PR DESCRIPTION
## What

Fixes the GitHub Actions Node 20 deprecation warning flagged on **Build / Validate shader compilation (Flatrim)** and **(VR)** in v1.9.1 CI:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/setup-python@v5.

## Changes

| File | Action | Before | After |
|------|--------|--------|-------|
| `.github/actions/prepare-shaders/action.yml` | `actions/setup-python` | `@v5` | `@v6` |
| `.github/workflows/pr-i18n.yaml` | `actions/setup-python` | `@v5` | `@v6` |
| `.github/workflows/pr-i18n.yaml` | `actions/checkout` | `@v4` | `@v6` |

`actions/setup-python@v6` is the current Node-24 major and is already in use across 5 other workflows in this repo (`ci-test`, `shader-cache`, `nexus-upload`, `pr-checks`, `release-build`), confirming the tag. The `prepare-shaders` composite action is what the shader-validation jobs invoke, so this clears the annotated warning at the source.

The lone `actions/checkout@v4` in `pr-i18n.yaml` was the same Node-20 deprecation family and a trivially safe bump (plain checkout, no behavioral change) — every other workflow already pins `checkout@v6`.

## Scope / coordination

Deliberately **did not touch** `release-build.yaml` or `nexus-upload.yaml` (reserved for the concurrent shader-cache work). Both already use `setup-python@v6` and current-major checkout/artifact actions, so there is **nothing left there** for the other agent to pick up.

## Node-20 pins deliberately left

None. A full scan of `.github/workflows/` and `.github/actions/` shows the rest of the repo is already on Node-24 majors: `checkout@v6`, `upload-artifact@v7`, `download-artifact@v6/v7`, `cache@v5`, `setup-python@v6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDtqDrtJ5ivBZ8fBX11EJG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development infrastructure and build tooling to use newer versions for improved compatibility and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->