### PR TITLE
refactor(llf): name focus-shadow engine wrappers

### DIFF
--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -1275,7 +1275,10 @@ namespace ShadowCasterManager
 		func(light);
 	}
 
-	static void GameSetupDirectionalLight(RE::BSShadowLight* light, RE::NiCamera* cam)
+	// Engine BSShadowDirectionalLight::SetupFocusShadowMaps (RelocationID 100817/107601);
+	// populates the per-actor focusShadowmapDescriptors -- a no-op without focus-shadow
+	// actors, so the old "DirectionalLight" name was misleading.
+	static void GameSetupFocusShadowMaps(RE::BSShadowLight* light, RE::NiCamera* cam)
 	{
 		using F = void (*)(RE::BSShadowLight*, RE::NiCamera*);
 		static REL::Relocation<F> func{ REL::RelocationID(100817, 107601) };
@@ -1762,7 +1765,7 @@ namespace ShadowCasterManager
 		if (s_focusShadowSlots > 0) {
 			bool drawFocus = ShadowField(light, drawFocusShadows);
 			if (drawFocus || (!*GetFocusShadowSelected() && light->GetIsFrustumOrDirectionalLight())) {
-				GameSetupDirectionalLight(light, camera);
+				GameSetupFocusShadowMaps(light, camera);
 				GameAccumulate(light);
 				if (globals::game::isVR) {
 					for (auto& desc : light->GetVRRuntimeData().focusShadowmapDescriptors) {

--- a/src/Features/LightLimitFix/ShadowCasterManager.cpp
+++ b/src/Features/LightLimitFix/ShadowCasterManager.cpp
@@ -574,7 +574,7 @@ namespace ShadowCasterManager
 		//        crash-2026-05-25-15-28-04.log RDX=0x3A4A3190
 		//        crash-2026-05-25-15-36-15.log RDX=0x3A4B11F5
 		//      all at 107141+0x319.
-		//   3. shadowLightsAccum entries created by GameAccumulate() (engine
+		//   3. shadowLightsAccum entries created by GameSetupFocusShadowAccumulators() (engine
 		//      focus path) bypass SLF's maskIndex assignment in EnableLight,
 		//      so maskIndex stays at uninitialized memory.
 		//
@@ -1267,9 +1267,10 @@ namespace ShadowCasterManager
 
 	// ---------- engine function wrappers ----------
 
-	static void GameAccumulate(RE::BSShadowLight* light)
+	// Engine BSShadowDirectionalLight::SetupFocusShadowAccumulators: allocates + registers
+	// the per-focus-actor BSShaderAccumulators (one per FocusShadowActors entry).
+	static void GameSetupFocusShadowAccumulators(RE::BSShadowLight* light)
 	{
-		// BSShadowDirectionalLight::AccumulateFullFrustumCascades / unk_Accumulate
 		using F = void (*)(RE::BSShadowLight*);
 		static REL::Relocation<F> func{ REL::RelocationID(100819, 107603) };
 		func(light);
@@ -1766,7 +1767,7 @@ namespace ShadowCasterManager
 			bool drawFocus = ShadowField(light, drawFocusShadows);
 			if (drawFocus || (!*GetFocusShadowSelected() && light->GetIsFrustumOrDirectionalLight())) {
 				GameSetupFocusShadowMaps(light, camera);
-				GameAccumulate(light);
+				GameSetupFocusShadowAccumulators(light);
 				if (globals::game::isVR) {
 					for (auto& desc : light->GetVRRuntimeData().focusShadowmapDescriptors) {
 						desc.vrRenderTarget[0] = RE::RENDER_TARGET_DEPTHSTENCIL::kNONE;


### PR DESCRIPTION
## What

Name two engine-function wrappers in `ShadowCasterManager.cpp` from their **verified** Ghidra identities (pure symbol renames + doc comments, no behavior change):

| RelocationID | was | now |
|---|---|---|
| `(100817, 107601)` | `GameSetupDirectionalLight` | `GameSetupFocusShadowMaps` |
| `(100819, 107603)` | `GameAccumulate` (comment: `AccumulateFullFrustumCascades`) | `GameSetupFocusShadowAccumulators` |

## Why

Both old names/comments were inaccurate, confirmed by Ghidra decompile:

- **100817** = `BSShadowDirectionalLight::SetupFocusShadowMaps` (SE 1.5.97 @ `0x141304da0`) — gated on `FocusShadowActors_size`, populates the per-actor `focusShadowmapDescriptors`. The old "DirectionalLight" implied a general directional setup it never performs.
- **100819** = `BSShadowDirectionalLight::SetupFocusShadowAccumulators` (SE @ `0x1413054c0`) — loops `FocusShadowActors` and lazily allocates + registers a per-actor `BSShaderAccumulator`. It accumulates nothing and has no cascades; the VR address library even listed it on the wrong class (`BSShadowLight::Accumulate`).

## Propagation

Both verified names are applied in the **SE/AE/VR Ghidra databases**. They are internal engine routines a consumer wouldn't call directly, so they are intentionally **not** added to CommonLibSSE-NG — Ghidra is the canonical record. The address-library `name` column is corrected separately (`skyrim_vr_address_library` #126).

Split out of #194 (PR #200) to keep that fix minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shadow rendering behavior within the light limit system through structural refinements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->