### PR TITLE
ci: skip Nexus changelog re-posting

### DIFF
--- a/.github/scripts/nexus_changelog.py
+++ b/.github/scripts/nexus_changelog.py
@@ -1,15 +1,14 @@
-"""Helpers for building the Nexus changelog payload from a GitHub release body.
+"""Helpers for the Nexus changelog post in .github/workflows/nexus-upload.yaml.
 
-Used by .github/workflows/nexus-upload.yaml. The Nexus "save documentation"
-endpoint that BUTR.NexusUploader (`unex changelog`) posts to emits one
-changelog row per newline in the supplied text and *appends* rows to the
-existing changelog rather than replacing them. A raw multi-line release body
-therefore explodes into many rows under a single version, and a re-run appends
-them all again — the "doubled up" entries reported in issue #198.
+The Nexus "save documentation" endpoint that BUTR.NexusUploader (`unex
+changelog`) posts to *appends* the supplied text to the existing changelog
+rather than replacing it. Re-running the upload for a version already on Nexus
+therefore appends that version's notes a second time — the "doubled up" entries
+reported in issue #198.
 
-release_changelog() collapses this version's notes into a single line (one row),
-and version_already_on_nexus() lets the workflow skip re-posting a version whose
-entry is already present so re-runs stay idempotent.
+version_already_on_nexus() lets the workflow skip the changelog for any version
+already present so re-runs stay idempotent. strip_audit() drops the internal
+Feature Version Audit block from the release body before it is posted.
 """
 
 from __future__ import annotations
@@ -27,38 +26,6 @@ _AUDIT_RE = re.compile(r"\n---\n+# Feature Version Audit\b.*", re.DOTALL)
 def strip_audit(body: str) -> str:
     """Drop the internal Feature Version Audit section from a release body."""
     return _AUDIT_RE.sub("", body or "").strip()
-
-
-def release_changelog(body: str) -> str:
-    """Flatten a GitHub release body into a single Nexus changelog line.
-
-    unex posts one Nexus changelog row per '\\n', so the multi-line body must be
-    collapsed to one line. Markdown bullet/heading markers are stripped and the
-    individual notes are joined with ' • ' so the single row stays readable.
-    """
-    body = strip_audit(body)
-    if not body:
-        return ""
-    # semantic-release opens the body with "## [x.y.z](compare-url) (date)";
-    # Nexus already keys the entry by version, so drop that redundant header.
-    body = re.sub(
-        r"^\s*#{1,6}\s*\[?\d[\w.\-]*\]?\([^)]*\)\s*\([^)]*\)\s*\n",
-        "",
-        body,
-        count=1,
-    )
-    items: list[str] = []
-    for raw in body.splitlines():
-        line = raw.strip()
-        if not line or line.startswith("---"):
-            continue
-        # Strip leading markdown heading (#) and list (*, -, +) markers.
-        line = re.sub(r"^#{1,6}\s+", "", line)
-        line = re.sub(r"^[*+-]\s+", "", line)
-        line = line.strip()
-        if line:
-            items.append(line)
-    return " • ".join(items)
 
 
 def version_already_on_nexus(

--- a/.github/scripts/nexus_changelog.py
+++ b/.github/scripts/nexus_changelog.py
@@ -61,8 +61,9 @@ def nexus_versions(
             files = json.load(resp).get("files", [])
     except (urllib.error.URLError, TimeoutError, ValueError, OSError):
         return None
-    main = [f for f in files if f.get("category_name") == "MAIN"]
-    check = main if main else files
+    # Strictly MAIN-only (no fall back to all files): for a mod with no MAIN
+    # file yet, an OPTIONAL upload sharing the version must not read as present.
+    check = [f for f in files if f.get("category_name") == "MAIN"]
     seen: list[str] = []
     for f in check:
         v = f.get("version", "")

--- a/.github/scripts/nexus_changelog.py
+++ b/.github/scripts/nexus_changelog.py
@@ -6,9 +6,10 @@ rather than replacing it. Re-running the upload for a version already on Nexus
 therefore appends that version's notes a second time — the "doubled up" entries
 reported in issue #198.
 
-version_already_on_nexus() lets the workflow skip the changelog for any version
-already present so re-runs stay idempotent. strip_audit() drops the internal
-Feature Version Audit block from the release body before it is posted.
+nexus_versions() returns the MAIN-category file versions on a mod (the single
+shared Nexus file-list query used by the dry-run check, the upload summary, and
+the idempotent changelog blank). strip_audit() drops the internal Feature
+Version Audit block from the release body before it is posted.
 """
 
 from __future__ import annotations
@@ -28,18 +29,21 @@ def strip_audit(body: str) -> str:
     return _AUDIT_RE.sub("", body or "").strip()
 
 
-def version_already_on_nexus(
+def nexus_versions(
     api_key: str,
     game_id: str,
     mod_id: str,
-    version: str,
     user_agent: str = "open-shaders-ci/1.0",
     timeout: int = 15,
-) -> bool | None:
-    """Return True/False if `version` is on the mod's file list, None if unknown.
+) -> list[str] | None:
+    """Return the mod's MAIN-category file versions (first-seen order), or None.
 
     None means the query could not be completed (missing key/mod id, network or
-    auth error) — callers should treat that as "don't suppress the changelog".
+    auth error) — callers treat that as "don't suppress / status unknown".
+
+    MAIN-only on purpose: this workflow also uploads prebuilt shader caches as
+    OPTIONAL files, so matching every file would let an OPTIONAL file sharing the
+    release version read as the MAIN file already being on Nexus.
     """
     if not api_key or not mod_id:
         return None
@@ -57,4 +61,11 @@ def version_already_on_nexus(
             files = json.load(resp).get("files", [])
     except (urllib.error.URLError, TimeoutError, ValueError, OSError):
         return None
-    return any(f.get("version") == version for f in files)
+    main = [f for f in files if f.get("category_name") == "MAIN"]
+    check = main if main else files
+    seen: list[str] = []
+    for f in check:
+        v = f.get("version", "")
+        if v and v not in seen:
+            seen.append(v)
+    return seen

--- a/.github/scripts/nexus_changelog.py
+++ b/.github/scripts/nexus_changelog.py
@@ -1,0 +1,93 @@
+"""Helpers for building the Nexus changelog payload from a GitHub release body.
+
+Used by .github/workflows/nexus-upload.yaml. The Nexus "save documentation"
+endpoint that BUTR.NexusUploader (`unex changelog`) posts to emits one
+changelog row per newline in the supplied text and *appends* rows to the
+existing changelog rather than replacing them. A raw multi-line release body
+therefore explodes into many rows under a single version, and a re-run appends
+them all again — the "doubled up" entries reported in issue #198.
+
+release_changelog() collapses this version's notes into a single line (one row),
+and version_already_on_nexus() lets the workflow skip re-posting a version whose
+entry is already present so re-runs stay idempotent.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.error
+import urllib.request
+
+# Trailing "# Feature Version Audit" block appended to the release body is
+# internal bookkeeping, not user-facing changelog content.
+_AUDIT_RE = re.compile(r"\n---\n+# Feature Version Audit\b.*", re.DOTALL)
+
+
+def strip_audit(body: str) -> str:
+    """Drop the internal Feature Version Audit section from a release body."""
+    return _AUDIT_RE.sub("", body or "").strip()
+
+
+def release_changelog(body: str) -> str:
+    """Flatten a GitHub release body into a single Nexus changelog line.
+
+    unex posts one Nexus changelog row per '\\n', so the multi-line body must be
+    collapsed to one line. Markdown bullet/heading markers are stripped and the
+    individual notes are joined with ' • ' so the single row stays readable.
+    """
+    body = strip_audit(body)
+    if not body:
+        return ""
+    # semantic-release opens the body with "## [x.y.z](compare-url) (date)";
+    # Nexus already keys the entry by version, so drop that redundant header.
+    body = re.sub(
+        r"^\s*#{1,6}\s*\[?\d[\w.\-]*\]?\([^)]*\)\s*\([^)]*\)\s*\n",
+        "",
+        body,
+        count=1,
+    )
+    items: list[str] = []
+    for raw in body.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("---"):
+            continue
+        # Strip leading markdown heading (#) and list (*, -, +) markers.
+        line = re.sub(r"^#{1,6}\s+", "", line)
+        line = re.sub(r"^[*+-]\s+", "", line)
+        line = line.strip()
+        if line:
+            items.append(line)
+    return " • ".join(items)
+
+
+def version_already_on_nexus(
+    api_key: str,
+    game_id: str,
+    mod_id: str,
+    version: str,
+    user_agent: str = "open-shaders-ci/1.0",
+    timeout: int = 15,
+) -> bool | None:
+    """Return True/False if `version` is on the mod's file list, None if unknown.
+
+    None means the query could not be completed (missing key/mod id, network or
+    auth error) — callers should treat that as "don't suppress the changelog".
+    """
+    if not api_key or not mod_id:
+        return None
+    url = f"https://api.nexusmods.com/v1/games/{game_id}/mods/{mod_id}/files.json"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "apikey": api_key,
+            "User-Agent": user_agent,
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            files = json.load(resp).get("files", [])
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError):
+        return None
+    return any(f.get("version") == version for f in files)

--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -280,7 +280,7 @@ jobs:
                   # Single-row AIO matrix trivially passes this filter.
                   python3 << 'PYEOF'
                   import json, os, fnmatch
-                  from nexus_changelog import version_already_on_nexus
+                  from nexus_changelog import nexus_versions
                   with open('nexus-matrix-raw.json') as f:
                       data = json.load(f)
                   try:
@@ -306,7 +306,8 @@ jobs:
                           continue
                       mod_id = str(row.get('nexus_mod_id', ''))
                       ver = row.get('mod_version') or version
-                      if version_already_on_nexus(api_key, game_id, mod_id, ver, ua) is True:
+                      versions = nexus_versions(api_key, game_id, mod_id, ua)
+                      if versions is not None and ver in versions:
                           print(f'::notice::Version {ver} already on Nexus mod {mod_id}; '
                                 f'skipping changelog re-post to avoid duplicate entry.')
                           row['changelog'] = ''
@@ -448,10 +449,14 @@ jobs:
             needs.prepare-nexus-matrix.outputs.has_uploads == 'true'
         runs-on: ubuntu-latest
         steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
             - name: Query Nexus for existing versions
               run: |
                   python3 << 'PYEOF'
-                  import json, os, urllib.request, urllib.error
+                  import json, os
+                  from nexus_changelog import nexus_versions
 
                   rows = json.loads(os.environ['UPLOAD_MATRIX']).get('include', [])
                   rows = [r for r in rows if not r.get('skip')]
@@ -486,32 +491,14 @@ jobs:
                           w(f'| {link} | `{planned}` | ⚠️ skipped | — |')
                           continue
 
-                      api_url = f'https://api.nexusmods.com/v1/games/{game_id}/mods/{mod_id}/files.json'
-                      req = urllib.request.Request(api_url, headers={
-                          'apikey': api_key,
-                          'User-Agent': ua,
-                          'Accept': 'application/json',
-                      })
-                      try:
-                          with urllib.request.urlopen(req, timeout=15) as resp:
-                              data = json.load(resp)
-                          api_ok = True
-                          files = data.get('files', [])
-                          main = [f for f in files if f.get('category_name') == 'MAIN']
-                          check = main if main else files
-                          seen = []
-                          for f in check:
-                              v = f.get('version', '')
-                              if v and v not in seen:
-                                  seen.append(v)
-                          versions_str = ', '.join(f'`{v}`' for v in seen[-5:]) or '—'
-                          status = '✅ exists' if planned in seen else '🆕 new'
-                          w(f'| {link} | `{planned}` | {status} | {versions_str} |')
-                      except urllib.error.HTTPError as e:
-                          err = {401: '❌ auth failed', 403: '❌ forbidden'}.get(e.code, f'❌ HTTP {e.code}')
-                          w(f'| {link} | `{planned}` | {err} | — |')
-                      except Exception:
-                          w(f'| {link} | `{planned}` | ❌ error | — |')
+                      seen = nexus_versions(api_key, game_id, mod_id, ua)
+                      if seen is None:
+                          w(f'| {link} | `{planned}` | ❌ could not verify | — |')
+                          continue
+                      api_ok = True
+                      versions_str = ', '.join(f'`{v}`' for v in seen[-5:]) or '—'
+                      status = '✅ exists' if planned in seen else '🆕 new'
+                      w(f'| {link} | `{planned}` | {status} | {versions_str} |')
 
                   w()
                   if api_key:
@@ -527,6 +514,7 @@ jobs:
                   NEXUS_GAME_ID: ${{ inputs.nexus_game_id || 'skyrimspecialedition' }}
                   MODE: ${{ needs.prepare-nexus-matrix.outputs.mode }}
                   UNEX_APIKEY: ${{ secrets.UNEX_APIKEY }}
+                  PYTHONPATH: ${{ github.workspace }}/.github/scripts
 
     upload-to-nexus:
         # Reusable workflow call: runs-on is intentionally omitted (runner is defined by the
@@ -611,6 +599,9 @@ jobs:
         needs: [prepare-nexus-matrix, prepare-artifacts, upload-to-nexus, check-nexus-versions]
         if: always() && needs.prepare-nexus-matrix.result == 'success'
         steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
             - name: Check upload status
               run: |
                   echo "## Nexus Upload Summary" >> $GITHUB_STEP_SUMMARY
@@ -634,7 +625,8 @@ jobs:
               if: needs.prepare-nexus-matrix.outputs.dry_run != 'true' && needs.prepare-nexus-matrix.outputs.has_uploads == 'true'
               run: |
                   python3 << 'PYEOF'
-                  import json, os, urllib.request, urllib.error
+                  import json, os
+                  from nexus_changelog import nexus_versions
 
                   rows = json.loads(os.environ['UPLOAD_MATRIX']).get('include', [])
                   rows = [r for r in rows if not r.get('skip')]
@@ -647,29 +639,6 @@ jobs:
                   def w(line=''):
                       summary.write(line + '\n')
 
-                  def nexus_versions(mod_id):
-                      if not api_key or not mod_id:
-                          return None
-                      url = f'https://api.nexusmods.com/v1/games/{game_id}/mods/{mod_id}/files.json'
-                      req = urllib.request.Request(url, headers={
-                          'apikey': api_key,
-                          'User-Agent': ua,
-                          'Accept': 'application/json',
-                      })
-                      try:
-                          with urllib.request.urlopen(req, timeout=15) as resp:
-                              files = json.load(resp).get('files', [])
-                          main = [f for f in files if f.get('category_name') == 'MAIN']
-                          check = main if main else files
-                          seen = []
-                          for f in check:
-                              v = f.get('version', '')
-                              if v and v not in seen:
-                                  seen.append(v)
-                          return seen
-                      except Exception:
-                          return None
-
                   succeeded, failed, unknowns = [], [], []
                   rows_status = []
                   for row in rows:
@@ -679,7 +648,7 @@ jobs:
                       label = row.get('mod_filename', name)
                       url = f'https://www.nexusmods.com/{game_id}/mods/{mod_id}' if mod_id else ''
                       artifact = f'nexus-upload-{name}'
-                      versions = nexus_versions(mod_id)
+                      versions = nexus_versions(api_key, game_id, mod_id, ua)
                       if versions is None:
                           status, icon = 'unknown', '❓'
                           unknowns.append(label)
@@ -720,3 +689,4 @@ jobs:
                   NEXUS_GAME_ID: ${{ inputs.nexus_game_id || 'skyrimspecialedition' }}
                   MODE: ${{ needs.prepare-nexus-matrix.outputs.mode }}
                   UNEX_APIKEY: ${{ secrets.UNEX_APIKEY }}
+                  PYTHONPATH: ${{ github.workspace }}/.github/scripts

--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -451,6 +451,8 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
+              with:
+                  persist-credentials: false
 
             - name: Query Nexus for existing versions
               run: |
@@ -601,6 +603,8 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
+              with:
+                  persist-credentials: false
 
             - name: Check upload status
               run: |

--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -205,14 +205,18 @@ jobs:
                     RELEASE_VER="${RELEASE_TAG#v}"
                     export RELEASE_VER
                     python3 << 'PYEOF'
-                  import json, os, re
+                  import json, os
+                  from nexus_changelog import release_changelog
                   with open('release.json') as f:
                       release = json.load(f)
                   if not isinstance(release, dict):
                       release = {}
-                  body = release.get('body') or ''
-                  body = re.sub(r'\n---\n+# Feature Version Audit\b.*', '', body, flags=re.DOTALL).strip()
                   release_ver = os.environ['RELEASE_VER']
+                  # Post only this version's notes, flattened to one line. unex posts
+                  # one Nexus changelog row per '\n' in the text, so a raw multi-line
+                  # body explodes into many rows under one version (the issue #198
+                  # "doubled up" rows). See nexus_changelog.release_changelog.
+                  changelog = release_changelog(release.get('body') or '')
                   # Prebuilt shader caches are uploaded separately as OPTIONAL files via the
                   # official Nexus action (see the upload-shader-caches job) — unex can only set
                   # MAIN files, so they are not part of this (unex) AIO matrix.
@@ -223,7 +227,7 @@ jobs:
                       'artifact_pattern': os.environ['EFFECTIVE_ARTIFACT'],
                       'mod_filename': os.environ['EFFECTIVE_FILENAME'],
                       'auto_upload': True,
-                      'changelog': body,
+                      'changelog': changelog,
                       'file_description': (
                           f'Open Shaders {release_ver} AIO. See changelog for included features. '
                           'Optional prebuilt shader caches (SE/AE and VR) are available as separate '
@@ -252,20 +256,20 @@ jobs:
                     ARGS+=( --release-version "$RELEASE_VER" )
                     python tools/feature_version_audit.py "${ARGS[@]}"
 
-                    # Splice the GitHub release body into the CORE row's changelog.
+                    # Splice this version's flattened changelog into the CORE row.
                     python3 << 'PYEOF'
-                  import json, os, re
+                  import json, os
+                  from nexus_changelog import release_changelog
                   with open('release.json') as f:
                       release = json.load(f)
                   if not isinstance(release, dict):
                       release = {}
-                  body = release.get('body') or ''
-                  body = re.sub(r'\n---\n+# Feature Version Audit\b.*', '', body, flags=re.DOTALL).strip()
+                  changelog = release_changelog(release.get('body') or '')
                   with open('nexus-matrix-raw.json') as f:
                       data = json.load(f)
                   for row in data:
                       if row.get('name') == 'core':
-                          row['changelog'] = body
+                          row['changelog'] = changelog
                           break
                   with open('nexus-matrix-raw.json', 'w') as f:
                       json.dump(data, f)
@@ -277,6 +281,7 @@ jobs:
                   # Single-row AIO matrix trivially passes this filter.
                   python3 << 'PYEOF'
                   import json, os, fnmatch
+                  from nexus_changelog import version_already_on_nexus
                   with open('nexus-matrix-raw.json') as f:
                       data = json.load(f)
                   try:
@@ -287,6 +292,25 @@ jobs:
                   except Exception:
                       release = {}
                   asset_names = [a['name'] for a in release.get('assets', [])]
+
+                  # Idempotent changelog: unex *appends* changelog rows, so blank
+                  # the changelog for any version already on Nexus. A re-run then
+                  # re-uploads the file but does not append a duplicate entry
+                  # (issue #198). Unknown (no key / API error) -> keep posting.
+                  api_key = os.environ.get('UNEX_APIKEY', '')
+                  game_id = os.environ.get('NEXUS_GAME_ID', 'skyrimspecialedition')
+                  ua = ('open-shaders-ci/1.0' if os.environ.get('MODE') == 'aio'
+                        else 'community-shaders-ci/1.0')
+                  version = os.environ.get('VERSION', '')
+                  for row in data:
+                      if not row.get('changelog'):
+                          continue
+                      mod_id = str(row.get('nexus_mod_id', ''))
+                      ver = row.get('mod_version') or version
+                      if version_already_on_nexus(api_key, game_id, mod_id, ver, ua) is True:
+                          print(f'::notice::Version {ver} already on Nexus mod {mod_id}; '
+                                f'skipping changelog re-post to avoid duplicate entry.')
+                          row['changelog'] = ''
                   def artifact_in_release(row):
                       pat = row.get('artifact_pattern', '')
                       return bool(pat) and any(fnmatch.fnmatch(n, pat) for n in asset_names)
@@ -346,6 +370,14 @@ jobs:
                   INPUT_MOD_FILENAME: ${{ inputs.mod_filename || '' }}
                   INPUT_ARTIFACT_PATTERN: ${{ inputs.artifact_pattern || '' }}
                   DRY_RUN: ${{ steps.dryrun.outputs.dry_run }}
+                  VERSION: ${{ steps.resolve.outputs.version }}
+                  MODE: ${{ steps.resolve.outputs.mode }}
+                  NEXUS_GAME_ID: ${{ inputs.nexus_game_id || 'skyrimspecialedition' }}
+                  # Idempotency query against Nexus (blank changelog for versions
+                  # already present). Absent key -> changelog still posts.
+                  UNEX_APIKEY: ${{ secrets.UNEX_APIKEY }}
+                  # The heredocs import .github/scripts/nexus_changelog.py.
+                  PYTHONPATH: ${{ github.workspace }}/.github/scripts
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     prepare-artifacts:

--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -206,17 +206,16 @@ jobs:
                     export RELEASE_VER
                     python3 << 'PYEOF'
                   import json, os
-                  from nexus_changelog import release_changelog
+                  from nexus_changelog import strip_audit
                   with open('release.json') as f:
                       release = json.load(f)
                   if not isinstance(release, dict):
                       release = {}
                   release_ver = os.environ['RELEASE_VER']
-                  # Post only this version's notes, flattened to one line. unex posts
-                  # one Nexus changelog row per '\n' in the text, so a raw multi-line
-                  # body explodes into many rows under one version (the issue #198
-                  # "doubled up" rows). See nexus_changelog.release_changelog.
-                  changelog = release_changelog(release.get('body') or '')
+                  # Post this version's release notes (minus the internal audit
+                  # block). Re-run duplicates are prevented by the idempotency
+                  # filter below, not by reformatting the body (issue #198).
+                  changelog = strip_audit(release.get('body') or '')
                   # Prebuilt shader caches are uploaded separately as OPTIONAL files via the
                   # official Nexus action (see the upload-shader-caches job) — unex can only set
                   # MAIN files, so they are not part of this (unex) AIO matrix.
@@ -256,15 +255,15 @@ jobs:
                     ARGS+=( --release-version "$RELEASE_VER" )
                     python tools/feature_version_audit.py "${ARGS[@]}"
 
-                    # Splice this version's flattened changelog into the CORE row.
+                    # Splice this version's changelog (audit-stripped body) into the CORE row.
                     python3 << 'PYEOF'
                   import json, os
-                  from nexus_changelog import release_changelog
+                  from nexus_changelog import strip_audit
                   with open('release.json') as f:
                       release = json.load(f)
                   if not isinstance(release, dict):
                       release = {}
-                  changelog = release_changelog(release.get('body') or '')
+                  changelog = strip_audit(release.get('body') or '')
                   with open('nexus-matrix-raw.json') as f:
                       data = json.load(f)
                   for row in data:

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tools/__pycache__/
 # clangd compile database (machine-specific absolute paths; regenerate with
 # tools/gen-clangd-db.ps1)
 /compile_commands.json
+.github/scripts/__pycache__/


### PR DESCRIPTION
## Problem

Re-running the Nexus upload for a release whose version is already on Nexus re-posts that version's changelog, and the `unex changelog` endpoint **appends** rather than replaces — so the entry shows up duplicated ("doubled up", issue #198).

## Fix

Make the changelog post **idempotent**: before posting, look up the version on the mod's Nexus file list and, if present, blank that row's changelog so the re-run re-uploads the file without appending a duplicate. If the query can't be completed (no API key / network error) it fails open — the changelog still posts. The release body itself is posted **as-is** (audit block stripped, as before) — no reformatting.

## One shared file-list query (no new duplication)

The workflow already queried `files.json` for version existence in two places (the dry-run version check and the upload summary), both MAIN-category-filtered. Rather than add a third, the idempotency check and both existing copies now route through a single `nexus_versions()` helper in `.github/scripts/nexus_changelog.py`:

- **MAIN-only**, matching the existing behavior — this workflow uploads prebuilt shader caches as **OPTIONAL** files, so matching every file would let an OPTIONAL file sharing the release version falsely read as the MAIN file being present and wrongly suppress the changelog.
- The two reporting jobs gain a `checkout` + `PYTHONPATH` to import the helper; the dry-run check's per-HTTP-status error labels (`auth failed`/`forbidden`) collapse to a single `could not verify`.

`strip_audit()` (drops the internal Feature Version Audit block) lives alongside it. Helper logic is covered by a local test (MAIN-filter incl. the OPTIONAL-exclusion case, fail-open on error).

Fixes #198.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Nexus Mods upload workflow with centralized changelog processing that automatically removes internal “Feature Version Audit” content before submission.
  * Added idempotent Nexus version checking to avoid generating upload entries when the target version is already present.
  * Refactored Nexus-related release automation to share version/changelog logic across jobs, and updated repo settings to ignore generated Python cache files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->